### PR TITLE
Removed unwanted timeout and UT log file creation

### DIFF
--- a/plugins/modules/dcnm_service_route_peering.py
+++ b/plugins/modules/dcnm_service_route_peering.py
@@ -4250,8 +4250,6 @@ class DcnmServiceRoutePeering:
             # We need the SRPs from create and modify list to check for deployment status. Collect them into new list
             self.deployed_srps = self.dcnm_srp_get_deployed_srp_list (self.diff_deploy)
 
-            # Wait for a while for the DCNM to deploy the config
-            time.sleep(180)
             # Ensure all the route peerings are properly deployed before returning.
             self.dcnm_srp_check_deployment_status (self.deployed_srps, "deployed")
 

--- a/tests/unit/modules/dcnm/test_dcnm_intf.py
+++ b/tests/unit/modules/dcnm/test_dcnm_intf.py
@@ -30,10 +30,17 @@ class TestDcnmIntfModule(TestDcnmModule):
 
     module = dcnm_interface
 
-    fd = open("dcnm-ut.log", "w")
+    fd = None
 
     def init_data(self):
         pass
+
+    def log_msg (self, msg):
+
+        if fd is None:
+            fd = open("intf-ut.log", "w")
+        self.fd.write (msg)
+        self.fd.flush()
 
     def log_msg (self, msg):
         self.fd.write (msg)


### PR DESCRIPTION
There was an extra timeout that was leftout during previous cleanup which is now removed from service route peering code
Cleaned up Interface Ut code to not create a UT log file if a specific log_msg has not been called.