### PR TITLE
Honor no_log parameters

### DIFF
--- a/plugins/module_utils/network/dcnm/dcnm.py
+++ b/plugins/module_utils/network/dcnm/dcnm.py
@@ -21,7 +21,7 @@ import time
 from ansible.module_utils.common import validation
 from ansible.module_utils.connection import Connection
 
-def validate_list_of_dicts(param_list, spec):
+def validate_list_of_dicts(param_list, spec, module=None):
     """ Validate/Normalize playbook params. Will raise when invalid parameters found.
     param_list: a playbook parameter list of dicts
     spec: an argument spec dict
@@ -87,6 +87,11 @@ def validate_list_of_dicts(param_list, spec):
                 if choice:
                     if item not in choice:
                         invalid_params.append('{} : Invalid choice provided'.format(item))
+
+                no_log = spec[param].get('no_log')
+                if no_log:
+                    if module is not None:
+                        module.no_log_values.add(item)
 
             valid_params_dict[param] = item
         normalized.append(valid_params_dict)

--- a/plugins/module_utils/network/dcnm/dcnm.py
+++ b/plugins/module_utils/network/dcnm/dcnm.py
@@ -92,6 +92,11 @@ def validate_list_of_dicts(param_list, spec, module=None):
                 if no_log:
                     if module is not None:
                         module.no_log_values.add(item)
+                    else:
+                        msg = "\n\n'{}' is a no_log parameter".format(param)
+                        msg += "\nAnsible module object must be passed to this "
+                        msg += "\nfunction to ensure it is not logged\n\n"
+                        raise Exception(msg)
 
             valid_params_dict[param] = item
         normalized.append(valid_params_dict)

--- a/plugins/modules/dcnm_inventory.py
+++ b/plugins/modules/dcnm_inventory.py
@@ -472,7 +472,7 @@ class DcnmInventory:
                 auth_proto=dict(type='str',
                                 choices=['MD5', 'SHA', 'MD5_DES', 'MD5_AES', 'SHA_DES', 'SHA_AES'],
                                 default='MD5'),
-                user_name=dict(required=True, type='str', length_max=32),
+                user_name=dict(required=True, type='str', no_log=True, length_max=32),
                 password=dict(required=True, type='str', no_log=True, length_max=32),
                 max_hops=dict(type='int', default=0),
                 role=dict(type='str',
@@ -496,7 +496,7 @@ class DcnmInventory:
                 self.module.fail_json(msg=msg)
 
             if self.config:
-                valid_inv, invalid_params = validate_list_of_dicts(self.config, inv_spec)
+                valid_inv, invalid_params = validate_list_of_dicts(self.config, inv_spec, self.module)
                 for inv in valid_inv:
                     self.validated.append(inv)
 


### PR DESCRIPTION
This fixes a bug where the `no_log` parameter was not being honored if set in the parameter spec.

There are two updates here:

* Update to module utils to allow a module write to set the `no_log` option and pass the Ansible module to add the parameter to the object no_log parameters
* Modify `dcnm_inventory` to not log authentication credentials when adding devices to the inventory

The new output in the ansible logs will be as follows

```json
               {
                    "auth_proto": "MD5",
                    "max_hops": 0,
                    "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                    "preserve_config": false,
                    "role": "leaf",
                    "seed_ip": "n9kv-leaf4",
                    "user_name": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
                }
```

**Note:** We can update all of the modules to pass the ansible module object so it's no longer an optional parameter but this was the least impactful way to make this change for now since `dcnm_inventory` is the only module in our collection that requires it currently.