### PR TITLE
Provide meaningful error when DCNM controller not accessible

### DIFF
--- a/plugins/httpapi/dcnm.py
+++ b/plugins/httpapi/dcnm.py
@@ -52,7 +52,6 @@ class HttpApi(HttpApiBase):
             'Content-Type': "text/plain"
         }
 
-
     def login(self, username, password):
         ''' DCNM Login Method.  This method is automatically called by the
             Ansible plugin architecture if an active Dcnm-Token is not already
@@ -92,6 +91,18 @@ class HttpApi(HttpApiBase):
         ''' This method handles all DCNM REST API requests other then login '''
         if json is None:
             json = {}
+
+        # Verify HTTPS request URL for DCNM controller is accessible
+        try:
+            requests.head(self.connection._url, verify=False)
+        except requests.exceptions.RequestException as e:
+            msg = """
+
+                  Please verify that the DCNM controller HTTPS URL ({}) is
+                  reachable from the Ansible controller and try again
+
+                  """.format(self.connection._url)
+            raise ConnectionError(str(e) + msg)
 
         try:
             # Perform some very basic path input validation.

--- a/plugins/httpapi/dcnm.py
+++ b/plugins/httpapi/dcnm.py
@@ -87,11 +87,7 @@ class HttpApi(HttpApiBase):
         # Clean up tokens
         self.connection._auth = None
 
-    def send_request(self, method, path, json=None):
-        ''' This method handles all DCNM REST API requests other then login '''
-        if json is None:
-            json = {}
-
+    def check_url_connection(self):
         # Verify HTTPS request URL for DCNM controller is accessible
         try:
             requests.head(self.connection._url, verify=False)
@@ -103,6 +99,13 @@ class HttpApi(HttpApiBase):
 
                   """.format(self.connection._url)
             raise ConnectionError(str(e) + msg)
+
+    def send_request(self, method, path, json=None):
+        ''' This method handles all DCNM REST API requests other then login '''
+        if json is None:
+            json = {}
+
+        self.check_url_connection()
 
         try:
             # Perform some very basic path input validation.
@@ -124,6 +127,8 @@ class HttpApi(HttpApiBase):
         ''' This method handles all DCNM REST API requests other then login '''
         if txt is None:
             txt = ''
+
+        self.check_url_connection()
 
         try:
             # Perform some very basic path input validation.


### PR DESCRIPTION
This fixes https://github.com/CiscoDevNet/ansible-dcnm/issues/46 to add a check to our httpapi plugin to verify the DCNM controller URL is reachable from the Ansible controller and generates a meaningful error message if not.


With this change the following error message is generated

```bash
ansible.module_utils.connection.ConnectionError: HTTPSConnectionPool(host='192.168.1.1', port=443): Max retries exceeded with url: / (Caused by NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x10603a3a0>: Failed to establish a new connection: [Errno 60] Operation timed out'))

                  Please verify that the DCNM controller HTTPS URL (https://192.168.1.1:443) is
                  reachable from the Ansible controller and try again

                  
fatal: [192.168.1.1]: FAILED! => {
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\n  File \"/Users/mwiebe/.ansible/tmp/ansible-local-2762hd9_0b9y/ansible-tmp-1617208757.344222-2841-137462343838236/AnsiballZ_dcnm_inventory.py\", line 102, in <module>\n    _ansiballz_main()\n  File \"/Users/mwiebe/.ansible/tmp/ansible-local-2762hd9_0b9y/ansible-tmp-1617208757.344222-2841-137462343838236/AnsiballZ_dcnm_inventory.py\", line 94, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/Users/mwiebe/.ansible/tmp/ansible-local-2762hd9_0b9y/ansible-tmp-1617208757.344222-2841-137462343838236/AnsiballZ_dcnm_inventory.py\", line 40, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.cisco.dcnm.plugins.modules.dcnm_inventory', init_globals=None, run_name='__main__', alter_sys=True)\n  File \"/Users/mwiebe/.pyenv/versions/3.8.0/lib/python3.8/runpy.py\", line 205, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/Users/mwiebe/.pyenv/versions/3.8.0/lib/python3.8/runpy.py\", line 95, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/Users/mwiebe/.pyenv/versions/3.8.0/lib/python3.8/runpy.py\", line 85, in _run_code\n    exec(code, run_globals)\n  File \"/var/folders/g4/zsm12cfd1rlg695d0mdxh2f40000gn/T/ansible_cisco.dcnm.dcnm_inventory_payload_8ptl8keq/ansible_cisco.dcnm.dcnm_inventory_payload.zip/ansible_collections/cisco/dcnm/plugins/modules/dcnm_inventory.py\", line 961, in <module>\n  File \"/var/folders/g4/zsm12cfd1rlg695d0mdxh2f40000gn/T/ansible_cisco.dcnm.dcnm_inventory_payload_8ptl8keq/ansible_cisco.dcnm.dcnm_inventory_payload.zip/ansible_collections/cisco/dcnm/plugins/modules/dcnm_inventory.py\", line 861, in main\n  File \"/var/folders/g4/zsm12cfd1rlg695d0mdxh2f40000gn/T/ansible_cisco.dcnm.dcnm_inventory_payload_8ptl8keq/ansible_cisco.dcnm.dcnm_inventory_payload.zip/ansible_collections/cisco/dcnm/plugins/modules/dcnm_inventory.py\", line 300, in get_have\n  File \"/var/folders/g4/zsm12cfd1rlg695d0mdxh2f40000gn/T/ansible_cisco.dcnm.dcnm_inventory_payload_8ptl8keq/ansible_cisco.dcnm.dcnm_inventory_payload.zip/ansible_collections/cisco/dcnm/plugins/module_utils/network/dcnm/dcnm.py\", line 280, in dcnm_send\n  File \"/var/folders/g4/zsm12cfd1rlg695d0mdxh2f40000gn/T/ansible_cisco.dcnm.dcnm_inventory_payload_8ptl8keq/ansible_cisco.dcnm.dcnm_inventory_payload.zip/ansible/module_utils/connection.py\", line 195, in __rpc__\nansible.module_utils.connection.ConnectionError: HTTPSConnectionPool(host='192.168.1.1', port=443): Max retries exceeded with url: / (Caused by NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x10603a3a0>: Failed to establish a new connection: [Errno 60] Operation timed out'))\n\n                  Please verify that the DCNM controller HTTPS URL (https://192.168.1.1:443) is\n                  reachable from the Ansible controller and try again\n\n                  \n",
    "module_stdout": "",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1
}

PLAY RECAP ************************************************************************************************************************************************************************
192.168.1.1                : ok=1    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
```