### PR TITLE
Template and Policy modules fixes after moving to 11.5 DCNM

### DIFF
--- a/tests/integration/targets/dcnm_policy/tasks/dcnm.yaml
+++ b/tests/integration/targets/dcnm_policy/tasks/dcnm.yaml
@@ -19,8 +19,25 @@
   loop_control:
     loop_var: test_case_to_run
 
+- name: Final Cleanup - delete telemetry policy that we created during init
+  cisco.dcnm.dcnm_policy:
+    fabric: "{{ ansible_it_fabric }}"
+    state: deleted                     # only choose form [merged, deleted, query]
+    config:
+      - name: my_feature_telemetry
+      - name: my_base_ospf
+      - switch:
+          - ip: "{{ ansible_switch1 }}"
+          - ip: "{{ ansible_switch2 }}"
+  register: result
+
+- assert:
+    that:
+      - 'item["RETURN_CODE"] == 200'
+  loop: '{{ result.response }}'
+
 - name: Final Cleanup - delete all templates created during init
-  cisco.dcnm.dcnm_template: 
+  cisco.dcnm.dcnm_template:
     state: deleted       # only choose form [merged, deleted, query]
     config:
       - name: template_101
@@ -28,11 +45,13 @@
       - name: template_103
       - name: template_104
       - name: template_105
+      - name: my_base_ospf
+      - name: my_feature_telemetry
 
   register: result
 
 - assert:
     that:
-      - 'item["RETURN_CODE"] == 200'  
+      - 'item["RETURN_CODE"] == 200'
   loop: '{{ result.response }}'
 

--- a/tests/integration/targets/prepare_dcnm_policy/tasks/main.yaml
+++ b/tests/integration/targets/prepare_dcnm_policy/tasks/main.yaml
@@ -4,30 +4,32 @@
 
 - name: Initialize the setup - delete all policies
   cisco.dcnm.dcnm_policy:
-    fabric: "{{ ansible_it_fabric }}" 
+    fabric: "{{ ansible_it_fabric }}"
     state: deleted                     # only choose form [merged, deleted, query]
-    config: 
+    config:
       - name: template_101  # name is mandatory
       - name: template_102  # name is mandatory
       - name: template_103  # name is mandatory
       - name: template_104  # name is mandatory
       - name: template_105  # name is mandatory
+      - name: my_base_ospf  # name is mandatory
+      - name: my_feature_telemetry  # name is mandatory
       - switch:
           - ip: "{{ ansible_switch1 }}"
           - ip: "{{ ansible_switch2 }}"
-  register: result  
+  register: result
 
 - assert:
     that:
-      - 'item["RETURN_CODE"] == 200'  
+      - 'item["RETURN_CODE"] == 200'
   loop: '{{ result.response }}'
 - assert:
     that:
-      - 'item["RETURN_CODE"] == 200'  
+      - 'item["RETURN_CODE"] == 200'
   loop: '{{ result.response }}'
 
-- name: Initialize the setup - delete all templates 
-  cisco.dcnm.dcnm_template: 
+- name: Initialize the setup - delete all templates
+  cisco.dcnm.dcnm_template:
     state: deleted       # only choose form [merged, deleted, query]
     config:
       - name: template_101
@@ -35,12 +37,14 @@
       - name: template_103
       - name: template_104
       - name: template_105
+      - name: my_base_ospf
+      - name: my_feature_telemetry
 
   register: result
 
 - assert:
     that:
-      - 'item["RETURN_CODE"] == 200'  
+      - 'item["RETURN_CODE"] == 200'
   loop: '{{ result.response }}'
 
 - block:
@@ -147,6 +151,125 @@
 
     - assert:
         that:
-          - 'item["RETURN_CODE"] == 200'  
+          - 'item["RETURN_CODE"] == 200'
           - '"Template Created" in item["DATA"]["status"]'
       loop: '{{ result.response }}'
