### PR TITLE
Interface module - provide a playbook option for checking deployment …

### DIFF
--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -27,6 +27,16 @@ description:
     - "Modify Ethernet Interfaces"
 author: Mallik Mudigonda(@mmudigon)
 options:
+  check_deploy:
+    description:
+    - Deploy operations may take considerable time in certain cases based on the configuration included
+      in the playbook. A success response from DCNM server does not guarantee the completion of deploy
+      operation. This flag if set indicates that the module should verify if the configured state is in
+      sync with what is requested in playbook. If not set the module will return without verifying the
+      state.
+    type: bool
+    required: false
+    default: false
   fabric:
     description:
     - Name of the target fabric for interface operations
@@ -2728,6 +2738,10 @@ class DcnmIntf:
 
     def dcnm_intf_check_deployment_status (self, deploy_list):
 
+        # Check for deployment status of all the configured objects only if the check_deploy flag is set.
+        if self.module.params['check_deploy'] is False:
+            return
+
         path = self.paths["GLOBAL_IF_DEPLOY"]
 
         for item in deploy_list:
@@ -2952,6 +2966,7 @@ def main():
         state=dict(type='str', default='merged',
                    choices=['merged', 'replaced', 'overridden', 'deleted',
                               'query']),
+        check_deploy=dict(type='bool', default=False)
     )
 
     module = AnsibleModule(argument_spec=element_spec,

--- a/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_delete_diff_options.yaml
+++ b/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_delete_diff_options.yaml
@@ -7,6 +7,7 @@
 
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_interface:
+    check_deploy: True
     fabric: "{{ ansible_it_fabric }}" 
     state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
   register: result  
@@ -23,6 +24,7 @@
 ##############################################
     - name: Create interfaces to check various delete form 1
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -99,6 +101,7 @@
 
     - name: Delete all interfaces form 1
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: deleted                        # only choose form [merged, replaced, deleted, overridden,query]
       register: result
@@ -123,6 +126,7 @@
 
     - name: Create all interfaces to check delete form 2
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -199,6 +203,7 @@
 
     - name: Delete all interfaces form 2
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: deleted                        # only choose form [merged, replaced, deleted, overridden,query]
         config:
@@ -228,6 +233,7 @@
 
     - name: Create all interfaces to check delete form 3
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -304,6 +310,7 @@
 
     - name: Delete all interfaces form 3
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: deleted                        # only choose form [merged, replaced, deleted, overridden,query]
         config:
@@ -344,6 +351,7 @@
 
     - name: Put fabric to default state
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
       register: result

--- a/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_eth_delete.yaml
+++ b/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_eth_delete.yaml
@@ -7,6 +7,7 @@
 
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_interface:
+    check_deploy: True
     fabric: "{{ ansible_it_fabric }}" 
     state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
   register: result  
@@ -24,6 +25,7 @@
 
     - name: Create ethernet interfaces
       cisco.dcnm.dcnm_interface: 
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -128,6 +130,7 @@
 
     - name: Delete ethernet interfaces
       cisco.dcnm.dcnm_interface: &eth_delete
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: deleted                        # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -250,6 +253,7 @@
 
     - name: Create ethernet interfaces
       cisco.dcnm.dcnm_interface: 
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -291,6 +295,7 @@
 
     - name: Delete a single ethernet interface
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: deleted                        # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -334,6 +339,7 @@
 
     - name: Put fabric to default state
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
       register: result

--- a/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_eth_merge.yaml
+++ b/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_eth_merge.yaml
@@ -7,6 +7,7 @@
 
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_interface:
+    check_deploy: True
     fabric: "{{ ansible_it_fabric }}" 
     state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
   register: result  
@@ -24,6 +25,7 @@
 
     - name: Create ethernet interfaces
       cisco.dcnm.dcnm_interface: &eth_merge
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -148,6 +150,7 @@
 
     - name: Put fabric to default state
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
       register: result

--- a/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_eth_override.yaml
+++ b/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_eth_override.yaml
@@ -7,6 +7,7 @@
 
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_interface:
+    check_deploy: True
     fabric: "{{ ansible_it_fabric }}" 
     state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
   register: result  
@@ -24,6 +25,7 @@
 
     - name: Create ethernet interfaces
       cisco.dcnm.dcnm_interface: &eth_merge
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -128,6 +130,7 @@
 
     - name: Override Ethernet interfaces
       cisco.dcnm.dcnm_interface: &eth_override
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -187,6 +190,7 @@
 
     - name: Put fabric to default state
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
       register: result

--- a/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_eth_replace.yaml
+++ b/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_eth_replace.yaml
@@ -7,6 +7,7 @@
 
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_interface:
+    check_deploy: True
     fabric: "{{ ansible_it_fabric }}" 
     state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
   register: result  
@@ -24,6 +25,7 @@
 
     - name: Create ethernet interfaces
       cisco.dcnm.dcnm_interface: &eth_merge
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -128,6 +130,7 @@
 
     - name: Replace ethernet interfaces
       cisco.dcnm.dcnm_interface: &eth_replace
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: replaced                       # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -244,6 +247,7 @@
 
     - name: Put fabric to default state
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
       register: result

--- a/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_intf_multi_switches.yaml
+++ b/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_intf_multi_switches.yaml
@@ -7,6 +7,7 @@
 
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_interface:
+    check_deploy: True
     fabric: "{{ ansible_it_fabric }}" 
     state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
   register: result  
@@ -24,6 +25,7 @@
 
     - name: Create all interfaces multiple switches
       cisco.dcnm.dcnm_interface: &intf_mix
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -100,6 +102,7 @@
 
     - name: Put fabric to default state
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
       register: result

--- a/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_intf_no_optional_elems.yaml
+++ b/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_intf_no_optional_elems.yaml
@@ -7,6 +7,7 @@
 
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_interface:
+    check_deploy: True
     fabric: "{{ ansible_it_fabric }}" 
     state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
   register: result  
@@ -24,6 +25,7 @@
 
     - name: Create all interfaces without optional elements
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -141,6 +143,7 @@
 
     - name: Delete all interfaces without optional elements
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: deleted                        # only choose form [merged, replaced, deleted, overridden,query]
         config:
@@ -260,6 +263,7 @@
 
     - name: Put fabric to default state
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
       register: result

--- a/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_intf_query.yaml
+++ b/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_intf_query.yaml
@@ -7,6 +7,7 @@
 
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_interface:
+    check_deploy: True
     fabric: "{{ ansible_it_fabric }}" 
     state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
   register: result  
@@ -24,6 +25,7 @@
 
     - name: Create a mixture of interfaces
       cisco.dcnm.dcnm_interface: &lo_merge
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -126,6 +128,7 @@
 
     - name: Query interface details - Existing
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: query                        # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -166,6 +169,7 @@
 
     - name: Query interface details - Non-Existing
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: query                        # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -202,6 +206,7 @@
 
     - name: Put fabric to default state
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
       register: result

--- a/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_lo_delete.yaml
+++ b/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_lo_delete.yaml
@@ -7,6 +7,7 @@
 
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_interface:
+    check_deploy: True
     fabric: "{{ ansible_it_fabric }}" 
     state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
   register: result  
@@ -24,6 +25,7 @@
 
     - name: Create loopback interfaces
       cisco.dcnm.dcnm_interface: &lo_merge
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -80,6 +82,7 @@
 
     - name: Delete loopback interfaces
       cisco.dcnm.dcnm_interface: &lo_del
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: deleted                        # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -156,6 +159,7 @@
 
     - name: Put fabric to default state
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
       register: result

--- a/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_lo_merge.yaml
+++ b/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_lo_merge.yaml
@@ -7,6 +7,7 @@
 
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_interface:
+    check_deploy: True
     fabric: "{{ ansible_it_fabric }}" 
     state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
   register: result  
@@ -24,6 +25,7 @@
 
     - name: Create loopback interfaces
       cisco.dcnm.dcnm_interface: &lo_merge
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -100,6 +102,7 @@
 
     - name: Put fabric to default state
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
       register: result

--- a/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_lo_override.yaml
+++ b/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_lo_override.yaml
@@ -7,6 +7,7 @@
 
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_interface:
+    check_deploy: True
     fabric: "{{ ansible_it_fabric }}" 
     state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
   register: result  
@@ -24,6 +25,7 @@
 
     - name: Create loopback interfaces
       cisco.dcnm.dcnm_interface: &lo_merge
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -80,6 +82,7 @@
 
     - name: Override loopback interfaces
       cisco.dcnm.dcnm_interface: &lo_override
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -156,6 +159,7 @@
 
     - name: Put fabric to default state
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
       register: result

--- a/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_lo_replace.yaml
+++ b/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_lo_replace.yaml
@@ -7,6 +7,7 @@
 
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_interface:
+    check_deploy: True
     fabric: "{{ ansible_it_fabric }}" 
     state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
   register: result  
@@ -24,6 +25,7 @@
 
     - name: Create loopback interfaces
       cisco.dcnm.dcnm_interface: &lo_merge
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -80,6 +82,7 @@
 
     - name: Replace loopback interfaces
       cisco.dcnm.dcnm_interface: &lo_replace
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: replaced                       # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -156,6 +159,7 @@
 
     - name: Put fabric to default state
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
       register: result

--- a/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_old_format_pb.yaml
+++ b/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_old_format_pb.yaml
@@ -7,6 +7,7 @@
 
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_interface:
+    check_deploy: True
     fabric: "{{ ansible_it_fabric }}" 
     state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
   register: result  
@@ -24,6 +25,7 @@
 
     - name: Create PC interface with profile name wrong
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -43,6 +45,7 @@
 
     - name: Create PC interface with profile name in old format
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -62,6 +65,7 @@
 
     - name: Create ETH interface with profile name old format
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -81,6 +85,7 @@
 
     - name: Create sub-interface with profile name in old format
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -103,6 +108,7 @@
 
     - name: Create Loopback interfaces with profile name in old format
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -123,6 +129,7 @@
 
     - name: Create vPC interface with profile name in old format
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -143,6 +150,7 @@
 
     - name: Create vPC interface with switch elements in old format
       cisco.dcnm.dcnm_interface: 
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
         config:

--- a/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_pc_delete.yaml
+++ b/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_pc_delete.yaml
@@ -7,6 +7,7 @@
 
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_interface:
+    check_deploy: True
     fabric: "{{ ansible_it_fabric }}" 
     state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
   register: result  
@@ -24,6 +25,7 @@
 
     - name: Create port channel interfaces
       cisco.dcnm.dcnm_interface: &pc_merge
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}"
         state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -114,6 +116,7 @@
 
     - name: Delete port channel interfaces
       cisco.dcnm.dcnm_interface: &pc_del
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: deleted                        # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -225,6 +228,7 @@
 
     - name: Put fabric to default state
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
       register: result

