### PR TITLE
Add full fabric integration tests and github actions ci tasks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,9 +6,9 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the develop branch
   push:
-    branches: [ test-ci ]
+    branches: [ develop ]
   pull_request:
-    branches: [ test-ci ]
+    branches: [ develop ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,88 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run.
+on:
+  # Triggers the workflow on push or pull request events but only for the develop branch
+  push:
+    branches: [ test-ci ]
+  pull_request:
+    branches: [ test-ci ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    name: Build DCNM collection
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ansible: [2.9.12, 2.10.0]
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+    
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+
+    - name: Install ansible-base (v${{ matrix.ansible }})
+      run: pip install https://github.com/ansible/ansible/archive/v${{ matrix.ansible }}.tar.gz --disable-pip-version-check
+
+    - name: Build a DCNM collection tarball
+      run: ansible-galaxy collection build --output-path "${GITHUB_WORKSPACE}/.cache/collection-tarballs"
+
+    - name: Store migrated collection artifacts
+      uses: actions/upload-artifact@v1
+      with:
+        name: collection
+        path: .cache/collection-tarballs
+
+  unit-tests:
+    name: Run DCNM Unit Tests
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ansible: [2.9.12, 2.10.0]
+    steps:
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+
+    - name: Install ansible-base (v${{ matrix.ansible }})
+      run: pip install https://github.com/ansible/ansible/archive/v${{ matrix.ansible }}.tar.gz --disable-pip-version-check
+
+    - name: Install coverage (v4.5.4)
+      run: pip install coverage==4.5.4
+    
+    - name: Install pytest (v5.4.1)
+      run: pip install pytest==5.4.1
+
+    - name: Download migrated collection artifacts
+      uses: actions/download-artifact@v1
+      with:
+        name: collection
+        path: .cache/collection-tarballs
+
+    - name: Install the collection tarball
+      run: ansible-galaxy collection install .cache/collection-tarballs/*.tar.gz
+
+    - name: Run DCNM Unit tests
+      run: coverage run --source=. -m pytest tests/unit/modules/dcnm/. -vvvv
+      #run: ansible-test units --docker -v --color --truncate 0 --coverage
+      working-directory: /home/runner/.ansible/collections/ansible_collections/cisco/dcnm
+      env:
+        PYTHONPATH: /home/runner/.ansible/collections
+
+    - name: Generate coverage report
+      run: coverage report
+      working-directory: /home/runner/.ansible/collections/ansible_collections/cisco/dcnm
+

--- a/playbooks/roles/dcnm_fabric/dcnm_hosts.yaml
+++ b/playbooks/roles/dcnm_fabric/dcnm_hosts.yaml
@@ -1,0 +1,20 @@
+all:
+  vars:
+    ansible_user: "admin"
+    ansible_password: "password-secret"
+    ansible_python_interpreter: python
+    ansible_httpapi_validate_certs: False
+    ansible_httpapi_use_ssl: True
+  children:
+    dcnm:
+      vars:
+        ansible_connection: ansible.netcommon.httpapi
+        ansible_network_os: cisco.dcnm.dcnm
+      hosts:
+        dcnm-instance.example.com:
+    nxos:
+      hosts:
+        n9k-hosta.example.com:
+           ansible_connection: ansible.netcommon.network_cli
+           ansible_network_os: cisco.nxos.nxos
+           ansible_ssh_port: 22

--- a/playbooks/roles/dcnm_fabric/dcnm_tests.yaml
+++ b/playbooks/roles/dcnm_fabric/dcnm_tests.yaml
@@ -1,0 +1,44 @@
+---
+# This playbook can be used to execute the dcnm_fabric test role.
+#
+# Replace the vars: section with details for your 2 spine, 4 leaf fabric.
+#
+#
+- hosts: dcnm
+  gather_facts: no
+  connection: ansible.netcommon.httpapi
+
+  vars:
+    # This testcase field can run any test in the tests directory for the role
+    testcase: spine_leaf_basic
+    fabric_name: fabric-name
+    spine1: n9k-spine1.example.com
+    spine2: n9k-spine2.example.com
+    leaf1: n9k-leaf1.example.com
+    leaf2: n9k-leaf2.example.com
+    leaf3: n9k-leaf3.example.com
+    leaf4: n9k-leaf4.example.com
+    username: admin
+    password: "secret-password"
+
+  roles:
+    - dcnm_fabric
+
+# Uncomment the following play if you want to verify connectivity between
+# host a and host c and d across the vxlan fabric setup by test spine_leaf_basic
+#
+
+# - hosts: nxos
+#   gather_facts: no
+#   connection: ansible.netcommon.network_cli
+#
+#   tasks:
+#     - name: Verify IP reachability for vni 4000
+#       nxos_ping:
+#         dest: 192.168.1.20
+#         state: present
+#
+#     - name: Verify IP reachability for vni 7000
+#       nxos_ping:
+#         dest: 192.168.2.20
+#         state: present

--- a/plugins/modules/dcnm_vrf.py
+++ b/plugins/modules/dcnm_vrf.py
@@ -69,7 +69,7 @@ options:
       vlan_id:
         description: 'vlan ID for the vrf attachment'
         type: int
-        required: false 
+        required: false
         note: If not specified in the playbook, DCNM will auto-select an available vlan_id
       vrf_template:
         description: 'Name of the config template to be used'
@@ -95,11 +95,11 @@ options:
             suboptions:
             vrf_lite:
                 description: 'VRF Lite Extensions options'
-                - peer_vrf: 
+                - peer_vrf:
                     description: 'VRF Name to which this extension is attached'
                     type: str
                     requited: mandatory
-                  interface: 
+                  interface:
                     description: 'Interface of the switch which is connected to the edge router'
                     type: str
                     requited: optional
@@ -123,7 +123,7 @@ options:
                     description: 'DOT1Q Id'
                     type: str
                     requited: optional
-                  peer_vrf: 
+                  peer_vrf:
                     description: 'VRF Name to which this extension is attached'
                     type: str
                     requited: mandatory
@@ -194,7 +194,6 @@ If rollback fails, the module does not attempt to rollback again, it just quits 
       vrf_template: Default_VRF_Universal
       vrf_extension_template: Default_VRF_Extension_Universal
       vlan_id: 2000
-      source: null
       service_vrf_template: null
       attach:
       - ip_address: 192.168.1.224
@@ -205,7 +204,6 @@ If rollback fails, the module does not attempt to rollback again, it just quits 
       vrf_id: 9008012
       vrf_template: Default_VRF_Universal
       vrf_extension_template: Default_VRF_Extension_Universal
-      source: null
       service_vrf_template: null
       attach:
       - ip_address: 192.168.1.224
@@ -222,13 +220,12 @@ If rollback fails, the module does not attempt to rollback again, it just quits 
       vrf_template: Default_VRF_Universal
       vrf_extension_template: Default_VRF_Extension_Universal
       vlan_id: 2000
-      source: null
       service_vrf_template: null
       attach:
       - ip_address: 192.168.1.224
       - ip_address: 192.168.1.225
         vrf_lite:
-	  # All parameters under vrf_lite except peer_vrf are optional and 
+	  # All parameters under vrf_lite except peer_vrf are optional and
 	  # will be supplied by DCNM when omitted in the playbook
           - peer_vrf: test_vrf_1 # peer_vrf is mandatory
             interface: Ethernet1/16 # optional
@@ -249,7 +246,6 @@ If rollback fails, the module does not attempt to rollback again, it just quits 
       vrf_template: Default_VRF_Universal
       vrf_extension_template: Default_VRF_Extension_Universal
       vlan_id: 2000
-      source: null
       service_vrf_template: null
       attach:
       - ip_address: 192.168.1.224
@@ -280,7 +276,6 @@ If rollback fails, the module does not attempt to rollback again, it just quits 
       vrf_template: Default_VRF_Universal
       vrf_extension_template: Default_VRF_Extension_Universal
       vlan_id: 2000
-      source: null
       service_vrf_template: null
       attach:
       - ip_address: 192.168.1.224
@@ -297,7 +292,6 @@ If rollback fails, the module does not attempt to rollback again, it just quits 
     #   vrf_template: Default_VRF_Universal
     #   vrf_extension_template: Default_VRF_Extension_Universal
     #   vlan_id: 2000
-    #   source: null
     #   service_vrf_template: null
     #   attach:
     #   - ip_address: 192.168.1.224
@@ -313,14 +307,12 @@ If rollback fails, the module does not attempt to rollback again, it just quits 
       vrf_template: Default_VRF_Universal
       vrf_extension_template: Default_VRF_Extension_Universal
       vlan_id: 2000
-      source: null
       service_vrf_template: null
     - vrf_name: ansible-vrf-r2
       vrf_id: 9008012
       vrf_template: Default_VRF_Universal
       vrf_extension_template: Default_VRF_Extension_Universal
       vlan_id: 2000
-      source: null
       service_vrf_template: null
 
 - name: Delete all the vrfs
@@ -338,13 +330,11 @@ If rollback fails, the module does not attempt to rollback again, it just quits 
       vrf_template: Default_VRF_Universal
       vrf_extension_template: Default_VRF_Extension_Universal
       vlan_id: 2000
-      source: null
       service_vrf_template: null
     - vrf_name: ansible-vrf-r2
       vrf_id: 9008012
       vrf_template: Default_VRF_Universal
       vrf_extension_template: Default_VRF_Extension_Universal
-      source: null
       service_vrf_template: null
 '''
 
@@ -352,7 +342,7 @@ If rollback fails, the module does not attempt to rollback again, it just quits 
 class DcnmVrf:
 
     def __init__(self, module):
-        
+
         self.module = module
         self.params = module.params
         self.fabric = module.params['fabric']
@@ -552,7 +542,6 @@ class DcnmVrf:
             if want['vrfId'] is not None and have['vrfId'] != want['vrfId']:
                 self.module.fail_json(msg="vrf_id for vrf:{} cant be updated to a different value".format(want['vrfName']))
             elif have['serviceVrfTemplate'] != want['serviceVrfTemplate'] or \
-                    have['source'] != want['source'] or \
                     have['vrfTemplate'] != want['vrfTemplate'] or \
                     have['vrfExtensionTemplate'] != want['vrfExtensionTemplate'] or \
                     vlanId_have != vlanId_want:
@@ -571,7 +560,6 @@ class DcnmVrf:
                 self.module.fail_json(
                     msg="vrf_id for vrf:{} cant be updated to a different value".format(want['vrfName']))
             elif have['serviceVrfTemplate'] != want['serviceVrfTemplate'] or \
-                    have['source'] != want['source'] or \
                     have['vrfTemplate'] != want['vrfTemplate'] or \
                     have['vrfExtensionTemplate'] != want['vrfExtensionTemplate']:
 
@@ -592,7 +580,7 @@ class DcnmVrf:
 
         v_template = vrf.get('vrf_template', 'Default_VRF_Universal')
         ve_template = vrf.get('vrf_extension_template', 'Default_VRF_Extension_Universal')
-        src = vrf.get('source', None)
+        src = None
         s_v_template = vrf.get('service_vrf_template', None)
 
         vrf_upd = {
@@ -1203,7 +1191,7 @@ class DcnmVrf:
                 new_attach_list.append(attach_d)
 
             if new_attach_list:
-                if diff_deploy:
+                if diff_deploy and vrf['vrfName'] in diff_deploy:
                     diff_deploy.remove(vrf['vrfName'])
                 new_attach_dict.update({'attach': new_attach_list})
                 new_attach_dict.update({'vrf_name': vrf['vrfName']})
@@ -1246,7 +1234,7 @@ class DcnmVrf:
                     want_vlanId = json_to_dict.get('vlanId', "0")
 
                     if (want_c['vrfName'] == vrf['vrfName'] and want_c['vrfId'] == vrf['vrfId'] and \
-                            want_c['source'] == vrf['source'] and str(want_vlanId) == vrf_vlanId):
+                            str(want_vlanId) == vrf_vlanId):
 
                         item = {'parent': {}, 'attach': []}
                         item['parent'] = vrf
@@ -1566,7 +1554,7 @@ class DcnmVrf:
                 source=dict(type='str', default=None),
                 service_vrf_template=dict(type='str', default=None),
                 attach=dict(type='list'),
-                deploy=dict(type='bool')
+                deploy=dict(type='bool', default=True)
             )
             att_spec = dict(
                 ip_address=dict(required=True, type='str'),
@@ -1586,6 +1574,12 @@ class DcnmVrf:
             msg = None
             if self.config:
                 for vrf in self.config:
+                    # A few user provided vrf parameters need special handling
+                    # Ignore user input for src and hard code it to None
+                    vrf['source'] = None
+                    if not vrf.get('service_vrf_template'):
+                        vrf['service_vrf_template'] = None
+
                     if 'vrf_name' not in vrf:
                         msg = "vrf_name is mandatory under vrf parameters"
 
@@ -1612,8 +1606,21 @@ class DcnmVrf:
                 valid_vrf, invalid_params = validate_list_of_dicts(self.config, vrf_spec)
                 for vrf in valid_vrf:
                     if vrf.get('attach'):
+                        # The deploy setting provided in the user parameters
+                        # has the following behavior:
+                        # (1) By default deploy is true
+                        # (2) The global 'deploy' option for the vrf applies to
+                        #     any attachments that don't have the 'deploy'
+                        #     option explicity set.
+                        for entry in vrf.get('attach'):
+                            if 'deploy' not in entry.keys() and 'deploy' in vrf:
+                                # This attach entry does not have a deploy key
+                                # but the vrf global deploy flag is set so set
+                                # it to the global 'deploy' value
+                                entry['deploy'] = vrf['deploy']
                         valid_att, invalid_att = validate_list_of_dicts(vrf['attach'], att_spec)
                         vrf['attach'] = valid_att
+
                         invalid_params.extend(invalid_att)
                         for lite in vrf.get('attach'):
                             if lite.get('vrf_lite'):
@@ -1625,6 +1632,7 @@ class DcnmVrf:
                 if invalid_params:
                     msg = 'Invalid parameters in playbook: {}'.format('\n'.join(invalid_params))
                     self.module.fail_json(msg=msg)
+
         else:
 
             vrf_spec = dict(

--- a/tests/integration/targets/dcnm_fabric/defaults/main.yaml
+++ b/tests/integration/targets/dcnm_fabric/defaults/main.yaml
@@ -1,0 +1,2 @@
+---
+testcase: "{{ testcase }}"

--- a/tests/integration/targets/dcnm_fabric/meta/main.yaml
+++ b/tests/integration/targets/dcnm_fabric/meta/main.yaml
@@ -1,0 +1,1 @@
+dependencies: []

--- a/tests/integration/targets/dcnm_fabric/tasks/dcnm.yaml
+++ b/tests/integration/targets/dcnm_fabric/tasks/dcnm.yaml
@@ -1,0 +1,20 @@
+---
+- name: collect dcnm test cases
+  find:
+    paths: "{{ role_path }}/tests"
+    patterns: "{{ testcase }}.yaml"
+  connection: local
+  register: dcnm_cases
+
+- set_fact:
+    test_cases:
+      files: "{{ dcnm_cases.files }}"
+
+- name: set test_items
+  set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
+
+- name: run test cases (connection=httpapi)
+  include: "{{ test_case_to_run }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run

--- a/tests/integration/targets/dcnm_fabric/tasks/fabric_setup.yaml
+++ b/tests/integration/targets/dcnm_fabric/tasks/fabric_setup.yaml
@@ -1,0 +1,86 @@
+---
+- debug: msg="Start adding spine and leaf devices to fabric {{ fabric_name }}"
+
+- name: PreTest Cleanup - Remove all spine and leaf devices from fabric
+  cisco.dcnm.dcnm_inventory:
+    fabric: cisco-live-virtual
+    state: deleted
+
+- block:
+  - name: Test Case Setup - Add Spine and Leaf devices to fabric
+    cisco.dcnm.dcnm_inventory: &spine_leaf_merged
+      fabric: "{{ fabric_name }}"
+      state: merged
+      config:
+        - seed_ip: "{{ spine1 }}"
+          auth_proto: MD5
+          user_name: "{{ username }}"
+          password: "{{ password }}"
+          max_hops: 0
+          role: spine
+          preserve_config: false
+        - seed_ip: "{{ spine2 }}"
+          auth_proto: MD5
+          user_name: "{{ username }}"
+          password: "{{ password }}"
+          max_hops: 0
+          role: spine
+          preserve_config: false
+        - seed_ip: "{{ leaf1 }}"
+          auth_proto: MD5
+          user_name: "{{ username }}"
+          password: "{{ password }}"
+          max_hops: 0
+          role: leaf
+          preserve_config: false
+        - seed_ip: "{{ leaf2 }}"
+          auth_proto: MD5
+          user_name: "{{ username }}"
+          password: "{{ password }}"
+          max_hops: 0
+          role: leaf
+          preserve_config: false
+        - seed_ip: "{{ leaf3 }}"
+          auth_proto: MD5
+          user_name: "{{ username }}"
+          password: "{{ password }}"
+          max_hops: 0
+          role: leaf
+          preserve_config: false
+        - seed_ip: "{{ leaf4 }}"
+          auth_proto: MD5
+          user_name: "{{ username }}"
+          password: "{{ password }}"
+          max_hops: 0
+          role: leaf
+          preserve_config: false
+    vars:
+        ansible_command_timeout: 1000
+        ansible_connect_timeout: 1000
+    register: result
+
+  - assert:
+      that:
+      - 'result.changed == true'
+
+  - name: Add spine and leaf devices to fabric - idempotence check
+    cisco.dcnm.dcnm_inventory: *spine_leaf_merged
+    vars:
+        ansible_command_timeout: 1000
+        ansible_connect_timeout: 1000
+    register: result
+
+  - assert:
+      that:
+      - 'result.changed == false'
+
+  - name: Query Spine Leaf Fabric
+    cisco.dcnm.dcnm_inventory:
+      fabric: "{{ fabric_name }}"
+      state: query
+    register: result
+
+  - meta: end_play
+
+  always:
+    - debug: msg="Finished adding spine and leaf devices to fabirc {{ fabric_name }}"

--- a/tests/integration/targets/dcnm_fabric/tasks/main.yaml
+++ b/tests/integration/targets/dcnm_fabric/tasks/main.yaml
@@ -1,0 +1,3 @@
+---
+- { include: fabric_setup.yaml, tags: ['dcnm_setup'] }
+- { include: dcnm.yaml, tags: ['dcnm_integration_tests'] }

--- a/tests/integration/targets/dcnm_fabric/tests/exec_vars/vrfs.yaml
+++ b/tests/integration/targets/dcnm_fabric/tests/exec_vars/vrfs.yaml
@@ -1,0 +1,23 @@
+---
+vrfs:
+  - vrf_name: green_red
+    vrf_id: 470000
+    vrf_template: Default_VRF_Universal
+    vrf_extension_template: Default_VRF_Extension_Universal
+    vlan_id: 201
+    source: null
+    service_vrf_template: null
+  - vrf_name: engineering
+    vrf_id: 480000
+    vrf_template: Default_VRF_Universal
+    vrf_extension_template: Default_VRF_Extension_Universal
+    vlan_id: 401
+    source: null
+    service_vrf_template: null
+  - vrf_name: sales
+    vrf_id: 550000
+    vrf_template: Default_VRF_Universal
+    vrf_extension_template: Default_VRF_Extension_Universal
+    vlan_id: 501
+    source: null
+    service_vrf_template: null

--- a/tests/integration/targets/dcnm_fabric/tests/spine_leaf_basic.yaml
+++ b/tests/integration/targets/dcnm_fabric/tests/spine_leaf_basic.yaml
@@ -1,0 +1,164 @@
+---
+- debug: msg="Starting dcnm_fabric spine_leaf_basic test"
+- debug: msg="Role Path {{ role_path }}"
+
+- name: Cleanup - Reset or Default Ethernet Interfaces
+  cisco.dcnm.dcnm_interface:
+    fabric: "{{ fabric_name }}"
+    state: deleted
+    config:
+      - name: "Ethernet1/3"
+      - name: "Ethernet1/4"
+
+- name: Cleanup - Delete Networks
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ fabric_name }}"
+    state: deleted
+
+- name: Cleanup - Delete Tenant VRF
+  cisco.dcnm.dcnm_vrf:
+    fabric: "{{ fabric_name }}"
+    state: deleted
+
+- block:
+
+  - name: Configure access ethernet interfaces
+    cisco.dcnm.dcnm_interface: &config_interfaces
+      fabric: "{{ fabric_name }}"
+      state: merged
+      config:
+        - name: "Ethernet1/3"
+          type: eth
+          switch:
+            - "{{ leaf1 }}"
+            - "{{ leaf3 }}"
+          deploy: true
+          profile:
+            admin_state: true
+            mode: access
+            speed: 'Auto'
+            bpdu_guard: true
+            port_type_fast: true
+            mtu: default
+            access_vlan: 55
+            cmds:
+              - no shutdown
+            description: "Access interface for vlan55"
+        - name: "Ethernet1/4"
+          type: eth
+          switch:
+            - "{{ leaf1 }}"
+            - "{{ leaf3 }}"
+          deploy: true
+          profile:
+            admin_state: true
+            mode: access
+            speed: 'Auto'
+            bpdu_guard: true
+            port_type_fast: true
+            mtu: default
+            access_vlan: 65
+            cmds:
+              - no shutdown
+            description: "Access interface for vlan65"
+    register: result
+
+  - assert:
+      that:
+      - 'result.changed == true'
+      - 'result.response[0].RETURN_CODE == 200'
+      - 'result.response[1].RETURN_CODE == 200'
+
+  - name: Configure access ethernet interfaces - Idempotence
+    cisco.dcnm.dcnm_interface: *config_interfaces
+    register: result
+
+  - assert:
+      that:
+      - 'result.changed == false'
+      - 'result.response|length == 0'
+
+  - name: Add Tenant VRF
+    cisco.dcnm.dcnm_vrf: &add_vrf
+      fabric: "{{ fabric_name }}"
+      state: merged
+      config:
+        - vrf_name: green_red
+          vrf_id: 470000
+          vlan_id: 201
+          attach:
+            - ip_address: "{{ leaf1 }}"
+            - ip_address: "{{ leaf3 }}"
+          deploy: true
+    register: result
+
+  - assert:
+      that:
+      - 'result.changed == true'
+      - 'result.response[0].RETURN_CODE == 200'
+      - 'result.response[1].RETURN_CODE == 200'
+      - 'result.response[2].RETURN_CODE == 200'
+
+  - name: Add Tenant VRF - Idempotence
+    cisco.dcnm.dcnm_vrf: *add_vrf
+    register: result
+
+  - assert:
+      that:
+      - 'result.changed == false'
+      - 'result.response|length == 0'
+
+  - name: Add Networks
+    cisco.dcnm.dcnm_network: &add_networks
+      fabric: "{{ fabric_name }}"
+      state: merged
+      config:
+        - net_name: l2vni_4000
+          vrf_name: green_red
+          net_id: 4000
+          vlan_id: 55
+          gw_ip_subnet: '192.168.1.1/24'
+          attach:
+          - ip_address: "{{ leaf1 }}"
+            ports: [ Ethernet1/3 ]
+            deploy: true
+          - ip_address: "{{ leaf3 }}"
+            ports: [ Ethernet1/3 ]
+            deploy: true
+        - net_name: l2vni_7000
+          vrf_name: green_red
+          net_id: 7000
+          vlan_id: 65
+          gw_ip_subnet: '192.168.2.1/24'
+          attach:
+          - ip_address: "{{ leaf1 }}"
+            ports: [ ]
+            deploy: true
+          - ip_address: "{{ leaf3 }}"
+            ports: [ ]
+            deploy: true
+    register: result
+
+  - assert:
+      that:
+      - 'result.changed == true'
+      - 'result.response[0].RETURN_CODE == 200'
+      - 'result.response[1].RETURN_CODE == 200'
+      - 'result.response[2].RETURN_CODE == 200'
+      - 'result.response[3].RETURN_CODE == 200'
+
+  - name: Sleep for 30 seconds before checking idempotence state
+    wait_for:
+      timeout: 30
+
+  - name: Add Networks - Idempotence
+    cisco.dcnm.dcnm_network: *add_networks
+    register: result
+
+  - assert:
+      that:
+      - 'result.changed == false'
+      - 'result.response|length == 0'
+
+  always:
+    - debug: msg="End dcnm_fabric spine_leaf_basic test"

--- a/tests/integration/targets/dcnm_fabric/tests/spine_leaf_merged.yaml
+++ b/tests/integration/targets/dcnm_fabric/tests/spine_leaf_merged.yaml
@@ -1,0 +1,353 @@
+---
+- debug: msg="Starting dcnm_fabric spine_leaf_merged test"
+- debug: msg="Role Path {{ role_path }}"
+
+- name: Include VRF List Items
+  include_vars: ./exec_vars/vrfs.yaml
+
+- name: Cleanup - Delete Networks
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ fabric_name }}"
+    state: deleted
+
+- name: Cleanup - Delete Tenant VRFs
+  cisco.dcnm.dcnm_vrf:
+    fabric: "{{ fabric_name }}"
+    state: deleted
+
+- block:
+
+  - name: Add Tenant VRF Objects
+    cisco.dcnm.dcnm_vrf: &add_vrfs
+      fabric: "{{ fabric_name }}"
+      state: merged
+      config: "{{ vrfs }}"
+    register: result
+
+  - assert:
+      that:
+      - 'result.changed == true'
+      - 'result.response|length == 3'
+
+  - name: Add Tenant VRF Objects - Idempotence
+    cisco.dcnm.dcnm_vrf: *add_vrfs
+    register: result
+
+  - assert:
+      that:
+      - 'result.changed == false'
+
+  - name: Query VRF State
+    cisco.dcnm.dcnm_vrf:
+      fabric: "{{ fabric_name }}"
+      state: query
+    register: result
+
+  - name: Query VRF State
+    cisco.dcnm.dcnm_vrf:
+      fabric: "{{ fabric_name }}"
+      state: query
+      config:
+        - vrf_name: green_red
+    register: result
+
+  - meta: end_play
+
+  - assert: &vrf_created_no_attach_deploy
+      that:
+      - 'result.response[0].parent.vrfName == "green_red"'
+      - 'result.response[0].parent.vrfId == 470000'
+      - 'result.response[0].parent.vrfStatus == "NA"'
+      - 'result.response[0].attach|length == 4'
+      - 'result.response[0].attach[0].switchDetailsList[0].islanAttached == false'
+      - 'result.response[0].attach[1].switchDetailsList[0].islanAttached == false'
+      - 'result.response[0].attach[2].switchDetailsList[0].islanAttached == false'
+      - 'result.response[0].attach[3].switchDetailsList[0].islanAttached == false'
+      - 'result.response[1].parent.vrfName == "engineering"'
+      - 'result.response[1].parent.vrfId == 480000'
+      - 'result.response[1].parent.vrfStatus == "NA"'
+      - 'result.response[1].attach|length == 4'
+      - 'result.response[1].attach[0].switchDetailsList[0].islanAttached == false'
+      - 'result.response[1].attach[1].switchDetailsList[0].islanAttached == false'
+      - 'result.response[1].attach[2].switchDetailsList[0].islanAttached == false'
+      - 'result.response[1].attach[3].switchDetailsList[0].islanAttached == false'
+      - 'result.response[2].parent.vrfName == "sales"'
+      - 'result.response[2].parent.vrfId == 550000'
+      - 'result.response[2].parent.vrfStatus == "NA"'
+      - 'result.response[2].attach|length == 4'
+      - 'result.response[2].attach[0].switchDetailsList[0].islanAttached == false'
+      - 'result.response[2].attach[1].switchDetailsList[0].islanAttached == false'
+      - 'result.response[2].attach[2].switchDetailsList[0].islanAttached == false'
+      - 'result.response[2].attach[3].switchDetailsList[0].islanAttached == false'
+
+  - name: Specify attachments to switches with global deploy flag set to false
+    cisco.dcnm.dcnm_vrf:
+      fabric: "{{ fabric_name }}"
+      state: merged
+      config:
+        - vrf_name: green_red
+          vrf_id: 470000
+          vlan_id: 201
+          attach:
+            - ip_address: "{{ leaf1 }}"
+            - ip_address: "{{ leaf2 }}"
+            - ip_address: "{{ leaf3 }}"
+            - ip_address: "{{ leaf4 }}"
+          deploy: false
+        - vrf_name: engineering
+          vrf_id: 480000
+          vlan_id: 401
+          attach:
+            - ip_address: "{{ leaf1 }}"
+            - ip_address: "{{ leaf2 }}"
+            - ip_address: "{{ leaf3 }}"
+            - ip_address: "{{ leaf4 }}"
+          deploy: false
+        - vrf_name: sales
+          vrf_id: 550000
+          vlan_id: 501
+          attach:
+            - ip_address: "{{ leaf1 }}"
+            - ip_address: "{{ leaf2 }}"
+            - ip_address: "{{ leaf3 }}"
+            - ip_address: "{{ leaf4 }}"
+          deploy: false
+    register: result
+
+  - name: Query VRF State
+    cisco.dcnm.dcnm_vrf:
+      fabric: "{{ fabric_name }}"
+      state: query
+    register: result
+
+  - assert: *vrf_created_no_attach_deploy
+
+  - name: Specify attachments to switches with global deploy flag set to true
+    cisco.dcnm.dcnm_vrf:
+      fabric: "{{ fabric_name }}"
+      state: merged
+      config:
+        - vrf_name: green_red
+          vrf_id: 470000
+          vlan_id: 201
+          attach:
+            - ip_address: "{{ leaf1 }}"
+            - ip_address: "{{ leaf2 }}"
+            - ip_address: "{{ leaf3 }}"
+            - ip_address: "{{ leaf4 }}"
+          deploy: true
+        - vrf_name: engineering
+          vrf_id: 480000
+          vlan_id: 401
+          attach:
+            - ip_address: "{{ leaf1 }}"
+            - ip_address: "{{ leaf2 }}"
+            - ip_address: "{{ leaf3 }}"
+            - ip_address: "{{ leaf4 }}"
+          deploy: true
+        - vrf_name: sales
+          vrf_id: 550000
+          vlan_id: 501
+          attach:
+            - ip_address: "{{ leaf1 }}"
+            - ip_address: "{{ leaf2 }}"
+            - ip_address: "{{ leaf3 }}"
+            - ip_address: "{{ leaf4 }}"
+          deploy: true
+    register: result
+
+  - assert:
+      that:
+      - 'result.changed == true'
+
+  - name: Query fabric state until vrfStatus transitions to DEPLOYED state
+    cisco.dcnm.dcnm_vrf:
+      fabric: "{{ fabric_name }}"
+      state: query
+    register: result
+    until:
+      - "result.response[0].parent.vrfStatus is search('DEPLOYED')"
+      - "result.response[1].parent.vrfStatus is search('DEPLOYED')"
+      - "result.response[2].parent.vrfStatus is search('DEPLOYED')"
+    retries: 20
+    delay: 5
+
+  - name: Query VRF State
+    cisco.dcnm.dcnm_vrf:
+      fabric: "{{ fabric_name }}"
+      state: query
+    register: result
+
+  - assert:
+      that:
+      - 'result.response[0].parent.vrfName == "green_red"'
+      - 'result.response[0].parent.vrfId == 470000'
+      - "result.response[0].parent.vrfStatus is search('DEPLOYED')"
+      - 'result.response[0].attach|length == 4'
+      - 'result.response[0].attach[0].switchDetailsList[0].islanAttached == true'
+      - 'result.response[0].attach[1].switchDetailsList[0].islanAttached == true'
+      - 'result.response[0].attach[2].switchDetailsList[0].islanAttached == true'
+      - 'result.response[0].attach[3].switchDetailsList[0].islanAttached == true'
+      - 'result.response[1].parent.vrfName == "engineering"'
+      - 'result.response[1].parent.vrfId == 480000'
+      - "result.response[1].parent.vrfStatus is search('DEPLOYED')"
+      - 'result.response[1].attach|length == 4'
+      - 'result.response[1].attach[0].switchDetailsList[0].islanAttached == true'
+      - 'result.response[1].attach[1].switchDetailsList[0].islanAttached == true'
+      - 'result.response[1].attach[2].switchDetailsList[0].islanAttached == true'
+      - 'result.response[1].attach[3].switchDetailsList[0].islanAttached == true'
+      - 'result.response[2].parent.vrfName == "sales"'
+      - 'result.response[2].parent.vrfId == 550000'
+      - "result.response[2].parent.vrfStatus is search('DEPLOYED')"
+      - 'result.response[2].attach|length == 4'
+      - 'result.response[2].attach[0].switchDetailsList[0].islanAttached == true'
+      - 'result.response[2].attach[1].switchDetailsList[0].islanAttached == true'
+      - 'result.response[2].attach[2].switchDetailsList[0].islanAttached == true'
+      - 'result.response[2].attach[3].switchDetailsList[0].islanAttached == true'
+
+  - name: Cleanup - Delete Tenant VRFs
+    cisco.dcnm.dcnm_vrf:
+      fabric: "{{ fabric_name }}"
+      state: deleted
+
+  - name: Add vrfs with global and per attach deploy override
+    cisco.dcnm.dcnm_vrf:
+      fabric: "{{ fabric_name }}"
+      state: merged
+      config:
+        - vrf_name: green_red
+          vrf_id: 470000
+          vlan_id: 201
+          attach:
+            - ip_address: "{{ leaf1 }}"
+              deploy: true
+            - ip_address: "{{ leaf2 }}"
+              deploy: true
+            - ip_address: "{{ leaf3 }}"
+            - ip_address: "{{ leaf4 }}"
+          deploy: false
+          # vrf green_red should be deployed on leaf1, leaf2
+          # vrf green_red should not be deployed on leaf3, leaf4
+        - vrf_name: engineering
+          vrf_id: 480000
+          vlan_id: 401
+          attach:
+            - ip_address: "{{ leaf1 }}"
+              deploy: false
+            - ip_address: "{{ leaf2 }}"
+              deploy: false
+            - ip_address: "{{ leaf3 }}"
+            - ip_address: "{{ leaf4 }}"
+          deploy: true
+          # vrf engineering should be deployed on leaf3, leaf4
+          # vrf engineering should not be deployed on leaf1, leaf2
+
+  - name: Query fabric state until vrfStatus transitions to DEPLOYED state
+    cisco.dcnm.dcnm_vrf:
+      fabric: "{{ fabric_name }}"
+      state: query
+    register: result
+    until:
+      - "result.response[0].parent.vrfStatus is search('DEPLOYED')"
+      - "result.response[1].parent.vrfStatus is search('DEPLOYED')"
+    retries: 20
+    delay: 5
+
+  - name: Query VRF State
+    cisco.dcnm.dcnm_vrf:
+      fabric: "{{ fabric_name }}"
+      state: query
+    register: result
+
+  - assert:
+      that:
+      - 'result.response[0].parent.vrfName == "green_red"'
+      - 'result.response[0].parent.vrfId == 470000'
+      - "result.response[0].parent.vrfStatus is search('DEPLOYED')"
+      - 'result.response[1].parent.vrfName == "engineering"'
+      - 'result.response[1].parent.vrfId == 480000'
+      - "result.response[1].parent.vrfStatus is search('DEPLOYED')"
+
+  - name: Cleanup - Delete Tenant VRFs
+    cisco.dcnm.dcnm_vrf:
+      fabric: "{{ fabric_name }}"
+      state: deleted
+
+  - name: Add VRFs with vrf_id and vlan_id autoselection by DCNM
+    cisco.dcnm.dcnm_vrf:
+      fabric: "{{ fabric_name }}"
+      state: merged
+      config:
+        - vrf_name: green_red
+          # vrf_id: 470000
+          # vlan_id: 201
+          attach:
+            - ip_address: "{{ leaf1 }}"
+            - ip_address: "{{ leaf2 }}"
+            - ip_address: "{{ leaf3 }}"
+            - ip_address: "{{ leaf4 }}"
+          deploy: true
+        - vrf_name: engineering
+          # vrf_id: 480000
+          # vlan_id: 401
+          attach:
+            - ip_address: "{{ leaf1 }}"
+            - ip_address: "{{ leaf2 }}"
+            - ip_address: "{{ leaf3 }}"
+            - ip_address: "{{ leaf4 }}"
+          deploy: true
+        - vrf_name: sales
+          # vrf_id: 550000
+          # vlan_id: 501
+          attach:
+            - ip_address: "{{ leaf1 }}"
+            - ip_address: "{{ leaf2 }}"
+            - ip_address: "{{ leaf3 }}"
+            - ip_address: "{{ leaf4 }}"
+          deploy: true
+    register: result
+
+  - name: Query fabric state until vrfStatus transitions to DEPLOYED state
+    cisco.dcnm.dcnm_vrf:
+      fabric: "{{ fabric_name }}"
+      state: query
+    register: result
+    until:
+      - "result.response[0].parent.vrfStatus is search('DEPLOYED')"
+      - "result.response[1].parent.vrfStatus is search('DEPLOYED')"
+      - "result.response[2].parent.vrfStatus is search('DEPLOYED')"
+    retries: 20
+    delay: 5
+
+  - name: Query VRF State
+    cisco.dcnm.dcnm_vrf:
+      fabric: "{{ fabric_name }}"
+      state: query
+    register: result
+
+  - assert:
+      that:
+      - 'result.response[0].parent.vrfName == "green_red"'
+      - "result.response[0].parent.vrfStatus is search('DEPLOYED')"
+      - 'result.response[0].attach|length == 4'
+      - 'result.response[0].attach[0].switchDetailsList[0].islanAttached == true'
+      - 'result.response[0].attach[1].switchDetailsList[0].islanAttached == true'
+      - 'result.response[0].attach[2].switchDetailsList[0].islanAttached == true'
+      - 'result.response[0].attach[3].switchDetailsList[0].islanAttached == true'
+      - 'result.response[1].parent.vrfName == "engineering"'
+      - "result.response[1].parent.vrfStatus is search('DEPLOYED')"
+      - 'result.response[1].attach|length == 4'
+      - 'result.response[1].attach[0].switchDetailsList[0].islanAttached == true'
+      - 'result.response[1].attach[1].switchDetailsList[0].islanAttached == true'
+      - 'result.response[1].attach[2].switchDetailsList[0].islanAttached == true'
+      - 'result.response[1].attach[3].switchDetailsList[0].islanAttached == true'
+      - 'result.response[2].parent.vrfName == "sales"'
+      - "result.response[2].parent.vrfStatus is search('DEPLOYED')"
+      - 'result.response[2].attach|length == 4'
+      - 'result.response[2].attach[0].switchDetailsList[0].islanAttached == true'
+      - 'result.response[2].attach[1].switchDetailsList[0].islanAttached == true'
+      - 'result.response[2].attach[2].switchDetailsList[0].islanAttached == true'
+      - 'result.response[2].attach[3].switchDetailsList[0].islanAttached == true'
+
+  always:
+    - debug: msg="End dcnm_fabric spine_leaf_merged test"

--- a/tests/integration/targets/dcnm_fabric/tests/spine_leaf_overridden.yaml
+++ b/tests/integration/targets/dcnm_fabric/tests/spine_leaf_overridden.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="Starting dcnm_fabric spine_leaf_merged test"
+- debug: msg="Starting dcnm_fabric spine_leaf_overridden test"
 - debug: msg="Role Path {{ role_path }}"
 
 - name: Include VRF List Items
@@ -20,7 +20,7 @@
   - name: Add Tenant VRF Objects
     cisco.dcnm.dcnm_vrf: &add_vrfs
       fabric: "{{ fabric_name }}"
-      state: merged
+      state: overridden
       config: "{{ vrfs }}"
     register: result
 
@@ -73,7 +73,7 @@
   - name: Specify attachments to switches with global deploy flag set to false
     cisco.dcnm.dcnm_vrf:
       fabric: "{{ fabric_name }}"
-      state: merged
+      state: overridden
       config:
         - vrf_name: green_red
           vrf_id: 470000
@@ -115,7 +115,7 @@
   - name: Specify attachments to switches with global deploy flag set to true
     cisco.dcnm.dcnm_vrf:
       fabric: "{{ fabric_name }}"
-      state: merged
+      state: overridden
       config:
         - vrf_name: green_red
           vrf_id: 470000
@@ -203,7 +203,7 @@
   - name: Add vrfs with global and per attach deploy override
     cisco.dcnm.dcnm_vrf:
       fabric: "{{ fabric_name }}"
-      state: merged
+      state: overridden
       config:
         - vrf_name: green_red
           vrf_id: 470000
@@ -266,7 +266,7 @@
   - name: Add VRFs with vrf_id and vlan_id autoselection by DCNM
     cisco.dcnm.dcnm_vrf:
       fabric: "{{ fabric_name }}"
-      state: merged
+      state: overridden
       config:
         - vrf_name: green_red
           # vrf_id: 470000
@@ -340,4 +340,4 @@
       - 'result.response[2].attach[3].switchDetailsList[0].islanAttached == true'
 
   always:
-    - debug: msg="End dcnm_fabric spine_leaf_merged test"
+    - debug: msg="End dcnm_fabric spine_leaf_overridden test"

--- a/tests/integration/targets/dcnm_fabric/tests/spine_leaf_replaced.yaml
+++ b/tests/integration/targets/dcnm_fabric/tests/spine_leaf_replaced.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="Starting dcnm_fabric spine_leaf_merged test"
+- debug: msg="Starting dcnm_fabric spine_leaf_replaced test"
 - debug: msg="Role Path {{ role_path }}"
 
 - name: Include VRF List Items
@@ -20,7 +20,7 @@
   - name: Add Tenant VRF Objects
     cisco.dcnm.dcnm_vrf: &add_vrfs
       fabric: "{{ fabric_name }}"
-      state: merged
+      state: replaced
       config: "{{ vrfs }}"
     register: result
 
@@ -73,7 +73,7 @@
   - name: Specify attachments to switches with global deploy flag set to false
     cisco.dcnm.dcnm_vrf:
       fabric: "{{ fabric_name }}"
-      state: merged
+      state: replaced
       config:
         - vrf_name: green_red
           vrf_id: 470000
@@ -115,7 +115,7 @@
   - name: Specify attachments to switches with global deploy flag set to true
     cisco.dcnm.dcnm_vrf:
       fabric: "{{ fabric_name }}"
-      state: merged
+      state: replaced
       config:
         - vrf_name: green_red
           vrf_id: 470000
@@ -203,7 +203,7 @@
   - name: Add vrfs with global and per attach deploy override
     cisco.dcnm.dcnm_vrf:
       fabric: "{{ fabric_name }}"
-      state: merged
+      state: replaced
       config:
         - vrf_name: green_red
           vrf_id: 470000
@@ -266,7 +266,7 @@
   - name: Add VRFs with vrf_id and vlan_id autoselection by DCNM
     cisco.dcnm.dcnm_vrf:
       fabric: "{{ fabric_name }}"
-      state: merged
+      state: replaced
       config:
         - vrf_name: green_red
           # vrf_id: 470000
@@ -340,4 +340,4 @@
       - 'result.response[2].attach[3].switchDetailsList[0].islanAttached == true'
 
   always:
-    - debug: msg="End dcnm_fabric spine_leaf_merged test"
+    - debug: msg="End dcnm_fabric spine_leaf_replaced test"

--- a/tests/integration/targets/dcnm_fabric/tests/spine_leaf_replaced_2.yaml
+++ b/tests/integration/targets/dcnm_fabric/tests/spine_leaf_replaced_2.yaml
@@ -1,0 +1,79 @@
+---
+- debug: msg="Starting dcnm_fabric spine_leaf_replaced_2 test"
+- debug: msg="Role Path {{ role_path }}"
+
+- name: Cleanup - Delete Networks
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ fabric_name }}"
+    state: deleted
+
+- name: Cleanup - Delete Tenant VRFs
+  cisco.dcnm.dcnm_vrf:
+    fabric: "{{ fabric_name }}"
+    state: deleted
+
+- block:
+
+  - name: Add 3 VRFs and deploy them to all leaf devices
+    cisco.dcnm.dcnm_vrf:
+      fabric: "{{ fabric_name }}"
+      state: replaced
+      config:
+        - vrf_name: green_red
+          vrf_id: 470000
+          vlan_id: 201
+          attach:
+            - ip_address: "{{ leaf1 }}"
+            - ip_address: "{{ leaf2 }}"
+            - ip_address: "{{ leaf3 }}"
+            - ip_address: "{{ leaf4 }}"
+        - vrf_name: engineering
+          vrf_id: 480000
+          vlan_id: 401
+          attach:
+            - ip_address: "{{ leaf1 }}"
+            - ip_address: "{{ leaf2 }}"
+            - ip_address: "{{ leaf3 }}"
+            - ip_address: "{{ leaf4 }}"
+        - vrf_name: sales
+          vrf_id: 550000
+          vlan_id: 501
+          attach:
+            - ip_address: "{{ leaf1 }}"
+            - ip_address: "{{ leaf2 }}"
+            - ip_address: "{{ leaf3 }}"
+            - ip_address: "{{ leaf4 }}"
+    register: result
+
+  - name: Query fabric state until vrfStatus transitions to DEPLOYED state
+    cisco.dcnm.dcnm_vrf:
+      fabric: "{{ fabric_name }}"
+      state: query
+    register: result
+    until:
+      - "result.response[0].parent.vrfStatus is search('DEPLOYED')"
+      - "result.response[1].parent.vrfStatus is search('DEPLOYED')"
+      - "result.response[2].parent.vrfStatus is search('DEPLOYED')"
+    retries: 20
+    delay: 5
+
+  - name: Replace engineering VRF to remove attachments
+    cisco.dcnm.dcnm_vrf:
+      fabric: "{{ fabric_name }}"
+      state: replaced
+      config:
+        - vrf_name: engineering
+          vrf_id: 480000
+          vlan_id: 401
+          deploy: true
+    register: result
+
+  - name: Query VRF State
+    cisco.dcnm.dcnm_vrf:
+      fabric: "{{ fabric_name }}"
+      state: query
+    register: result
+
+
+  always:
+    - debug: msg="End dcnm_fabric spine_leaf_replaced_2 test"


### PR DESCRIPTION
Summary of updates:

* Add new gihub actions CI file to build collection, run unit tests and generate simple code coverage report.
* Add new dcnm_fabric role tests to validate modules using a full fabric
    * Additional coverage will be added to these tests.  This is only a starting point.
    * More tests to be added once dcnm_vrf and dcnm_network query capabilities added to query based on object key
* Fixes the following bugs with dcnm_vrf module
    * Type conversion for vrf config data when read from an ansible file
    * VRFs were deployed even when the deploy flag was set to false
    * Removed source parameter from examples and hardcoded it to None.  This should not be exposed in the playbook parameters but leaving it here just in case customers have specified it in their playbooks.
    * Whitespace issues
  