+
+    - name: Create templates with arguments
+      cisco.dcnm.dcnm_template:
+        state: merged        # only choose form [merged, deleted, query]
+        config:
+          - name: my_base_ospf
+            tags: "base_ospf clone"
+            description: "template which is a clone of base_ospf"
+            content: |
+              ##template variables
+
+              #    Copyright (c) 2018 by Cisco Systems, Inc.
+              #    All rights reserved.
+
+              @(DisplayName="OSPF Process Tag", Description="OSPF routing process tag")
+              string OSPF_TAG {
+                minLength = 1;
+                maxLength = 20;
+              };
+
+              @(DisplayName="Loopback IP", Description="Loopback IP address used as router-id")
+              ipV4Address LOOPBACK_IP;
+
+              ##
+              ##template content
+
+              router ospf $$OSPF_TAG$$
+              router-id $$LOOPBACK_IP$$
+
+              ##
+      register: result
+    - assert:
+        that:
+          - 'result.changed == true'
+          - '(result["diff"][0]["merged"] | length) == 1'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["query"] | length) == 0'
+
+    - assert:
+        that:
+          - 'item["RETURN_CODE"] == 200'
+          - '"Template Created" in item["DATA"]["status"]'
+      loop: '{{ result.response }}'
+
+# Policy IT cases depend on telemetry feature being enabled on the switches. So create a policy for
+# deploying the telemetry feature on the switches before starting the tests
+
+    - name: Create template for telemetry feature
+      cisco.dcnm.dcnm_template:
+        state: merged        # only choose form [merged, deleted, query]
+        config:
+          - name: my_feature_telemetry
+            tags: "telemetry"
+            description: "internal template for enabling telemetry feature"
+            content: |
+              ##
+              ##template content
+
+              feature telemetry
+
+              ##
+      register: result
+    - assert:
+        that:
+          - 'result.changed == true'
+          - '(result["diff"][0]["merged"] | length) == 1'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["query"] | length) == 0'
+
+    - assert:
+        that:
+          - 'item["RETURN_CODE"] == 200'
+          - '"Template Created" in item["DATA"]["status"]'
+      loop: '{{ result.response }}'
+
+# Create the policy to deploy telemetry feature on the switches
+    - name: Create telemetry policy
+      cisco.dcnm.dcnm_policy:
+        fabric: "{{ ansible_it_fabric }}"
+        config:
+          - name: my_feature_telemetry  # This must be a valid template name
+            create_additional_policy: false  # Do not create a policy if it already exists
+            priority: 101
+
+          - switch:
+              - ip: "{{ ansible_switch1 }}"
+              - ip: "{{ ansible_switch2 }}"
+        deploy: true
+        state: merged
+      register: result
+
+    - assert:
+        that:
+          - 'result.changed == true'
+          - '(result["diff"][0]["merged"] | length) == 2'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["query"] | length) == 0'
+          - '(result["diff"][0]["deploy"] | length) == 2'
+
+    # Assert for Create responses
+    - assert:
+        that:
+          - 'item["RETURN_CODE"] == 200'
+          - '"is created successfully" in item["DATA"]["successList"][0]["message"]'
+      when: (my_idx < (result["diff"][0]["merged"] | length))
+      loop: '{{ result.response }}'
+      loop_control:
+        index_var: my_idx
+
+    # Assert for deploy responses
+    - assert:
+        that:
+          - 'item["RETURN_CODE"] == 200'
+          - '(item["DATA"][0]["successPTIList"].split(",") | length) == 1'
+      when: (my_idx == (result["diff"][0]["merged"] | length))
+      loop: '{{ result.response }}'
+      loop_control:
+        index_var: my_idx
+


### PR DESCRIPTION
Changes in this commit

- Updated response handling in Template module to process responses for templates with and without args
- Policy It cases require a template with args. It is now created in prepare_dcnm_policy
- Cleanup of all the templates and policies created during init