### PR TITLE
Fixes in template module to support args and also enable required feature for IT

### DIFF
--- a/plugins/modules/dcnm_template.py
+++ b/plugins/modules/dcnm_template.py
@@ -242,7 +242,7 @@ class DcnmTemplate:
     def dcnm_template_get_template_payload(self, ditem):
 
         if self.module.params["state"] == "merged":
-            std_cont = "##template properties\nname = __TEMPLATE_NAME;\ndescription = __DESCRIPTION;\ntags = __TAGS;\nuserDefined = true;\nsupportedPlatforms = All;\ntemplateType = POLICY;\ntemplateSubType = DEVICE;\ncontentType = TEMPLATE_CLI;\nimplements = implements;\ndependencies = ;\npublished = false;\n##\n##template variables\n##\n##template content\n"
+            std_cont = "##template properties\nname = __TEMPLATE_NAME;\ndescription = __DESCRIPTION;\ntags = __TAGS;\nuserDefined = true;\nsupportedPlatforms = All;\ntemplateType = POLICY;\ntemplateSubType = DEVICE;\ncontentType = TEMPLATE_CLI;\nimplements = implements;\ndependencies = ;\npublished = false;\n##\n##template content\n"
 
             template_payload = {}
 
@@ -334,11 +334,19 @@ class DcnmTemplate:
             # DATA may have multiple dicts with different reports. Check all reports and ignore warnings.
             # If there are errors, take it as validation failure
 
-            for d in resp["DATA"]:
-                if d["reportItemType"].lower() == "error":
+            # resp['DATA'] may be a list in case of templates with no parameters. But for templates
+            # with parameters resp['DATA'] will be a dict directly with 'status' as 'Template Validation Successful'
+            if isinstance(resp['DATA'], list):
+                for d in resp["DATA"]:
+                    if d.get("reportItemType", ' ').lower() == "error":
+                        self.result["response"].append(resp)
+                        return 0
+                return resp["RETURN_CODE"]
+            elif isinstance(resp['DATA'], dict):
+                if resp['DATA'].get("status",  ' ').lower() != "template validation successful":
                     self.result["response"].append(resp)
                     return 0
-            return resp["RETURN_CODE"]
+                return resp["RETURN_CODE"]
         else:
             return 0
 
@@ -589,7 +597,7 @@ class DcnmTemplate:
 
     def dcnm_template_build_content(self, content, name, desc, tags):
 
-        std_cont = "##template properties\nname = __TEMPLATE_NAME;\ndescription = __DESCRIPTION;\ntags = __TAGS;\nuserDefined = true;\nsupportedPlatforms = All;\ntemplateType = POLICY;\ntemplateSubType = DEVICE;\ncontentType = TEMPLATE_CLI;\nimplements = implements;\ndependencies = ;\npublished = false;\n##\n##template variables\n##\n##template content\n"
+        std_cont = "##template properties\nname = __TEMPLATE_NAME;\ndescription = __DESCRIPTION;\ntags = __TAGS;\nuserDefined = true;\nsupportedPlatforms = All;\ntemplateType = POLICY;\ntemplateSubType = DEVICE;\ncontentType = TEMPLATE_CLI;\nimplements = implements;\ndependencies = ;\npublished = false;\n##\n##template content\n"
         template_payload = {}
 
         mod_cont = re.sub(" +", " ", content)

--- a/tests/integration/targets/dcnm_policy/tasks/dcnm.yaml
+++ b/tests/integration/targets/dcnm_policy/tasks/dcnm.yaml
@@ -19,6 +19,22 @@
   loop_control:
     loop_var: test_case_to_run
 
+- name: Final Cleanup - delete telemetry policy that we created during init
+  cisco.dcnm.dcnm_policy: 
+    fabric: "{{ ansible_it_fabric }}" 
+    state: deleted                     # only choose form [merged, deleted, query]
+    config: 
+      - name: my_feature_telemetry
+      - switch:
+          - ip: "{{ ansible_switch1 }}"
+          - ip: "{{ ansible_switch2 }}"
+  register: result  
+
+- assert:
+    that:
+      - 'item["RETURN_CODE"] == 200'  
+  loop: '{{ result.response }}'
+
 - name: Final Cleanup - delete all templates created during init
   cisco.dcnm.dcnm_template: 
     state: deleted       # only choose form [merged, deleted, query]
@@ -28,6 +44,7 @@
       - name: template_103
       - name: template_104
       - name: template_105
+      - name: my_feature_telemetry
 
   register: result
 

--- a/tests/integration/targets/prepare_dcnm_policy/tasks/main.yaml
+++ b/tests/integration/targets/prepare_dcnm_policy/tasks/main.yaml
@@ -12,6 +12,8 @@
       - name: template_103  # name is mandatory
       - name: template_104  # name is mandatory
       - name: template_105  # name is mandatory
