### PR TITLE
[WIP] dcnm_policy deploy flag issue

### DIFF
--- a/docs/cisco.dcnm.dcnm_policy_module.rst
+++ b/docs/cisco.dcnm.dcnm_policy_module.rst
@@ -377,6 +377,8 @@ Examples
     - name: Create different policies
       cisco.dcnm.dcnm_policy:
         fabric: "{{ ansible_it_fabric }}"
+        state: merged
+        deploy: true
         config:
           - name: template_101  # This must be a valid template name
             create_additional_policy: false  # Do not create a policy if it already exists
@@ -400,8 +402,6 @@ Examples
                   - name: template_105  # This must be a valid template name
                     create_additional_policy: false  # Do not create a policy if it already exists
               - ip: "{{ ansible_switch2 }}"
-            deploy: true
-            state: merged
 
     CREATE POLICY (including arguments)
 
@@ -429,6 +429,8 @@ Examples
     - name: Modify different policies
       cisco.dcnm.dcnm_policy:
         fabric: "{{ ansible_it_fabric }}"
+        state: merged
+        deploy: true
         config:
           - name: POLICY-101101  # This must be a valid POLICY ID
             create_additional_policy: false  # Do not create a policy if it already exists
@@ -452,8 +454,6 @@ Examples
                   - name: POLICY-105105  # This must be a valid POLICY ID
                     create_additional_policy: false  # Do not create a policy if it already exists
                   - ip: "{{ ansible_switch2 }}"
-            deploy: true
-            state: merged
 
     DELETE POLICY
 
@@ -496,33 +496,33 @@ Examples
     - name: Query all policies from the specified switches
       cisco.dcnm.dcnm_policy:
         fabric: "{{ ansible_it_fabric }}"
+        state: query
         config:
           - switch:
               - ip: "{{ ansible_switch1 }}"
               - ip: "{{ ansible_switch2 }}"
-        state: query
 
     - name: Query policies matching template names
       cisco.dcnm.dcnm_policy:
         fabric: "{{ ansible_it_fabric }}"
+        state: query
         config:
           - name: template_101
           - name: template_102
           - name: template_103
           - switch:
               - ip: "{{ ansible_switch1 }}"
-        state: query
 
     - name: Query policies using policy-ids
       cisco.dcnm.dcnm_policy:
         fabric: "{{ ansible_it_fabric }}"
+        state: query
         config:
           - name: POLICY-101101
           - name: POLICY-102102
           - name: POLICY-103103
           - switch:
               - ip: "{{ ansible_switch1 }}"
-        state: query
 
 
 

--- a/docs/cisco.dcnm.dcnm_template_module.rst
+++ b/docs/cisco.dcnm.dcnm_template_module.rst
@@ -164,16 +164,16 @@ Examples
     Deleted:
       Templates defined in the playbook will be deleted from the target.
 
-      Deletes the list of templates specified in the playbook. 
+      Deletes the list of templates specified in the playbook.
 
     Query:
       Returns the current DCNM state for the templates listed in the playbook.
 
 
-    # To create or modify templates 
+    # To create or modify templates
 
     - name: Create or modify templates
-        cisco.dcnm.dcnm_template: 
+        cisco.dcnm.dcnm_template:
           state: merged        # only choose form [merged, deleted, query]
           config:
             - name: template_101
@@ -210,7 +210,7 @@ Examples
                     dst-grp 102
                     snsr-grp 102 sample-interval 10102
 
-    # To delete templates 
+    # To delete templates
 
     - name: Delete templates
         cisco.dcnm.dcnm_template:
@@ -224,7 +224,7 @@ Examples
 
             - name: template_104
 
-    # To query templates 
+    # To query templates
 
     - name: Query templates
         cisco.dcnm.dcnm_template:

--- a/plugins/modules/dcnm_policy.py
+++ b/plugins/modules/dcnm_policy.py
@@ -187,6 +187,8 @@ NOTE: In the following create task, policies identified by template names templa
 - name: Create different policies
   cisco.dcnm.dcnm_policy:
     fabric: "{{ ansible_it_fabric }}"
+    state: merged
+    deploy: true
     config:
       - name: template_101  # This must be a valid template name
         create_additional_policy: false  # Do not create a policy if it already exists
@@ -210,8 +212,6 @@ NOTE: In the following create task, policies identified by template names templa
               - name: template_105  # This must be a valid template name
                 create_additional_policy: false  # Do not create a policy if it already exists
           - ip: "{{ ansible_switch2 }}"
-        deploy: true
-        state: merged
 
 CREATE POLICY (including arguments)
 
@@ -239,6 +239,8 @@ NOTE: Since there can be multiple policies with the same template name, policy-i
 - name: Modify different policies
   cisco.dcnm.dcnm_policy:
     fabric: "{{ ansible_it_fabric }}"
+    state: merged
+    deploy: true
     config:
       - name: POLICY-101101  # This must be a valid POLICY ID
         create_additional_policy: false  # Do not create a policy if it already exists
@@ -262,8 +264,6 @@ NOTE: Since there can be multiple policies with the same template name, policy-i
               - name: POLICY-105105  # This must be a valid POLICY ID
                 create_additional_policy: false  # Do not create a policy if it already exists
               - ip: "{{ ansible_switch2 }}"
-        deploy: true
-        state: merged
 
 DELETE POLICY
 
@@ -306,40 +306,39 @@ NOTE: In the case of Query using template names, all policies that have a matchi
 - name: Query all policies from the specified switches
   cisco.dcnm.dcnm_policy:
     fabric: "{{ ansible_it_fabric }}"
+    state: query
     config:
       - switch:
           - ip: "{{ ansible_switch1 }}"
           - ip: "{{ ansible_switch2 }}"
-    state: query
 
 - name: Query policies matching template names
   cisco.dcnm.dcnm_policy:
     fabric: "{{ ansible_it_fabric }}"
+    state: query
     config:
       - name: template_101
       - name: template_102
       - name: template_103
       - switch:
           - ip: "{{ ansible_switch1 }}"
-    state: query
 
 - name: Query policies using policy-ids
   cisco.dcnm.dcnm_policy:
     fabric: "{{ ansible_it_fabric }}"
+    state: query
     config:
       - name: POLICY-101101
       - name: POLICY-102102
       - name: POLICY-103103
       - switch:
           - ip: "{{ ansible_switch1 }}"