--- a/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_pc_merge.yaml
+++ b/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_pc_merge.yaml
@@ -7,6 +7,7 @@
 
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_interface:
+    check_deploy: True
     fabric: "{{ ansible_it_fabric }}" 
     state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
   register: result  
@@ -24,6 +25,7 @@
 
     - name: Create port channel interfaces
       cisco.dcnm.dcnm_interface: &pc_merge
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}"
         state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -134,6 +136,7 @@
 
     - name: Put fabric to default state
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
       register: result

--- a/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_pc_override.yaml
+++ b/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_pc_override.yaml
@@ -7,6 +7,7 @@
 
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_interface:
+    check_deploy: True
     fabric: "{{ ansible_it_fabric }}" 
     state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
   register: result  
@@ -24,6 +25,7 @@
 
     - name: Create port channel interfaces
       cisco.dcnm.dcnm_interface: &pc_merge
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}"
         state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -114,6 +116,7 @@
 
     - name: Override port channel interfaces
       cisco.dcnm.dcnm_interface: &pc_over
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -176,6 +179,7 @@
 
     - name: Put fabric to default state
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
       register: result

--- a/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_pc_replace.yaml
+++ b/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_pc_replace.yaml
@@ -7,6 +7,7 @@
 
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_interface:
+    check_deploy: True
     fabric: "{{ ansible_it_fabric }}" 
     state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
   register: result  