+      - name: my_base_ospf  # name is mandatory
+      - name: my_feature_telemetry  # name is mandatory
       - switch:
           - ip: "{{ ansible_switch1 }}"
           - ip: "{{ ansible_switch2 }}"
@@ -35,6 +37,8 @@
       - name: template_103
       - name: template_104
       - name: template_105
+      - name: my_base_ospf
+      - name: my_feature_telemetry
 
   register: result
 
@@ -150,3 +154,122 @@
           - 'item["RETURN_CODE"] == 200'  
           - '"Template Created" in item["DATA"]["status"]'
       loop: '{{ result.response }}'
+
+    - name: Create templates with arguments
+      cisco.dcnm.dcnm_template: 
+        state: merged        # only choose form [merged, deleted, query]
+        config:
+          - name: my_base_ospf
+            tags: "base_ospf clone"
+            description: "template which is a clone of base_ospf"
+            content: |
+              ##template variables
+
+              #    Copyright (c) 2018 by Cisco Systems, Inc.
+              #    All rights reserved.
+
+              @(DisplayName="OSPF Process Tag", Description="OSPF routing process tag")
+              string OSPF_TAG {
+                minLength = 1;
+                maxLength = 20;
+              };
+
+              @(DisplayName="Loopback IP", Description="Loopback IP address used as router-id")
+              ipV4Address LOOPBACK_IP;
+
+              ##
+              ##template content
+
+              router ospf $$OSPF_TAG$$
+              router-id $$LOOPBACK_IP$$
+
+              ##
+      register: result
+    - assert:
+        that:
+          - 'result.changed == true'
+          - '(result["diff"][0]["merged"] | length) == 1'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["query"] | length) == 0'
+
+    - assert:
+        that:
+          - 'item["RETURN_CODE"] == 200'  
+          - '"Template Created" in item["DATA"]["status"]'
+      loop: '{{ result.response }}'
+
+# Policy IT cases depend on telemetry feature being enabled on the switches. So create a policy for 
+# deploying the telemetry feature on the switches before starting the tests
+
+    - name: Create template for telemetry feature
+      cisco.dcnm.dcnm_template: 
+        state: merged        # only choose form [merged, deleted, query]
+        config:
+          - name: my_feature_telemetry
+            tags: "telemetry"
+            description: "internal template for enabling telemetry feature"
+            content: |
+              ##
+              ##template content
+
+              feature telemetry
+
+              ##
+      register: result
+    - assert:
+        that:
+          - 'result.changed == true'
+          - '(result["diff"][0]["merged"] | length) == 1'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["query"] | length) == 0'
+
+    - assert:
+        that:
+          - 'item["RETURN_CODE"] == 200'  
+          - '"Template Created" in item["DATA"]["status"]'
+      loop: '{{ result.response }}'
+
+# Create the policy to deploy telemetry feature on the switches
+    - name: Create telemetry policy
+      cisco.dcnm.dcnm_policy: 
+        fabric: "{{ ansible_it_fabric }}" 
+        config: 
+          - name: my_feature_telemetry  # This must be a valid template name
+            create_additional_policy: false  # Do not create a policy if it already exists
+            priority: 101 
+
+          - switch:
+              - ip: "{{ ansible_switch1 }}"
+              - ip: "{{ ansible_switch2 }}"
+        deploy: true
+        state: merged
+      register: result
+
+    - assert:
+        that:
+          - 'result.changed == true'
+          - '(result["diff"][0]["merged"] | length) == 2'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["query"] | length) == 0'
+          - '(result["diff"][0]["deploy"] | length) == 2'
+
+    # Assert for Create responses
+    - assert:
+        that:
+          - 'item["RETURN_CODE"] == 200'
+          - '"is created successfully" in item["DATA"]["successList"][0]["message"]'
+      when: (my_idx < (result["diff"][0]["merged"] | length))   
+      loop: '{{ result.response }}'
+      loop_control:
+        index_var: my_idx
+
+    # Assert for deploy responses
+    - assert:
+        that:
+          - 'item["RETURN_CODE"] == 200'
+          - '(item["DATA"][0]["successPTIList"].split(",") | length) == 1'
+      when: (my_idx == (result["diff"][0]["merged"] | length))   
+      loop: '{{ result.response }}'
+      loop_control:
+        index_var: my_idx
+


### PR DESCRIPTION
This is a bug fix in template module. The following are the fixes:

1. Template creation with argument support had an issue in the "content". That was updated
2. Since testing of policy module require support for telemetry feature on the box, the feature enablement is now done in the prepare_dcnm_policy module at the beginning of the tests.
3. Deploy response for templates with arguments is different from templates without arguments. Updated the code handling the response.