-    state: query
 """
 
-import time
 import json
 import re
 import copy
-import sys
+import datetime
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import Connection
@@ -350,8 +349,6 @@ from ansible_collections.cisco.dcnm.plugins.module_utils.network.dcnm.dcnm impor
     validate_list_of_dicts,
     get_ip_sn_dict,
 )
-
-import datetime
 
 
 class DcnmPolicy:

--- a/plugins/modules/dcnm_template.py
+++ b/plugins/modules/dcnm_template.py
@@ -22,7 +22,7 @@ module: dcnm_template
 short_description: DCNM Ansible Module for managing templates.
 version_added: "1.1.0"
 description:
-    - DCNM Ansible Module for creating, deleting and modifying template service 
+    - DCNM Ansible Module for creating, deleting and modifying template service
     - operations
 author: Mallik Mudigonda
 options:
@@ -36,7 +36,7 @@ options:
       - query
     default: merged
 
-  config:   
+  config:
     description: A dictionary of template operations
     type: list
     elements: dict
@@ -84,16 +84,16 @@ Merged:
 Deleted:
   Templates defined in the playbook will be deleted from the target.
 
-  Deletes the list of templates specified in the playbook. 
+  Deletes the list of templates specified in the playbook.
 
 Query:
   Returns the current DCNM state for the templates listed in the playbook.
 
 
-# To create or modify templates 
+# To create or modify templates
 
 - name: Create or modify templates
-    cisco.dcnm.dcnm_template: 
+    cisco.dcnm.dcnm_template:
       state: merged        # only choose form [merged, deleted, query]
       config:
         - name: template_101
@@ -130,7 +130,7 @@ Query:
                 dst-grp 102
                 snsr-grp 102 sample-interval 10102
 
-# To delete templates 
+# To delete templates
 
 - name: Delete templates
     cisco.dcnm.dcnm_template:
@@ -144,7 +144,7 @@ Query:
 
         - name: template_104
 
-# To query templates 
+# To query templates
 
 - name: Query templates
     cisco.dcnm.dcnm_template:
@@ -202,6 +202,9 @@ class DcnmTemplate:
             self.fd.write(msg)
 
     def dcnm_template_validate_input(self):
+
+        if self.config is None:
+            self.module.fail_json(msg="config: parameter is required and cannot be empty")
 
         if self.module.params["state"] == "merged":
             template_spec = dict(
@@ -599,6 +602,8 @@ class DcnmTemplate:
                 resp = resp[0]
             if resp and resp["RETURN_CODE"] == 200:
                 create_flag = True
+            if resp and resp['RETURN_CODE'] >= 400:
+                self.module.fail_json(msg=resp)
 
         self.result["changed"] = delete_flag or create_flag
 
@@ -632,7 +637,7 @@ def main():
     """ main entry point for module execution
     """
     element_spec = dict(
-        config=dict(required=False, type="list"),
+        config=dict(required=True, type="list"),
         state=dict(
             type="str",
             default="merged",

--- a/tests/integration/targets/dcnm_policy/tests/dcnm/dcnm_policy_delete.yaml
+++ b/tests/integration/targets/dcnm_policy/tests/dcnm/dcnm_policy_delete.yaml
@@ -4,9 +4,9 @@
 
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_policy:
-    fabric: "{{ ansible_it_fabric }}" 
+    fabric: "{{ ansible_it_fabric }}"
     state: deleted                     # only choose form [merged, deleted, query]
-    config: 
+    config:
       - name: template_101  # name is mandatory
       - name: template_102  # name is mandatory
       - name: template_103  # name is mandatory
@@ -14,11 +14,11 @@
       - name: template_105  # name is mandatory
       - switch:
           - ip: "{{ ansible_switch1 }}"
-  register: result  
+  register: result
 
 - assert:
     that:
-      - 'item["RETURN_CODE"] == 200'  
+      - 'item["RETURN_CODE"] == 200'
   loop: '{{ result.response }}'
 
 - block:
@@ -29,8 +29,9 @@
 
     - name: Create policies
       cisco.dcnm.dcnm_policy: &create_pol
-        fabric: "{{ ansible_it_fabric }}" 
-        config: 
+        fabric: "{{ ansible_it_fabric }}"
+        state: merged
+        config:
           - name: template_101  # name is mandatory
 
           - name: template_102  # name is mandatory
@@ -44,7 +45,6 @@
           - switch:
               - ip: "{{ ansible_switch1 }}"
 
-        state: merged
       register: result
 
     - assert:
@@ -60,7 +60,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '"is created successfully" in item["DATA"]["successList"][0]["message"]'
-      when: (my_idx < (result["diff"][0]["merged"] | length))   
+      when: (my_idx < (result["diff"][0]["merged"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -70,15 +70,16 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '(item["DATA"][0]["successPTIList"].split(",") | length) == 5'
-      when: (my_idx == (result["diff"][0]["merged"] | length))   
+      when: (my_idx == (result["diff"][0]["merged"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
 
     - name: Delete policies - using template names
       cisco.dcnm.dcnm_policy: &del_pol
-        fabric: "{{ ansible_it_fabric }}" 
-        config: 
+        fabric: "{{ ansible_it_fabric }}"
+        state: deleted
+        config:
           - name: template_101  # name is mandatory
 
           - name: template_102  # name is mandatory
@@ -92,7 +93,6 @@
           - switch:
               - ip: "{{ ansible_switch1 }}"
 
-        state: deleted
       register: result
 
     - assert:
@@ -106,7 +106,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - 'item["MESSAGE"] == "OK"'
-      when: (my_idx < (result["diff"][0]["deleted"] | length))   
+      when: (my_idx < (result["diff"][0]["deleted"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -115,7 +115,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - 'item["MESSAGE"] == "OK"'
-      when: (my_idx == (result["diff"][0]["deleted"] | length))   
+      when: (my_idx == (result["diff"][0]["deleted"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -124,7 +124,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '"Deleted successfully" in item["DATA"]["message"]'
-      when: (my_idx > (result["diff"][0]["deleted"] | length))   
+      when: (my_idx > (result["diff"][0]["deleted"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -144,7 +144,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - 'item["MESSAGE"] == "OK"'
-      when: (my_idx < (result["diff"][0]["deleted"] | length))   
+      when: (my_idx < (result["diff"][0]["deleted"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -153,7 +153,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - 'item["MESSAGE"] == "OK"'
-      when: (my_idx == (result["diff"][0]["deleted"] | length))   
+      when: (my_idx == (result["diff"][0]["deleted"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -162,7 +162,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '"Deleted successfully" in item["DATA"]["message"]'
-      when: (my_idx > (result["diff"][0]["deleted"] | length))   
+      when: (my_idx > (result["diff"][0]["deleted"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -184,7 +184,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '"is created successfully" in item["DATA"]["successList"][0]["message"]'
-      when: (my_idx < (result["diff"][0]["merged"] | length))   
+      when: (my_idx < (result["diff"][0]["merged"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -194,7 +194,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '(item["DATA"][0]["successPTIList"].split(",") | length) == 5'
-      when: (my_idx == (result["diff"][0]["merged"] | length))   
+      when: (my_idx == (result["diff"][0]["merged"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -202,29 +202,29 @@
     - name: Setting fact
       set_fact:
         del_policy_list: "{{ (del_policy_list | default([])) + [item['DATA']['successList'][0]['message'].split(' ')[0]] }}"
-      when: (my_idx < (result["diff"][0]["merged"] | length))   
+      when: (my_idx < (result["diff"][0]["merged"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
-    
+
     - name: Show the policy_list information
       debug:
-        var: del_policy_list 
+        var: del_policy_list
 
     - name: Setting fact
       set_fact:
-        list_len: "{{ del_policy_list | length }}" 
+        list_len: "{{ del_policy_list | length }}"
 
     - name: Delete policies - using policy IDs
-      cisco.dcnm.dcnm_policy: 
-        fabric: "{{ ansible_it_fabric }}" 
+      cisco.dcnm.dcnm_policy:
+        fabric: "{{ ansible_it_fabric }}"
         state: deleted
-        config: 
+        config:
           - name: "{{ item }}"  # Pick the policy Ids from the facts
           - switch:
               - ip: "{{ ansible_switch1 }}"
 
-      loop: '{{ del_policy_list }}'      
+      loop: '{{ del_policy_list }}'
       register: result
 
     - assert:
@@ -242,8 +242,9 @@
 
     - name: Create multiple policies for a template
       cisco.dcnm.dcnm_policy:
-        fabric: "{{ ansible_it_fabric }}" 
-        config: 
+        fabric: "{{ ansible_it_fabric }}"
+        state: merged
+        config:
           - name: template_101  # name is mandatory
             create_additional_policy: true  # Create a policy even if it already exists
 
@@ -253,7 +254,6 @@
           - switch:
               - ip: "{{ ansible_switch1 }}"
 
-        state: merged
       register: result
 
     - assert:
@@ -269,7 +269,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '"is created successfully" in item["DATA"]["successList"][0]["message"]'
-      when: (my_idx < (result["diff"][0]["merged"] | length))   
+      when: (my_idx < (result["diff"][0]["merged"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -279,20 +279,20 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '(item["DATA"][0]["successPTIList"].split(",") | length) == 2'
-      when: (my_idx == (result["diff"][0]["merged"] | length))   
+      when: (my_idx == (result["diff"][0]["merged"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
 
     - name: Delete all matching policies using template name
       cisco.dcnm.dcnm_policy:
-        fabric: "{{ ansible_it_fabric }}" 
+        fabric: "{{ ansible_it_fabric }}"
         state: deleted                     # only choose form [merged, deleted, query]
-        config: 
+        config:
           - name: template_101  # This can either be a policy name like POLICY-xxxxx or template name
           - switch:
              - ip: "{{ ansible_switch1 }}"
-      register: result  
+      register: result
 
     - assert:
         that:
@@ -305,7 +305,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - 'item["MESSAGE"] == "OK"'
-      when: (my_idx < (result["diff"][0]["deleted"] | length))   
+      when: (my_idx < (result["diff"][0]["deleted"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -314,7 +314,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - 'item["MESSAGE"] == "OK"'
-      when: (my_idx == (result["diff"][0]["deleted"] | length))   
+      when: (my_idx == (result["diff"][0]["deleted"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -323,7 +323,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '"Deleted successfully" in item["DATA"]["message"]'
-      when: (my_idx > (result["diff"][0]["deleted"] | length))   
+      when: (my_idx > (result["diff"][0]["deleted"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -336,9 +336,9 @@
 
     - name: Delete all created policies
       cisco.dcnm.dcnm_policy:
-        fabric: "{{ ansible_it_fabric }}" 
+        fabric: "{{ ansible_it_fabric }}"
         state: deleted                     # only choose form [merged, deleted, query]
-        config: 
+        config:
           - name: template_101  # This can either be a policy name like POLICY-xxxxx or template name
           - name: template_102  # This can either be a policy name like POLICY-xxxxx or template name
           - name: template_103  # This can either be a policy name like POLICY-xxxxx or template name
@@ -346,7 +346,7 @@
           - name: template_105  # This can either be a policy name like POLICY-xxxxx or template name
           - switch:
              - ip: "{{ ansible_switch1 }}"
-      register: result  
+      register: result
 
     - assert:
         that:

--- a/tests/integration/targets/dcnm_policy/tests/dcnm/dcnm_policy_merge.yaml
+++ b/tests/integration/targets/dcnm_policy/tests/dcnm/dcnm_policy_merge.yaml
@@ -4,9 +4,9 @@
 
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_policy:
-    fabric: "{{ ansible_it_fabric }}" 
+    fabric: "{{ ansible_it_fabric }}"
     state: deleted                     # only choose form [merged, deleted, query]
-    config: 
+    config:
       - name: template_101  # name is mandatory
       - name: template_102  # name is mandatory
       - name: template_103  # name is mandatory
@@ -14,11 +14,11 @@
       - name: template_105  # name is mandatory
       - switch:
           - ip: "{{ ansible_switch1 }}"
-  register: result  
+  register: result
 
 - assert:
     that:
-      - 'item["RETURN_CODE"] == 200'  
+      - 'item["RETURN_CODE"] == 200'
   loop: '{{ result.response }}'
 
 
@@ -28,13 +28,15 @@
 ##                MERGE                     ##
 ##############################################
 
-    - name: Create different non-existing policies 
+    - name: Create different non-existing policies
       cisco.dcnm.dcnm_policy: &dcnm_pol
-        fabric: "{{ ansible_it_fabric }}" 
-        config: 
+        fabric: "{{ ansible_it_fabric }}"
+        deploy: true
+        state: merged
+        config:
           - name: template_101  # This must be a valid template name
             create_additional_policy: false  # Do not create a policy if it already exists
-            priority: 101 
+            priority: 101
 
           - name: template_102  # This must be a valid template name
             create_additional_policy: false  # Do not create a policy if it already exists
@@ -54,8 +56,6 @@
                   - name: template_105  # This must be a valid template name
                     create_additional_policy: false  # Do not create a policy if it already exists
               - ip: "{{ ansible_switch1 }}"
-        deploy: true
-        state: merged
       register: result
 
     - assert:
@@ -71,7 +71,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '"is created successfully" in item["DATA"]["successList"][0]["message"]'
-      when: (my_idx < (result["diff"][0]["merged"] | length))   
+      when: (my_idx < (result["diff"][0]["merged"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -81,7 +81,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '(item["DATA"][0]["successPTIList"].split(",") | length) == 5'
-      when: (my_idx == (result["diff"][0]["merged"] | length))   
+      when: (my_idx == (result["diff"][0]["merged"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -103,7 +103,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '"is created successfully" in item["DATA"]["successList"][0]["message"]'
-      when: (my_idx < (result["diff"][0]["merged"] | length))   
+      when: (my_idx < (result["diff"][0]["merged"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -113,21 +113,21 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '(item["DATA"][0]["successPTIList"].split(",") | length) == 5'
-      when: (my_idx == (result["diff"][0]["merged"] | length))   
+      when: (my_idx == (result["diff"][0]["merged"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
 
     - name: Delete some policies
       cisco.dcnm.dcnm_policy:
-        fabric: "{{ ansible_it_fabric }}" 
+        fabric: "{{ ansible_it_fabric }}"
         state: deleted          # only choose form [merged, deleted, query]
-        config: 
+        config:
           - name: template_104  # This can either be a policy name like POLICY-xxxxx or template name
           - name: template_105  # This can either be a policy name like POLICY-xxxxx or template name
           - switch:
             - ip: "{{ ansible_switch1 }}"
-      register: result  
+      register: result
 
     - assert:
         that:
@@ -140,7 +140,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - 'item["MESSAGE"] == "OK"'
-      when: (my_idx < (result["diff"][0]["deleted"] | length))   
+      when: (my_idx < (result["diff"][0]["deleted"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -149,7 +149,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - 'item["MESSAGE"] == "OK"'
-      when: (my_idx == (result["diff"][0]["deleted"] | length))   
+      when: (my_idx == (result["diff"][0]["deleted"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -158,18 +158,20 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '"Deleted successfully" in item["DATA"]["message"]'
-      when: (my_idx > (result["diff"][0]["deleted"] | length))   
+      when: (my_idx > (result["diff"][0]["deleted"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
 
     - name: Create a mixture of existing and non-existing policies
-      cisco.dcnm.dcnm_policy: 
-        fabric: "{{ ansible_it_fabric }}" 
-        config: 
+      cisco.dcnm.dcnm_policy:
+        fabric: "{{ ansible_it_fabric }}"
+        deploy: true
+        state: merged
+        config:
           - name: template_101  # This must be a valid template name
             create_additional_policy: false  # Do not create a policy if it already exists
-            priority: 101 
+            priority: 101
 
           - name: template_102  # This must be a valid template name
             create_additional_policy: false  # Do not create a policy if it already exists
@@ -189,8 +191,6 @@
                   - name: template_105  # This must be a valid template name
                     create_additional_policy: false  # Do not create a policy if it already exists
               - ip: "{{ ansible_switch1 }}"
-        deploy: true
-        state: merged
       register: result
 
     - assert:
@@ -206,7 +206,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '"is created successfully" in item["DATA"]["successList"][0]["message"]'
-      when: (my_idx < (result["diff"][0]["merged"] | length))   
+      when: (my_idx < (result["diff"][0]["merged"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -216,21 +216,21 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '(item["DATA"][0]["successPTIList"].split(",") | length) == 5'
-      when: (my_idx == (result["diff"][0]["merged"] | length))   
+      when: (my_idx == (result["diff"][0]["merged"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
 
     - name: Delete some policies
       cisco.dcnm.dcnm_policy:
-        fabric: "{{ ansible_it_fabric }}" 
+        fabric: "{{ ansible_it_fabric }}"
         state: deleted          # only choose form [merged, deleted, query]
-        config: 
+        config:
           - name: template_104  # This can either be a policy name like POLICY-xxxxx or template name
           - name: template_105  # This can either be a policy name like POLICY-xxxxx or template name
           - switch:
             - ip: "{{ ansible_switch1 }}"
-      register: result  
+      register: result
 
     - assert:
         that:
@@ -243,7 +243,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - 'item["MESSAGE"] == "OK"'
-      when: (my_idx < (result["diff"][0]["deleted"] | length))   
+      when: (my_idx < (result["diff"][0]["deleted"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -252,7 +252,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - 'item["MESSAGE"] == "OK"'
-      when: (my_idx == (result["diff"][0]["deleted"] | length))   
+      when: (my_idx == (result["diff"][0]["deleted"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -261,15 +261,16 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '"Deleted successfully" in item["DATA"]["message"]'
-      when: (my_idx > (result["diff"][0]["deleted"] | length))   
+      when: (my_idx > (result["diff"][0]["deleted"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
 
     - name: Create policies without mentioning state
-      cisco.dcnm.dcnm_policy: 
-        fabric: "{{ ansible_it_fabric }}" 
-        config: 
+      cisco.dcnm.dcnm_policy:
+        fabric: "{{ ansible_it_fabric }}"
+        deploy: true
+        config:
           - switch:
               - ip: "{{ ansible_switch1 }}"
                 policies:
@@ -279,7 +280,6 @@
                   - name: template_105  # This must be a valid template name
                     create_additional_policy: false  # Do not create a policy if it already exists
               - ip: "{{ ansible_switch1 }}"
-        deploy: true
       register: result
 
     - assert:
@@ -295,7 +295,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '"is created successfully" in item["DATA"]["successList"][0]["message"]'
-      when: (my_idx < (result["diff"][0]["merged"] | length))   
+      when: (my_idx < (result["diff"][0]["merged"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -305,21 +305,21 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '(item["DATA"][0]["successPTIList"].split(",") | length) == 2'
-      when: (my_idx == (result["diff"][0]["merged"] | length))   
+      when: (my_idx == (result["diff"][0]["merged"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
 
     - name: Delete some policies
       cisco.dcnm.dcnm_policy:
-        fabric: "{{ ansible_it_fabric }}" 
+        fabric: "{{ ansible_it_fabric }}"
         state: deleted          # only choose form [merged, deleted, query]
-        config: 
+        config:
           - name: template_104  # This can either be a policy name like POLICY-xxxxx or template name
           - name: template_105  # This can either be a policy name like POLICY-xxxxx or template name
           - switch:
             - ip: "{{ ansible_switch1 }}"
-      register: result  
+      register: result
 
     - assert:
         that:
@@ -332,7 +332,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - 'item["MESSAGE"] == "OK"'
-      when: (my_idx < (result["diff"][0]["deleted"] | length))   
+      when: (my_idx < (result["diff"][0]["deleted"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -341,7 +341,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - 'item["MESSAGE"] == "OK"'
-      when: (my_idx == (result["diff"][0]["deleted"] | length))   
+      when: (my_idx == (result["diff"][0]["deleted"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -350,28 +350,28 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '"Deleted successfully" in item["DATA"]["message"]'
-      when: (my_idx > (result["diff"][0]["deleted"] | length))   
+      when: (my_idx > (result["diff"][0]["deleted"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
 
     - name: Create same policy with create_additional_policy flag set
-      cisco.dcnm.dcnm_policy: 
-        fabric: "{{ ansible_it_fabric }}" 
-        config: 
+      cisco.dcnm.dcnm_policy:
+        fabric: "{{ ansible_it_fabric }}"
+        deploy: true
+        config:
           - name: template_104  # This must be a valid template name
             create_additional_policy: false # Do not create a policy if it already exists
             description: create template_104
-            priority: 104 
+            priority: 104
 
           - name: template_104  # This must be a valid template name
             create_additional_policy: true # Do not create a policy if it already exists
             description: create template_104
-            priority: 104 
+            priority: 104
 
           - switch:
               - ip: "{{ ansible_switch1 }}"
-        deploy: true
       register: result
 
     - assert:
@@ -387,7 +387,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '"is created successfully" in item["DATA"]["successList"][0]["message"]'
-      when: (my_idx < (result["diff"][0]["merged"] | length))   
+      when: (my_idx < (result["diff"][0]["merged"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -397,21 +397,21 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '(item["DATA"][0]["successPTIList"].split(",") | length) == 2'
-      when: (my_idx == (result["diff"][0]["merged"] | length))   
+      when: (my_idx == (result["diff"][0]["merged"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
 
     - name: Delete some policies
       cisco.dcnm.dcnm_policy:
-        fabric: "{{ ansible_it_fabric }}" 
+        fabric: "{{ ansible_it_fabric }}"
         state: deleted          # only choose form [merged, deleted, query]
-        config: 
+        config:
           - name: template_104  # This can either be a policy name like POLICY-xxxxx or template name
           - name: template_105  # This can either be a policy name like POLICY-xxxxx or template name
           - switch:
             - ip: "{{ ansible_switch1 }}"
-      register: result  
+      register: result
 
     - assert:
         that:
@@ -424,7 +424,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - 'item["MESSAGE"] == "OK"'
-      when: (my_idx < (result["diff"][0]["deleted"] | length))   
+      when: (my_idx < (result["diff"][0]["deleted"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -433,7 +433,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - 'item["MESSAGE"] == "OK"'
-      when: (my_idx == (result["diff"][0]["deleted"] | length))   
+      when: (my_idx == (result["diff"][0]["deleted"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -442,23 +442,23 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '"Deleted successfully" in item["DATA"]["message"]'
-      when: (my_idx > (result["diff"][0]["deleted"] | length))   
+      when: (my_idx > (result["diff"][0]["deleted"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
 
     - name: Create policy without deploy flag
-      cisco.dcnm.dcnm_policy: 
-        fabric: "{{ ansible_it_fabric }}" 
-        config: 
+      cisco.dcnm.dcnm_policy:
+        fabric: "{{ ansible_it_fabric }}"
+        deploy: false
+        config:
           - name: template_104  # This must be a valid template name
             create_additional_policy: false # Do not create a policy if it already exists
             description: create template_104
-            priority: 104 
+            priority: 104
 
           - switch:
               - ip: "{{ ansible_switch1 }}"
-        deploy: false
       register: result
 
     - assert:
@@ -474,7 +474,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '"is created successfully" in item["DATA"]["successList"][0]["message"]'
-      when: (my_idx < (result["diff"][0]["merged"] | length))   
+      when: (my_idx < (result["diff"][0]["merged"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -484,7 +484,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '(item["DATA"][0]["successPTIList"].split(",") | length) == 0'
-      when: (my_idx == (result["diff"][0]["merged"] | length))   
+      when: (my_idx == (result["diff"][0]["merged"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -497,9 +497,9 @@
 
     - name: Delete all created policies
       cisco.dcnm.dcnm_policy:
-        fabric: "{{ ansible_it_fabric }}" 
+        fabric: "{{ ansible_it_fabric }}"
         state: deleted                     # only choose form [merged, deleted, query]
-        config: 
+        config:
           - name: template_101  # This can either be a policy name like POLICY-xxxxx or template name
           - name: template_102  # This can either be a policy name like POLICY-xxxxx or template name
           - name: template_103  # This can either be a policy name like POLICY-xxxxx or template name
@@ -507,7 +507,7 @@
           - name: template_105  # This can either be a policy name like POLICY-xxxxx or template name
           - switch:
              - ip: "{{ ansible_switch1 }}"
-      register: result  
+      register: result
 
     - assert:
         that:

--- a/tests/integration/targets/dcnm_policy/tests/dcnm/dcnm_policy_merge_checkmode.yaml
+++ b/tests/integration/targets/dcnm_policy/tests/dcnm/dcnm_policy_merge_checkmode.yaml
@@ -4,9 +4,9 @@
 
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_policy:
-    fabric: "{{ ansible_it_fabric }}" 
+    fabric: "{{ ansible_it_fabric }}"
     state: deleted                     # only choose form [merged, deleted, query]
-    config: 
+    config:
       - name: template_101  # name is mandatory
       - name: template_102  # name is mandatory
       - name: template_103  # name is mandatory
@@ -14,11 +14,11 @@
       - name: template_105  # name is mandatory
       - switch:
           - ip: "{{ ansible_switch1 }}"
-  register: result  
+  register: result
 
 - assert:
     that:
-      - 'item["RETURN_CODE"] == 200'  
+      - 'item["RETURN_CODE"] == 200'
   loop: '{{ result.response }}'
 
 
@@ -28,13 +28,16 @@
 ##                MERGE                     ##
 ##############################################
 
-    - name: Create different non-existing policies 
+    - name: Create different non-existing policies
       cisco.dcnm.dcnm_policy: &dcnm_pol
-        fabric: "{{ ansible_it_fabric }}" 
+        fabric: "{{ ansible_it_fabric }}"
+        deploy: true
+        state: merged
+        check_mode: true
         config: 
           - name: template_101  # This must be a valid template name
             create_additional_policy: false  # Do not create a policy if it already exists
-            priority: 101 
+            priority: 101
 
           - name: template_102  # This must be a valid template name
             create_additional_policy: false  # Do not create a policy if it already exists
@@ -54,9 +57,6 @@
                   - name: template_105  # This must be a valid template name
                     create_additional_policy: false  # Do not create a policy if it already exists
               - ip: "{{ ansible_switch1 }}"
-        deploy: true
-        state: merged
-        check_mode: true
       register: result
 
     - assert:
@@ -76,9 +76,9 @@
 
     - name: Delete all created policies
       cisco.dcnm.dcnm_policy:
-        fabric: "{{ ansible_it_fabric }}" 
+        fabric: "{{ ansible_it_fabric }}"
         state: deleted                     # only choose form [merged, deleted, query]
-        config: 
+        config:
           - name: template_101  # This can either be a policy name like POLICY-xxxxx or template name
           - name: template_102  # This can either be a policy name like POLICY-xxxxx or template name
           - name: template_103  # This can either be a policy name like POLICY-xxxxx or template name
@@ -86,7 +86,7 @@
           - name: template_105  # This can either be a policy name like POLICY-xxxxx or template name
           - switch:
              - ip: "{{ ansible_switch1 }}"
-      register: result  
+      register: result
 
     - assert:
         that:

--- a/tests/integration/targets/dcnm_policy/tests/dcnm/dcnm_policy_merge_multi_switch.yaml
+++ b/tests/integration/targets/dcnm_policy/tests/dcnm/dcnm_policy_merge_multi_switch.yaml
@@ -4,9 +4,9 @@
 
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_policy:
-    fabric: "{{ ansible_it_fabric }}" 
+    fabric: "{{ ansible_it_fabric }}"
     state: deleted                     # only choose form [merged, deleted, query]
-    config: 
+    config:
       - name: template_101  # name is mandatory
       - name: template_102  # name is mandatory
       - name: template_103  # name is mandatory
@@ -15,11 +15,11 @@
       - switch:
           - ip: "{{ ansible_switch1 }}"
           - ip: "{{ ansible_switch2 }}"
-  register: result  
+  register: result
 
 - assert:
     that:
-      - 'item["RETURN_CODE"] == 200'  
+      - 'item["RETURN_CODE"] == 200'
   loop: '{{ result.response }}'
 
 
@@ -31,17 +31,17 @@
 
     - name: Create policy on multile switches
       cisco.dcnm.dcnm_policy: &dcnm_pol
-        fabric: "{{ ansible_it_fabric }}" 
+        fabric: "{{ ansible_it_fabric }}"
+        deploy: true
+        state: merged
         config: 
           - name: template_101  # This must be a valid template name
             create_additional_policy: false  # Do not create a policy if it already exists
-            priority: 101 
+            priority: 101
 
           - switch:
               - ip: "{{ ansible_switch1 }}"
               - ip: "{{ ansible_switch2 }}"
-        deploy: true
-        state: merged
       register: result
 
     - assert:
@@ -57,7 +57,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '"is created successfully" in item["DATA"]["successList"][0]["message"]'
-      when: (my_idx < (result["diff"][0]["merged"] | length))   
+      when: (my_idx < (result["diff"][0]["merged"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -67,7 +67,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '(item["DATA"][0]["successPTIList"].split(",") | length) == 1'
-      when: (my_idx >= (result["diff"][0]["merged"] | length))   
+      when: (my_idx >= (result["diff"][0]["merged"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -89,7 +89,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '"is created successfully" in item["DATA"]["successList"][0]["message"]'
-      when: (my_idx < (result["diff"][0]["merged"] | length))   
+      when: (my_idx < (result["diff"][0]["merged"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -99,7 +99,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '(item["DATA"][0]["successPTIList"].split(",") | length) == 1'
-      when: (my_idx >= (result["diff"][0]["merged"] | length))   
+      when: (my_idx >= (result["diff"][0]["merged"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -112,14 +112,14 @@
 
     - name: Delete all created policies
       cisco.dcnm.dcnm_policy:
-        fabric: "{{ ansible_it_fabric }}" 
+        fabric: "{{ ansible_it_fabric }}"
         state: deleted                     # only choose form [merged, deleted, query]
-        config: 
+        config:
           - name: template_101  # This can either be a policy name like POLICY-xxxxx or template name
           - switch:
              - ip: "{{ ansible_switch1 }}"
              - ip: "{{ ansible_switch2 }}"
-      register: result  
+      register: result
 
     - assert:
         that:

--- a/tests/integration/targets/dcnm_policy/tests/dcnm/dcnm_policy_modify.yaml
+++ b/tests/integration/targets/dcnm_policy/tests/dcnm/dcnm_policy_modify.yaml
@@ -4,9 +4,9 @@
 
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_policy:
-    fabric: "{{ ansible_it_fabric }}" 
+    fabric: "{{ ansible_it_fabric }}"
     state: deleted                     # only choose form [merged, deleted, query]
-    config: 
+    config:
       - name: template_101  # name is mandatory
       - name: template_102  # name is mandatory
       - name: template_103  # name is mandatory
@@ -14,11 +14,11 @@
       - name: template_105  # name is mandatory
       - switch:
           - ip: "{{ ansible_switch1 }}"
-  register: result  
+  register: result
 
 - assert:
     that:
-      - 'item["RETURN_CODE"] == 200'  
+      - 'item["RETURN_CODE"] == 200'
   loop: '{{ result.response }}'
 
 - block:
@@ -27,13 +27,15 @@
 ##                MERGE                     ##
 ##############################################
 
-    - name: Create different non-existing policies 
+    - name: Create different non-existing policies
       cisco.dcnm.dcnm_policy: &dcnm_pol
-        fabric: "{{ ansible_it_fabric }}" 
-        config: 
+        fabric: "{{ ansible_it_fabric }}"
+        deploy: true
+        state: merged
+        config:
           - name: template_101  # This must be a valid template name
             create_additional_policy: false  # Do not create a policy if it already exists
-            priority: 101 
+            priority: 101
 
           - name: template_102  # This must be a valid template name
             create_additional_policy: false  # Do not create a policy if it already exists
@@ -53,8 +55,6 @@
                   - name: template_105  # This must be a valid template name
                     create_additional_policy: false  # Do not create a policy if it already exists
               - ip: "{{ ansible_switch1 }}"
-        deploy: true
-        state: merged
       register: result
 
     - assert:
@@ -70,7 +70,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '"is created successfully" in item["DATA"]["successList"][0]["message"]'
-      when: (my_idx < (result["diff"][0]["merged"] | length))   
+      when: (my_idx < (result["diff"][0]["merged"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -80,7 +80,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '(item["DATA"][0]["successPTIList"].split(",") | length) == 5'
-      when: (my_idx == (result["diff"][0]["merged"] | length))   
+      when: (my_idx == (result["diff"][0]["merged"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -88,31 +88,31 @@
     - name: Setting fact
       set_fact:
         modify_policy_list: "{{ (modify_policy_list | default([])) + [item['DATA']['successList'][0]['message'].split(' ')[0]] }}"
-      when: (my_idx < (result["diff"][0]["merged"] | length))   
+      when: (my_idx < (result["diff"][0]["merged"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
-    
+
     - name: Show the policy_list information
       debug:
-        var: modify_policy_list 
+        var: modify_policy_list
 
     - name: Setting fact
       set_fact:
-        list_len: "{{ modify_policy_list | length }}" 
+        list_len: "{{ modify_policy_list | length }}"
 
     - name: Modify existing policy using template name - should fail
-      cisco.dcnm.dcnm_policy: 
-        fabric: "{{ ansible_it_fabric }}" 
-        config: 
+      cisco.dcnm.dcnm_policy:
+        fabric: "{{ ansible_it_fabric }}"
+        deploy: true
+        state: merged
+        config:
           - name: template_101  # This must be a valid template name
             create_additional_policy: false  # Do not create a policy if it already exists
             description: Trying to modify existing policy using templateName
-            priority: 1000 
+            priority: 1000
           - switch:
               - ip: "{{ ansible_switch1 }}"
-        deploy: true
-        state: merged
       register: result
 
     - assert:
@@ -125,16 +125,16 @@
           - '(result["diff"][0]["skipped"] | length) == 1'
 
     - name: Modify policies - using policy IDs
-      cisco.dcnm.dcnm_policy: 
-        fabric: "{{ ansible_it_fabric }}" 
+      cisco.dcnm.dcnm_policy:
+        fabric: "{{ ansible_it_fabric }}"
         state: merged
-        config: 
+        config:
           - name: "{{ item }}"  # Pick the policy Ids from the facts
             description: Modified the policy "{{ item }}" using policy ID
             priority: "{{ 100 + my_idx }}"
           - switch:
               - ip: "{{ ansible_switch1 }}"
-      loop: '{{ modify_policy_list }}'      
+      loop: '{{ modify_policy_list }}'
       loop_control:
         index_var: my_idx
       register: result
@@ -143,7 +143,7 @@
     - assert:
         that:
           - 'item["RETURN_CODE"] == 200'
-      when: (my_idx < (result.results[0]["diff"][0]["merged"] | length))   
+      when: (my_idx < (result.results[0]["diff"][0]["merged"] | length))
       loop: '{{ result.results[0].response }}'
       loop_control:
         index_var: my_idx
@@ -153,7 +153,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '(item["DATA"][0]["successPTIList"].split(",") | length) == 1'
-      when: (my_idx == (result.results[0]["diff"][0]["merged"] | length))   
+      when: (my_idx == (result.results[0]["diff"][0]["merged"] | length))
       loop: '{{ result.results[0].response }}'
       loop_control:
         index_var: my_idx
@@ -166,9 +166,9 @@
 
     - name: Delete all created policies
       cisco.dcnm.dcnm_policy:
-        fabric: "{{ ansible_it_fabric }}" 
+        fabric: "{{ ansible_it_fabric }}"
         state: deleted                     # only choose form [merged, deleted, query]
-        config: 
+        config:
           - name: template_101  # This can either be a policy name like POLICY-xxxxx or template name
           - name: template_102  # This can either be a policy name like POLICY-xxxxx or template name
           - name: template_103  # This can either be a policy name like POLICY-xxxxx or template name
@@ -176,7 +176,7 @@
           - name: template_105  # This can either be a policy name like POLICY-xxxxx or template name
           - switch:
              - ip: "{{ ansible_switch1 }}"
-      register: result  
+      register: result
 
     - assert:
         that:

--- a/tests/integration/targets/dcnm_policy/tests/dcnm/dcnm_policy_query.yaml
+++ b/tests/integration/targets/dcnm_policy/tests/dcnm/dcnm_policy_query.yaml
@@ -4,9 +4,9 @@
 
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_policy:
-    fabric: "{{ ansible_it_fabric }}" 
+    fabric: "{{ ansible_it_fabric }}"
     state: deleted                     # only choose form [merged, deleted, query]
-    config: 
+    config:
       - name: template_101  # name is mandatory
       - name: template_102  # name is mandatory
       - name: template_103  # name is mandatory
@@ -14,11 +14,11 @@
       - name: template_105  # name is mandatory
       - switch:
           - ip: "{{ ansible_switch1 }}"
-  register: result  
+  register: result
 
 - assert:
     that:
-      - 'item["RETURN_CODE"] == 200'  
+      - 'item["RETURN_CODE"] == 200'
   loop: '{{ result.response }}'
 
 
@@ -28,13 +28,15 @@
 ##                MERGE                     ##
 ##############################################
 
-    - name: Create different non-existing policies 
-      cisco.dcnm.dcnm_policy: 
-        fabric: "{{ ansible_it_fabric }}" 
-        config: 
+    - name: Create different non-existing policies
+      cisco.dcnm.dcnm_policy:
+        fabric: "{{ ansible_it_fabric }}"
+        deploy: true
+        state: merged
+        config:
           - name: template_101  # This must be a valid template name
             create_additional_policy: false  # Do not create a policy if it already exists
-            priority: 101 
+            priority: 101
 
           - name: template_102  # This must be a valid template name
             create_additional_policy: false  # Do not create a policy if it already exists
@@ -54,8 +56,6 @@
                   - name: template_105  # This must be a valid template name
                     create_additional_policy: false  # Do not create a policy if it already exists
               - ip: "{{ ansible_switch1 }}"
-        deploy: true
-        state: merged
       register: result
 
     - assert:
@@ -71,7 +71,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '"is created successfully" in item["DATA"]["successList"][0]["message"]'
-      when: (my_idx < (result["diff"][0]["merged"] | length))   
+      when: (my_idx < (result["diff"][0]["merged"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -81,7 +81,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '(item["DATA"][0]["successPTIList"].split(",") | length) == 5'
-      when: (my_idx == (result["diff"][0]["merged"] | length))   
+      when: (my_idx == (result["diff"][0]["merged"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -89,29 +89,29 @@
     - name: Setting fact
       set_fact:
         query_policy_list: "{{ (query_policy_list | default([])) + [item['DATA']['successList'][0]['message'].split(' ')[0]] }}"
-      when: (my_idx < (result["diff"][0]["merged"] | length))   
+      when: (my_idx < (result["diff"][0]["merged"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
-    
+
     - name: Show the policy_list information
       debug:
-        var: query_policy_list 
+        var: query_policy_list
 
     - name: Setting fact
       set_fact:
-        list_len: "{{ query_policy_list | length }}" 
+        list_len: "{{ query_policy_list | length }}"
 
 ##############################################
 ##                QUERY                     ##
 ##############################################
     - name: Query all policies from the specified switches
       cisco.dcnm.dcnm_policy:
-        fabric: "{{ ansible_it_fabric }}" 
-        config: 
+        fabric: "{{ ansible_it_fabric }}"
+        state: query
+        config:
           - switch:
               - ip: "{{ ansible_switch1 }}"
-        state: query
       register: result
 
     - assert:
@@ -125,14 +125,14 @@
 
     - name: Query specific policies
       cisco.dcnm.dcnm_policy:
-        fabric: "{{ ansible_it_fabric }}" 
-        config: 
+        fabric: "{{ ansible_it_fabric }}"
+        state: query
+        config:
           - name: template_101
           - name: template_102
           - name: template_103
           - switch:
               - ip: "{{ ansible_switch1 }}"
-        state: query
       register: result
 
     - assert:
@@ -145,16 +145,17 @@
           - '(result["response"] | length) == 3'
 
     - name: Create additional policies same as  existing policies
-      cisco.dcnm.dcnm_policy: 
-        fabric: "{{ ansible_it_fabric }}" 
-        config: 
+      cisco.dcnm.dcnm_policy:
+        fabric: "{{ ansible_it_fabric }}"
+        state: merged
+        config:
           - name: template_101  # This must be a valid template name
             create_additional_policy: true  # Create a policy if it already exists
-            priority: 101 
+            priority: 101
 
           - name: template_101  # This must be a valid template name
             create_additional_policy: true  # Create a policy if it already exists
-            priority: 101 
+            priority: 101
 
           - name: template_102  # This must be a valid template name
             create_additional_policy: true  # Create a policy if it already exists
@@ -166,7 +167,6 @@
 
           - switch:
               - ip: "{{ ansible_switch1 }}"
-        state: merged
       register: result
 
     - assert:
@@ -182,7 +182,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '"is created successfully" in item["DATA"]["successList"][0]["message"]'
-      when: (my_idx < (result["diff"][0]["merged"] | length))   
+      when: (my_idx < (result["diff"][0]["merged"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -192,15 +192,15 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '(item["DATA"][0]["successPTIList"].split(",") | length) == 4'
-      when: (my_idx == (result["diff"][0]["merged"] | length))   
+      when: (my_idx == (result["diff"][0]["merged"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
 
     - name: Query with template names matching multiple policies
       cisco.dcnm.dcnm_policy:
-        fabric: "{{ ansible_it_fabric }}" 
-        config: 
+        fabric: "{{ ansible_it_fabric }}"
+        config:
           - name: template_101
           - name: template_102
           - name: template_103
@@ -220,13 +220,13 @@
 
     - name: Query policies with policy ID
       cisco.dcnm.dcnm_policy:
-        fabric: "{{ ansible_it_fabric }}" 
-        config: 
+        fabric: "{{ ansible_it_fabric }}"
+        state: query
+        config:
           - name: "{{ item }}"  # Pick the policy Ids from the facts
           - switch:
               - ip: "{{ ansible_switch1 }}"
-        state: query
-      loop: '{{ query_policy_list }}'      
+      loop: '{{ query_policy_list }}'
       register: result
 
     - assert:
@@ -247,9 +247,9 @@
 
     - name: Delete all created policies
       cisco.dcnm.dcnm_policy:
-        fabric: "{{ ansible_it_fabric }}" 
+        fabric: "{{ ansible_it_fabric }}"
         state: deleted                     # only choose form [merged, deleted, query]
-        config: 
+        config:
           - name: template_101  # This can either be a policy name like POLICY-xxxxx or template name
           - name: template_102  # This can either be a policy name like POLICY-xxxxx or template name
           - name: template_103  # This can either be a policy name like POLICY-xxxxx or template name
@@ -257,7 +257,7 @@
           - name: template_105  # This can either be a policy name like POLICY-xxxxx or template name
           - switch:
              - ip: "{{ ansible_switch1 }}"
-      register: result  
+      register: result
 
     - assert:
         that:

--- a/tests/integration/targets/dcnm_policy/tests/dcnm/dcnm_policy_with_vars_merge.yaml
+++ b/tests/integration/targets/dcnm_policy/tests/dcnm/dcnm_policy_with_vars_merge.yaml
@@ -4,17 +4,17 @@
 
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_policy:
-    fabric: "{{ ansible_it_fabric }}" 
+    fabric: "{{ ansible_it_fabric }}"
     state: deleted                     # only choose form [merged, deleted, query]
-    config: 
+    config:
       - name: my_base_ospf  # name is mandatory
       - switch:
           - ip: "{{ ansible_switch1 }}"
-  register: result  
+  register: result
 
 - assert:
     that:
-      - 'item["RETURN_CODE"] == 200'  
+      - 'item["RETURN_CODE"] == 200'
   loop: '{{ result.response }}'
 
 
@@ -26,16 +26,16 @@
 
     - name: Create policy without including required variables
       cisco.dcnm.dcnm_policy:
-        fabric: "{{ ansible_it_fabric }}" 
-        config: 
+        fabric: "{{ ansible_it_fabric }}"
+        deploy: true
+        state: merged
+        config:
           - name: my_base_ospf  # This must be a valid template name
             create_additional_policy: true  # Do not create a policy if it already exists
-            priority: 101 
+            priority: 101
 
           - switch:
               - ip: "{{ ansible_switch1 }}"
-        deploy: true
-        state: merged
       register: result
       ignore_errors: yes
 
@@ -55,20 +55,20 @@
           - '"LOOPBACK_IP" in result["response"][0]["DATA"]["failureList"][0]["message"]'
 
     - name: Create policy including required variables
-      cisco.dcnm.dcnm_policy: 
-        fabric: "{{ ansible_it_fabric }}" 
-        config: 
+      cisco.dcnm.dcnm_policy:
+        fabric: "{{ ansible_it_fabric }}"
+        deploy: true
+        state: merged
+        config:
           - name: my_base_ospf  # This must be a valid template name
             create_additional_policy: true  # Do not create a policy if it already exists
-            priority: 101 
+            priority: 101
             policy_vars:
               OSPF_TAG: 2000
               LOOPBACK_IP: 10.122.84.108
 
           - switch:
               - ip: "{{ ansible_switch1 }}"
-        deploy: true
-        state: merged
       register: result
 
     - assert:
@@ -84,7 +84,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '"is created successfully" in item["DATA"]["successList"][0]["message"]'
-      when: (my_idx < (result["diff"][0]["merged"] | length))   
+      when: (my_idx < (result["diff"][0]["merged"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -94,7 +94,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '(item["DATA"][0]["successPTIList"].split(",") | length) == 1'
-      when: (my_idx == (result["diff"][0]["merged"] | length))   
+      when: (my_idx == (result["diff"][0]["merged"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
@@ -102,24 +102,24 @@
     - name: Setting fact
       set_fact:
         mergev_policy_list: "{{ (mergev_policy_list | default([])) + [item['DATA']['successList'][0]['message'].split(' ')[0]] }}"
-      when: (my_idx < (result["diff"][0]["merged"] | length))   
+      when: (my_idx < (result["diff"][0]["merged"] | length))
       loop: '{{ result.response }}'
       loop_control:
         index_var: my_idx
-    
+
     - name: Show the policy_list information
       debug:
-        var: mergev_policy_list 
+        var: mergev_policy_list
 
     - name: Setting fact
       set_fact:
-        list_len: "{{ mergev_policy_list | length }}" 
+        list_len: "{{ mergev_policy_list | length }}"
 
     - name: Modify policy with variables - using policy IDs
-      cisco.dcnm.dcnm_policy: 
-        fabric: "{{ ansible_it_fabric }}" 
+      cisco.dcnm.dcnm_policy:
+        fabric: "{{ ansible_it_fabric }}"
         state: merged
-        config: 
+        config:
           - name: "{{ item }}"  # Pick the policy Ids from the facts
             description: Modified the policy "{{ item }}" using policy ID
             priority: "{{ 100 + my_idx }}"
@@ -130,7 +130,7 @@
           - switch:
               - ip: "{{ ansible_switch1 }}"
 
-      loop: '{{ mergev_policy_list }}'      
+      loop: '{{ mergev_policy_list }}'
       loop_control:
         index_var: my_idx
       register: result
@@ -139,7 +139,7 @@
     - assert:
         that:
           - 'item["RETURN_CODE"] == 200'
-      when: (my_idx < (result.results[0]["diff"][0]["merged"] | length))   
+      when: (my_idx < (result.results[0]["diff"][0]["merged"] | length))
       loop: '{{ result.results[0].response }}'
       loop_control:
         index_var: my_idx
@@ -149,7 +149,7 @@
         that:
           - 'item["RETURN_CODE"] == 200'
           - '(item["DATA"][0]["successPTIList"].split(",") | length) == 1'
-      when: (my_idx == (result.results[0]["diff"][0]["merged"] | length))   
+      when: (my_idx == (result.results[0]["diff"][0]["merged"] | length))
       loop: '{{ result.results[0].response }}'
       loop_control:
         index_var: my_idx
@@ -162,13 +162,13 @@
 
     - name: Delete all created policies
       cisco.dcnm.dcnm_policy:
-        fabric: "{{ ansible_it_fabric }}" 
+        fabric: "{{ ansible_it_fabric }}"
         state: deleted                     # only choose form [merged, deleted, query]
-        config: 
+        config:
           - name: my_base_ospf  # This can either be a policy name like POLICY-xxxxx or template name
           - switch:
              - ip: "{{ ansible_switch1 }}"
-      register: result  
+      register: result
 
     - assert:
         that:

--- a/tests/integration/targets/dcnm_template/tests/dcnm/dcnm_template_merge.yaml
+++ b/tests/integration/targets/dcnm_template/tests/dcnm/dcnm_template_merge.yaml
@@ -3,7 +3,7 @@
 ##############################################
 
 - name: Initialize the setup
-  cisco.dcnm.dcnm_template: 
+  cisco.dcnm.dcnm_template:
     state: deleted       # only choose form [merged, deleted, query]
     config:
       - name: template_101
@@ -15,7 +15,7 @@
 
 - assert:
     that:
-      - 'item["RETURN_CODE"] == 200'  
+      - 'item["RETURN_CODE"] == 200'
   loop: '{{ result.response }}'
 
 - block:
@@ -105,7 +105,7 @@
 
     - assert:
         that:
-          - 'item["RETURN_CODE"] == 200'  
+          - 'item["RETURN_CODE"] == 200'
           - '"Template Created" in item["DATA"]["status"]'
       loop: '{{ result.response }}'
 
@@ -120,8 +120,11 @@
           - '(result["diff"][0]["deleted"] | length) == 0'
           - '(result["diff"][0]["query"] | length) == 0'
 
+    # This task will generate an error and return code 500 since the template
+    # is in use.  We ignore the error for the task to continue running the
+    # playbook but still check the error data returned by the module.
     - name: Modify existing template which is in use
-      cisco.dcnm.dcnm_template: 
+      cisco.dcnm.dcnm_template:
         config:
           - name: template_inuse_1
             description: "Template_installed"
@@ -140,22 +143,16 @@
                   dst-grp 1
                   snsr-grp 1 sample-interval 10000
       register: result
+      ignore_errors: yes
 
     - assert:
         that:
           - 'result.changed == false'
-          - '(result["diff"][0]["merged"] | length) == 1'
-          - '(result["diff"][0]["deleted"] | length) == 0'
-          - '(result["diff"][0]["query"] | length) == 0'
-
-    - assert:
-        that:
-          - 'item["RETURN_CODE"] != 200'  
-          - '"Template is already in use" in item["DATA"]'
-      loop: '{{ result.response }}'
+          - 'result.msg["RETURN_CODE"] == 500'
+          - '"Template is already in use" in result.msg["DATA"]'
 
     - name: Create templates without mentioning state
-      cisco.dcnm.dcnm_template: 
+      cisco.dcnm.dcnm_template:
         config:
           - name: template_105
             description: "Template_105"
@@ -184,7 +181,7 @@
 
     - assert:
         that:
-          - 'item["RETURN_CODE"] == 200'  
+          - 'item["RETURN_CODE"] == 200'
           - '"Template Created" in item["DATA"]["status"]'
       loop: '{{ result.response }}'
 
@@ -195,7 +192,7 @@
   always:
 
     - name: Delete all templates created
-      cisco.dcnm.dcnm_template: 
+      cisco.dcnm.dcnm_template:
         state: deleted       # only choose form [merged, deleted, query]
         config:
           - name: template_101
@@ -212,7 +209,7 @@
 
     - assert:
         that:
-          - 'item["RETURN_CODE"] == 200'  
+          - 'item["RETURN_CODE"] == 200'
           - '"Template deletion successful" in item["DATA"]'
       loop: '{{ result.response }}'
 
@@ -222,4 +219,3 @@
           - '(result["diff"][0]["merged"] | length) == 0'
           - '(result["diff"][0]["deleted"] | length) == 5'
           - '(result["diff"][0]["query"] | length) == 0'
-


### PR DESCRIPTION
This PR fixes the following:

* Fixes documentation to display the `deploy:` parameter must be indented to match the `config:` parameter
* Re-orders `state:` and `deploy:` parameters in the integration tests to be above `config:` but at the same indent level
* Fixes trailing white space issues in template and policy tests
* Removes a few unused import statements
* Fixes a few issues with `dcnm_template`
    * If the `config:` parameter is not specified or is empty the module generates a traceback.
    * Adds a check in `dcnm_template_validate_input` function to check for return code greater then 400 return the failure as a json fail message instead of silently ignoring the failure
    * Fixes one of the unit tests to test for the json failure for error return code
    * Fixes associated integration test to handle errors of this kind

**Note:**

- All `dcnm_template` and `dcnm_policy` integration and unit tests pass.