### PR TITLE
Add python requests module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 ansible
+requests


### PR DESCRIPTION
Our httpapi plugin uses the `requests` python module so we need to include it in our `requirements.txt` file