### PR TITLE
Vrf name input change for L2 networks

### DIFF
--- a/plugins/module_utils/network/dcnm/dcnm.py
+++ b/plugins/module_utils/network/dcnm/dcnm.py
@@ -74,6 +74,8 @@ def validate_list_of_dicts(param_list, spec, module=None):
                     if spec[param].get('length_max'):
                         if 1 <= len(item) <= spec[param].get('length_max'):
                             pass
+                        elif param == "vrf_name" and (len(item) <= spec[param].get('length_max')):
+                            pass
                         else:
                             invalid_params.append('{}:{} : The string exceeds the allowed '
                                                   'range of max {} char'.format(param, item,


### PR DESCRIPTION
This PR adds the capability to specify vrf_name as "" for L2 networks. For L2 networks, user can either specify vrf_name as "" or they can avoid specifying vrf_name at all