### PR TITLE
Fix dcnm_inventory version check

### DIFF
--- a/plugins/modules/dcnm_inventory.py
+++ b/plugins/modules/dcnm_inventory.py
@@ -234,9 +234,9 @@ class DcnmInventory:
             response=[]
         )
 
+        self.controller_version = dcnm_version_supported(self.module)
         self.fabric_details = get_fabric_details(self.module, self.fabric)
 
-        self.controller_version = dcnm_version_supported(self.module)
         self.nd = True if self.controller_version >= 12 else False
 
     def update_discover_params(self, inv):


### PR DESCRIPTION
This fixes an issue where the dcnm_inventory module was not working properly with ndfc.

We need to call the `dcnm_version_supported` api first so that the connection gets established before calling `get_fabric_details` so that it does not result in empty output.

