### PR TITLE
Add dhcp_loopback_id parameter support

### DIFF
--- a/docs/cisco.dcnm.dcnm_network_module.rst
+++ b/docs/cisco.dcnm.dcnm_network_module.rst
@@ -170,6 +170,22 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>dhcp_loopback_id</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Loopback ID for DHCP Relay interface</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>dhcp_srvr1_ip</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -516,7 +532,7 @@ Parameters
 Examples
 --------
 
-.. code-block:: yaml
+.. code-block:: yaml+jinja
 
     # This module supports the following states:
     #

--- a/plugins/module_utils/network/dcnm/dcnm.py
+++ b/plugins/module_utils/network/dcnm/dcnm.py
@@ -83,8 +83,11 @@ def validate_list_of_dicts(param_list, spec, module=None):
                                                                                 spec[param].get('length_max')))
                 elif type == 'int':
                     item = v.check_type_int(item)
+                    min_value = 1
+                    if spec[param].get('range_min') is not None:
+                        min_value = spec[param].get('range_min')
                     if spec[param].get('range_max'):
-                        if 1 <= item <= spec[param].get('range_max'):
+                        if min_value <= item <= spec[param].get('range_max'):
                             pass
                         else:
                             invalid_params.append('{}:{} : The item exceeds the allowed '

--- a/tests/integration/targets/dcnm_network/tasks/dcnm.yaml
+++ b/tests/integration/targets/dcnm_network/tasks/dcnm.yaml
@@ -1,7 +1,7 @@
 ---
 - name: collect dcnm test cases
   find:
-    paths: "{{ role_path }}/tests/dcnm"
+    paths: ["{{ role_path }}/tests/dcnm", "{{ role_path }}/tests/dcnm/self-contained-tests"]
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: dcnm_cases

--- a/tests/integration/targets/dcnm_network/tasks/main.yaml
+++ b/tests/integration/targets/dcnm_network/tasks/main.yaml
@@ -32,4 +32,36 @@
     that:
     - 'controller_version != "Unable to determine controller version"'
 
+- name: Remove all existing networks to start with a clean state
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ ansible_it_fabric }}"
+    state: deleted
+
+- name: Create vrfs required for this test and remove all other vrfs
+  cisco.dcnm.dcnm_vrf:
+    fabric: "{{ ansible_it_fabric }}"
+    state: overridden
+    config:
+    - vrf_name: ansible-vrf-int1
+      vrf_id: 9008011
+      vlan_id: 500
+      attach:
+      - ip_address: "{{ ansible_switch1 }}"
+      - ip_address: "{{ ansible_switch2 }}"
+      deploy: true
+    - vrf_name: Tenant-1
+      vrf_id: 9008012
+      vlan_id: 501
+      attach:
+      - ip_address: "{{ ansible_switch1 }}"
+      - ip_address: "{{ ansible_switch2 }}"
+      deploy: true
+    - vrf_name: Tenant-2
+      vrf_id: 9008013
+      vlan_id: 502
+      attach:
+      - ip_address: "{{ ansible_switch1 }}"
+      - ip_address: "{{ ansible_switch2 }}"
+      deploy: true
+
 - { include: dcnm.yaml, tags: ['dcnm'] }

