### PR TITLE
Template format fix

### DIFF
--- a/plugins/modules/dcnm_template.py
+++ b/plugins/modules/dcnm_template.py
@@ -253,12 +253,11 @@ class DcnmTemplate:
 
             template_payload = {}
 
-            mod_cont = re.sub(" +", " ", ditem["content"])
             std_cont = std_cont.replace("__TEMPLATE_NAME", ditem["name"])
             std_cont = std_cont.replace("__DESCRIPTION", ditem["description"])
             std_cont = std_cont.replace("__TAGS", ditem["tags"])
 
-            final_cont = std_cont + mod_cont + "##"
+            final_cont = std_cont + ditem["content"] + "##"
 
             template_payload["template_name"] = ditem["name"]
             template_payload["content"] = final_cont
@@ -477,6 +476,8 @@ class DcnmTemplate:
                 self.result["changed"] = False
             else:
                 self.result["changed"] = True
+        else:
+            self.module.fail_json(msg=resp)
 
         if policies:
             self.result["template-policy-map"] = policies
@@ -612,12 +613,11 @@ class DcnmTemplate:
         std_cont = "##template properties\nname = __TEMPLATE_NAME;\ndescription = __DESCRIPTION;\ntags = __TAGS;\nuserDefined = true;\nsupportedPlatforms = All;\ntemplateType = POLICY;\ntemplateSubType = DEVICE;\ncontentType = TEMPLATE_CLI;\nimplements = implements;\ndependencies = ;\npublished = false;\n##\n##template content\n"
         template_payload = {}
 
-        mod_cont = re.sub(" +", " ", content)
         std_cont = std_cont.replace("__TEMPLATE_NAME", name)
         std_cont = std_cont.replace("__DESCRIPTION", desc)
         std_cont = std_cont.replace("__TAGS", tags)
 
-        final_cont = std_cont + mod_cont + "##"
+        final_cont = std_cont + content + "##"
         return final_cont
 
     # Flatten the incoming config database and have the required fileds updated.

--- a/tests/integration/targets/prepare_dcnm_template/tasks/main.yaml
+++ b/tests/integration/targets/prepare_dcnm_template/tasks/main.yaml
@@ -23,6 +23,11 @@
   cisco.dcnm.dcnm_template: 
     state: deleted       # only choose form [merged, deleted, query]
     config:
+      - name: template_101
+      - name: template_102
+      - name: template_103
+      - name: template_104
+      - name: template_105
       - name: template_inuse_1
       - name: template_inuse_2
       - name: my_feature_telemetry

--- a/tests/unit/modules/dcnm/test_dcnm_template.py
+++ b/tests/unit/modules/dcnm/test_dcnm_template.py
@@ -34,13 +34,17 @@ class TestDcnmTemplateModule(TestDcnmModule):
 
     module = dcnm_template
 
-    fd = open("template-ut.log", "w")
+    fd = None
 
     def init_data(self):
         pass
 
     def log_msg (self, msg):
+
+        if fd is None:
+            fd = open("template-ut.log", "w")
         self.fd.write (msg)
+        self.fd.flush()
 
     def setUp(self):
 


### PR DESCRIPTION
This PR fixes the following:

1. The format of the CLI commands sent to DCNM server was wrong since all blank spaces were stripped. This is now fixed
2. Some cleanup of templates during prepare test cases
3. Open log files only when logs are used and not open it by default