@@ -24,6 +25,7 @@
 
     - name: Create port channel interfaces
       cisco.dcnm.dcnm_interface: &pc_merge
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}"
         state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -114,6 +116,7 @@
 
     - name: Replace port channel interfaces
       cisco.dcnm.dcnm_interface: &pc_replace
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: replaced                       # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -216,6 +219,7 @@
 
     - name: Put fabric to default state
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
       register: result

--- a/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_sub_delete.yaml
+++ b/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_sub_delete.yaml
@@ -7,6 +7,7 @@
 
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_interface:
+    check_deploy: True
     fabric: "{{ ansible_it_fabric }}" 
     state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
   register: result  
@@ -24,6 +25,7 @@
 
     - name: Create sub-interfaces
       cisco.dcnm.dcnm_interface: &sub_merge
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
         config: 
@@ -86,6 +88,7 @@
 
     - name: Delete sub-interfaces
       cisco.dcnm.dcnm_interface: &del_subint
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: deleted                        # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -169,6 +172,7 @@
 
     - name: Put fabric to default state
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
       register: result

--- a/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_sub_merge.yaml
+++ b/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_sub_merge.yaml
@@ -7,6 +7,7 @@
 
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_interface:
+    check_deploy: True
     fabric: "{{ ansible_it_fabric }}" 
     state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
   register: result  