--- a/tests/integration/targets/dcnm_network/tests/dcnm/self-contained-tests/sm_dhcp_params.yaml
+++ b/tests/integration/targets/dcnm_network/tests/dcnm/self-contained-tests/sm_dhcp_params.yaml
@@ -1,0 +1,57 @@
+- name: Setup - Remove all existing networks
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ ansible_it_fabric }}"
+    state: deleted
+
+- name: Test dhcp parameters for state merged
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ ansible_it_fabric }}"
+    state: merged
+    config:
+    - net_name: ansible-net13
+      vrf_name: ansible-vrf-int1
+      net_id: 7009
+      vlan_id: 3505
+      gw_ip_subnet: '152.168.30.1/24'
+      mtu_l3intf: 7600
+      arp_suppress: False
+      int_desc: 'test interface'
+      is_l2only: False
+      vlan_name: testvlan
+      dhcp_srvr1_ip: '1.1.1.1'
+      dhcp_srvr2_ip: '2.2.2.2'
+      dhcp_srvr3_ip: '3.3.3.3'
+      dhcp_srvr1_vrf: one
+      dhcp_srvr2_vrf: two
+      dhcp_srvr3_vrf: three
+      dhcp_loopback_id: 0
+      attach:
+      - ip_address: "{{ ansible_switch1 }}"
+        ports: []
+      deploy: True
+  register: result
+
+- assert:
+    that:
+    - 'result.changed == true'
+
+- name: Query fabric state until networkStatus transitions to DEPLOYED state
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ ansible_it_fabric }}"
+    state: query
+  register: result
+  until:
+    - "result.response[0].parent.networkStatus is search('DEPLOYED')"
+  retries: 30
+  delay: 2
+
+- assert:
+    that:
+    - "result.response[0].parent.networkTemplateConfig.dhcpServerAddr1 is search('1.1.1.1')"
+    - "result.response[0].parent.networkTemplateConfig.dhcpServerAddr2 is search('2.2.2.2')"
+    - "result.response[0].parent.networkTemplateConfig.dhcpServerAddr3 is search('3.3.3.3')"
+    - "result.response[0].parent.networkTemplateConfig.vrfDhcp is search('one')"
+    - "result.response[0].parent.networkTemplateConfig.vrfDhcp2 is search('two')"
+    - "result.response[0].parent.networkTemplateConfig.vrfDhcp3 is search('three')"
+    - "result.response[0].parent.networkTemplateConfig.loopbackId is search('0')"
+

--- a/tests/integration/targets/dcnm_network/tests/dcnm/self-contained-tests/sm_dhcp_update.yaml
+++ b/tests/integration/targets/dcnm_network/tests/dcnm/self-contained-tests/sm_dhcp_update.yaml
@@ -1,0 +1,100 @@
+- name: Setup - Remove all existing networks
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ ansible_it_fabric }}"
+    state: deleted
+
+- name: Create network with initial dhcp parameter values
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ ansible_it_fabric }}"
+    state: merged
+    config:
+    - net_name: ansible-net13
+      vrf_name: ansible-vrf-int1
+      net_id: 7009
+      vlan_id: 3505
+      gw_ip_subnet: '152.168.30.1/24'
+      mtu_l3intf: 7600
+      arp_suppress: False
+      int_desc: 'test interface'
+      is_l2only: False
+      vlan_name: testvlan
+      dhcp_srvr1_ip: '1.1.1.1'
+      dhcp_srvr2_ip: '2.2.2.2'
+      dhcp_srvr3_ip: '3.3.3.3'
+      dhcp_srvr1_vrf: one
+      dhcp_srvr2_vrf: two
+      dhcp_srvr3_vrf: three
+      dhcp_loopback_id: 0
+      attach:
+      - ip_address: "{{ ansible_switch1 }}"
+        ports: []
+      deploy: True
+  register: result
+
+- name: Query fabric state until networkStatus transitions to DEPLOYED state
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ ansible_it_fabric }}"
+    state: query
+  register: result
+  until:
+    - "result.response[0].parent.networkStatus is search('DEPLOYED')"
+  retries: 30
+  delay: 2
+
+- assert:
+    that:
+    - "result.response[0].parent.networkTemplateConfig.dhcpServerAddr1 is search('1.1.1.1')"
+    - "result.response[0].parent.networkTemplateConfig.dhcpServerAddr2 is search('2.2.2.2')"
+    - "result.response[0].parent.networkTemplateConfig.dhcpServerAddr3 is search('3.3.3.3')"
+    - "result.response[0].parent.networkTemplateConfig.vrfDhcp is search('one')"
+    - "result.response[0].parent.networkTemplateConfig.vrfDhcp2 is search('two')"
+    - "result.response[0].parent.networkTemplateConfig.vrfDhcp3 is search('three')"
+    - "result.response[0].parent.networkTemplateConfig.loopbackId is search('0')"
+
+- name: Change dhcp parameter values
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ ansible_it_fabric }}"
+    state: merged
+    config:
+    - net_name: ansible-net13
+      vrf_name: ansible-vrf-int1
+      net_id: 7009
+      vlan_id: 3505
+      gw_ip_subnet: '152.168.30.1/24'
+      mtu_l3intf: 7600
+      arp_suppress: False
+      int_desc: 'test interface'
+      is_l2only: False
+      vlan_name: testvlan
+      dhcp_srvr1_ip: '1.1.55.55'
+      dhcp_srvr2_ip: '2.2.55.55'
+      dhcp_srvr3_ip: '3.3.55.55'
+      dhcp_srvr1_vrf: one_fifty_five
+      dhcp_srvr2_vrf: two_fifty_five
+      dhcp_srvr3_vrf: three_fifty_five
+      dhcp_loopback_id: 55
+      attach:
+      - ip_address: "{{ ansible_switch1 }}"
+        ports: []
+      deploy: True
+  register: result
+
+- name: Query fabric state until networkStatus transitions to DEPLOYED state
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ ansible_it_fabric }}"
+    state: query
+  register: result
+  until:
+    - "result.response[0].parent.networkStatus is search('DEPLOYED')"
+  retries: 30
+  delay: 2
+
+- assert:
+    that:
+    - "result.response[0].parent.networkTemplateConfig.dhcpServerAddr1 is search('1.1.55.55')"
+    - "result.response[0].parent.networkTemplateConfig.dhcpServerAddr2 is search('2.2.55.55')"
+    - "result.response[0].parent.networkTemplateConfig.dhcpServerAddr3 is search('3.3.55.55')"
+    - "result.response[0].parent.networkTemplateConfig.vrfDhcp is search('one_fifty_five')"
+    - "result.response[0].parent.networkTemplateConfig.vrfDhcp2 is search('two_fifty_five')"
+    - "result.response[0].parent.networkTemplateConfig.vrfDhcp3 is search('three_fifty_five')"
+    - "result.response[0].parent.networkTemplateConfig.loopbackId is search('55')"