@@ -24,6 +25,7 @@
 
     - name: Create sub-interfaces
       cisco.dcnm.dcnm_interface: &sub_merge
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
         config: 
@@ -106,6 +108,7 @@
 
     - name: Put fabric to default state
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
       register: result

--- a/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_sub_override.yaml
+++ b/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_sub_override.yaml
@@ -7,6 +7,7 @@
 
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_interface:
+    check_deploy: True
     fabric: "{{ ansible_it_fabric }}" 
     state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
   register: result  
@@ -24,6 +25,7 @@
 
     - name: Create sub-interfaces
       cisco.dcnm.dcnm_interface: &sub_merge
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
         config: 
@@ -86,6 +88,7 @@
 
     - name: Override sub-interfaces
       cisco.dcnm.dcnm_interface: &sub_over
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -149,6 +152,7 @@
 
     - name: Put fabric to default state
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
       register: result

--- a/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_sub_replace.yaml
+++ b/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_sub_replace.yaml
@@ -7,6 +7,7 @@
 
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_interface:
+    check_deploy: True
     fabric: "{{ ansible_it_fabric }}" 
     state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
   register: result  
@@ -24,6 +25,7 @@
 
     - name: Create sub-interfaces
       cisco.dcnm.dcnm_interface: &sub_merge
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
         config: 
@@ -86,6 +88,7 @@
 
     - name: Replace sub-interfaces
       cisco.dcnm.dcnm_interface: &sub_replace
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: replaced                       # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -168,6 +171,7 @@
 
     - name: Put fabric to default state
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
       register: result

--- a/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_vpc_delete.yaml
+++ b/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_vpc_delete.yaml
@@ -7,6 +7,7 @@
 
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_interface:
+    check_deploy: True
     fabric: "{{ ansible_it_fabric }}" 
     state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
   register: result  
@@ -24,6 +25,7 @@
 
     - name: Create vPC interfaces
       cisco.dcnm.dcnm_interface: &vpc_merge
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -96,6 +98,7 @@
 
     - name: Delete vPC interfaces
       cisco.dcnm.dcnm_interface: &vpc_del
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: deleted                        # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -188,6 +191,7 @@
 
     - name: Put fabric to default state
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
       register: result

--- a/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_vpc_merge.yaml
+++ b/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_vpc_merge.yaml
@@ -7,6 +7,7 @@
 
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_interface:
+    check_deploy: True
     fabric: "{{ ansible_it_fabric }}" 
     state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
   register: result  
@@ -24,6 +25,7 @@
 
     - name: Create vPC interfaces
       cisco.dcnm.dcnm_interface: &vpc_merge
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -115,6 +117,7 @@
 
     - name: Put fabric to default state
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
       register: result

--- a/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_vpc_override.yaml
+++ b/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_vpc_override.yaml
@@ -7,6 +7,7 @@
 
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_interface:
+    check_deploy: True
     fabric: "{{ ansible_it_fabric }}" 
     state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
   register: result  
@@ -24,6 +25,7 @@
 
     - name: Create vPC interfaces
       cisco.dcnm.dcnm_interface: &vpc_merge
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -96,6 +98,7 @@
 
     - name: Override vPC interfaces
       cisco.dcnm.dcnm_interface: &vpc_override
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -168,6 +171,7 @@
 
     - name: Put fabric to default state
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
       register: result

--- a/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_vpc_replace.yaml
+++ b/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_vpc_replace.yaml
@@ -7,6 +7,7 @@
 
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_interface:
+    check_deploy: True
     fabric: "{{ ansible_it_fabric }}" 
     state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
   register: result  
@@ -24,6 +25,7 @@
 
     - name: Create vPC interfaces
       cisco.dcnm.dcnm_interface: &vpc_merge
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -96,6 +98,7 @@
 
     - name: Replace vPC interfaces
       cisco.dcnm.dcnm_interface: &vpc_replace
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: replaced                       # only choose form [merged, replaced, deleted, overridden, query]
         config:
@@ -196,6 +199,7 @@
 
     - name: Put fabric to default state
       cisco.dcnm.dcnm_interface:
+        check_deploy: True
         fabric: "{{ ansible_it_fabric }}" 
         state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
       register: result


### PR DESCRIPTION
The following are the updates to interface module
- provide a playbook option "check_deploy" in playbooks to enable user to specify if the module should check for fnal deployed status of all objects
- check the deployment status only if "check_deploy" parameter is ser to True. 