--- a/tests/integration/targets/dcnm_network/tests/dcnm/self-contained-tests/so_dhcp_update.yaml
+++ b/tests/integration/targets/dcnm_network/tests/dcnm/self-contained-tests/so_dhcp_update.yaml
@@ -1,0 +1,141 @@
+- name: Setup - Remove all existing networks
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ ansible_it_fabric }}"
+    state: deleted
+
+- name: Create network with initial dhcp parameter values
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ ansible_it_fabric }}"
+    state: merged
+    config:
+    - net_name: ansible-net13
+      vrf_name: ansible-vrf-int1
+      net_id: 7009
+      vlan_id: 3505
+      gw_ip_subnet: '152.168.30.1/24'
+      mtu_l3intf: 7600
+      arp_suppress: False
+      int_desc: 'test interface'
+      is_l2only: False
+      vlan_name: testvlan_net13
+      dhcp_srvr1_ip: '1.1.1.1'
+      dhcp_srvr2_ip: '2.2.2.2'
+      dhcp_srvr3_ip: '3.3.3.3'
+      dhcp_srvr1_vrf: one
+      dhcp_srvr2_vrf: two
+      dhcp_srvr3_vrf: three
+      dhcp_loopback_id: 1022
+      attach:
+        - ip_address: "{{ ansible_switch1 }}"
+          ports: []
+      deploy: True
+    - net_name: ansible-net14
+      vrf_name: ansible-vrf-int1
+      net_id: 7010
+      vlan_id: 3506
+      gw_ip_subnet: '152.168.31.1/24'
+      mtu_l3intf: 7600
+      arp_suppress: False
+      int_desc: 'test interface'
+      is_l2only: False
+      vlan_name: testvlan_net14
+      dhcp_srvr1_ip: '11.11.11.11'
+      dhcp_srvr2_ip: '12.12.12.12'
+      dhcp_srvr3_ip: '13.13.13.13'
+      dhcp_srvr1_vrf: eleven
+      dhcp_srvr2_vrf: twelve
+      dhcp_srvr3_vrf: thirteen
+      dhcp_loopback_id: 1023
+      attach:
+        - ip_address: "{{ ansible_switch1 }}"
+          ports: []
+      deploy: True
+  register: result
+
+- name: Query fabric state until networkStatus transitions to DEPLOYED state
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ ansible_it_fabric }}"
+    state: query
+  register: result
+  until:
+    - "result.response[0].parent.networkStatus is search('DEPLOYED')"
+    - "result.response[1].parent.networkStatus is search('DEPLOYED')"
+  retries: 30
+  delay: 2
+
+- set_fact:
+    testnet1: "{{ item }}"
+  when: "item.parent.displayName is search('ansible-net13')"
+  loop: "{{ result.response }}"
+
+- set_fact:
+    testnet2: "{{ item }}"
+  when: "item.parent.displayName is search('ansible-net14')"
+  loop: "{{ result.response }}"
+
+- assert:
+    that:
+    - "testnet1.parent.networkTemplateConfig.dhcpServerAddr1 is search('1.1.1.1')"
+    - "testnet1.parent.networkTemplateConfig.dhcpServerAddr2 is search('2.2.2.2')"
+    - "testnet1.parent.networkTemplateConfig.dhcpServerAddr3 is search('3.3.3.3')"
+    - "testnet1.parent.networkTemplateConfig.vrfDhcp is search('one')"
+    - "testnet1.parent.networkTemplateConfig.vrfDhcp2 is search('two')"
+    - "testnet1.parent.networkTemplateConfig.vrfDhcp3 is search('three')"
+    - "testnet1.parent.networkTemplateConfig.loopbackId is search('1022')"
+    - "testnet2.parent.networkTemplateConfig.dhcpServerAddr1 is search('11.11.11.11')"
+    - "testnet2.parent.networkTemplateConfig.dhcpServerAddr2 is search('12.12.12.12')"
+    - "testnet2.parent.networkTemplateConfig.dhcpServerAddr3 is search('13.13.13.13')"
+    - "testnet2.parent.networkTemplateConfig.vrfDhcp is search('eleven')"
+    - "testnet2.parent.networkTemplateConfig.vrfDhcp2 is search('twelve')"
+    - "testnet2.parent.networkTemplateConfig.vrfDhcp3 is search('thirteen')"
+    - "testnet2.parent.networkTemplateConfig.loopbackId is search('1023')"
+
+
+- name: Override network with a single network and change values within that newtwork
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ ansible_it_fabric }}"
+    state: overridden
+    config:
+    - net_name: ansible-net14
+      vrf_name: ansible-vrf-int1
+      net_id: 7010
+      vlan_id: 3506
+      gw_ip_subnet: '152.168.31.1/24'
+      mtu_l3intf: 7600
+      arp_suppress: False
+      int_desc: 'test interface'
+      is_l2only: False
+      vlan_name: testvlan_net14
+      dhcp_srvr1_ip: '55.11.11.11'
+      dhcp_srvr2_ip: '55.12.12.12'
+      dhcp_srvr3_ip: '55.13.13.13'
+      dhcp_srvr1_vrf: eleven
+      dhcp_srvr2_vrf: twelve
+      dhcp_srvr3_vrf: thirteen
+      dhcp_loopback_id: 55
+      attach:
+        - ip_address: "{{ ansible_switch1 }}"
+          ports: []
+      deploy: True
+  register: result
+
+- name: Query fabric state until networkStatus transitions to DEPLOYED state
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ ansible_it_fabric }}"
+    state: query
+  register: result
+  until:
+    - "result.response[0].parent.networkStatus is search('DEPLOYED')"
+  retries: 30
+  delay: 2
+
+- assert:
+    that:
+    - "result.response|length == 1"
+    - "result.response[0].parent.networkTemplateConfig.dhcpServerAddr1 is search('55.11.11.11')"
+    - "result.response[0].parent.networkTemplateConfig.dhcpServerAddr2 is search('55.12.12.12')"
+    - "result.response[0].parent.networkTemplateConfig.dhcpServerAddr3 is search('55.13.13.13')"
+    - "result.response[0].parent.networkTemplateConfig.vrfDhcp is search('eleven')"
+    - "result.response[0].parent.networkTemplateConfig.vrfDhcp2 is search('twelve')"
+    - "result.response[0].parent.networkTemplateConfig.vrfDhcp3 is search('thirteen')"
+    - "result.response[0].parent.networkTemplateConfig.loopbackId is search('55')"

--- a/tests/unit/modules/dcnm/fixtures/dcnm_intf_subint_configs.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_intf_subint_configs.json
@@ -172,7 +172,7 @@
 				"ipv6_addr": "fe80::02",
 				"int_vrf": "default",
 				"ipv4_mask_len": 16,
-				"ipv6_mask_len": 48,
+				"ipv6_mask_len": 68,
 				"fabric": "test_fabric",
 				"sno": "SAL1819SAN8",
 				"vlan": 201,


### PR DESCRIPTION
This is a cherry-pick of the recent feature support I added and published as a hot-fix to Ansible Galaxy.  We don't have this feature in develop so this is essentially a double commit.

Original commit here: https://github.com/CiscoDevNet/ansible-dcnm/commit/a7de8a969bb00bac2af2843f6e6add87997e51fc

There are also a couple of formatting changes that my IDE picked up and changed.