### PR TITLE
Task execution should fail when template content is invalid

### DIFF
--- a/plugins/modules/dcnm_template.py
+++ b/plugins/modules/dcnm_template.py
@@ -695,6 +695,9 @@ def main():
 
     dcnm_template.result["diff"] = dcnm_template.changed_dict
 
+    if dcnm_template.changed_dict[0]["failed"]:
+        module.fail_json("Template validation failed", **dcnm_template.result)
+
     if dcnm_template.diff_create or dcnm_template.diff_delete:
         dcnm_template.result["changed"] = True
     else:

--- a/tests/unit/modules/dcnm/test_dcnm_template.py
+++ b/tests/unit/modules/dcnm/test_dcnm_template.py
@@ -660,7 +660,7 @@ class TestDcnmTemplateModule(TestDcnmModule):
 
         set_module_args(dict(state='merged',
                              config=self.playbook_config))
-        result = self.execute_module(changed=False, failed=False)
+        result = self.execute_module(changed=False, failed=True)
 
 
         self.assertEqual(len(result['diff'][0]['failed']), 1)


### PR DESCRIPTION
Currently we report success when template validation fails, but nothing gets created in DCNM:
TASK [Create CLI templates from template folder] *********************************************************************************************************************************************************************
ok: [10.53.207.208] => (item={'key': 'CUSTOM_sub_prefix_list_fw_transit', 'value': '/Users/rdavyden/Documents/Python-dev/g/templates/sub_prefix_list_fw_transit.template'}) => {"ansible_loop_var": "item", "changed": false, "item": {"key": "CUSTOM_sub_prefix_list_fw_transit", "value": "/Users/rdavyden/Documents/Python-dev/g/templates/sub_prefix_list_fw_transit.template"}, "response": [{"DATA": [{"endColumn": 21, "endLine": 11, "message": "Encountered \" <ANNOTATION_VALUE> \"PREFIX-LIST_ENTRIES \"\" at line11, column 3.\nWas expecting one of:\n    <EOF> \n    \"@\" ...\n    \"struct\" ...\n    \"boolean\" ...\n    \"enum\" ...\n    \"float\" ...\n    \"floatRange\" ...\n    \"integer\" ...\n    \"long\" ...\n    \"integerRange\" ...\n    \"interface\" ...\n    \"interfaceRange\" ...\n    \"ipV4Address\" ...\n    \"ipV4AddressWithSubnet\" ...\n    \"ipV4AddressRange\" ...\n    \"ipV6Address\" ...\n    \"ipV6AddressWithPrefix\" ...\n    \"ipV6AddressWithSubnet\" ...\n    \"ipAddressWithoutPrefix\" ...\n    \"ipAddress\" ...\n    \"ipAddressList\" ...\n    \"ISISNetAddress\" ...\n    \"macAddress\" ...\n    \"string\" ...\n    \"wwn\" ...\n    \"string[]\" ...\n    \"ipAddress[]\" ...\n    <PARAMETER_NAME> ...\n    <PARAMETER_ARRAY> ...\n    <PARAMETER_DESC> ...\n    \",\" ...\n    ", "reportItemType": "ERROR", "startColumn": 3, "startLine": 11}], "MESSAGE": "OK", "METHOD": "POST", "REQUEST_PATH": "https://10.53.207.208:443/rest/config/templates/validate", "RETURN_CODE": 200}]}

PLAY RECAP ***********************************************************************************************************************************************************************************************************
10.53.207.208           >>>>>>>   : ok=5   <<<<< changed=0    unreachable=0   >>>>> failed=0  <<<<<  skipped=5    rescued=0    ignored=0  


No template gets created in DCNM due to error in the template. Bu playbook finishes successfully on the other hand. This violates fail fast principle and makes troubleshooting of playbooks and any tasks depending on template existence problematic.
We should fail task properly if template being pushed is failing validation and not report success.

After proposed fix:

TASK [Create CLI templates from template folder] *********************************************************************************************************************************************************************
failed: [10.53.207.208] (item={'key': 'CUSTOM_sub_prefix_list_fw_transit', 'value': '/Users/rdavyden/Documents/Python-dev/g/templates/sub_prefix_list_fw_transit.template'}) => {"ansible_loop_var": "item", "changed": false, "item": {"key": "CUSTOM_sub_prefix_list_fw_transit", "value": "/Users/rdavyden/Documents/Python-dev/g/templates/sub_prefix_list_fw_transit.template"}, "msg": "Template validation failed", "response": [{"DATA": [{"endColumn": 21, "endLine": 11, "message": "Encountered \" <ANNOTATION_VALUE> \"PREFIX-LIST_ENTRIES \"\" at line11, column 3.\nWas expecting one of:\n    <EOF> \n    \"@\" ...\n    \"struct\" ...\n    \"boolean\" ...\n    \"enum\" ...\n    \"float\" ...\n    \"floatRange\" ...\n    \"integer\" ...\n    \"long\" ...\n    \"integerRange\" ...\n    \"interface\" ...\n    \"interfaceRange\" ...\n    \"ipV4Address\" ...\n    \"ipV4AddressWithSubnet\" ...\n    \"ipV4AddressRange\" ...\n    \"ipV6Address\" ...\n    \"ipV6AddressWithPrefix\" ...\n    \"ipV6AddressWithSubnet\" ...\n    \"ipAddressWithoutPrefix\" ...\n    \"ipAddress\" ...\n    \"ipAddressList\" ...\n    \"ISISNetAddress\" ...\n    \"macAddress\" ...\n    \"string\" ...\n    \"wwn\" ...\n    \"string[]\" ...\n    \"ipAddress[]\" ...\n    <PARAMETER_NAME> ...\n    <PARAMETER_ARRAY> ...\n    <PARAMETER_DESC> ...\n    \",\" ...\n    ", "reportItemType": "ERROR", "startColumn": 3, "startLine": 11}], "MESSAGE": "OK", "METHOD": "POST", "REQUEST_PATH": "https://10.53.207.208:443/rest/config/templates/validate", "RETURN_CODE": 200}]}

PLAY RECAP ***********************************************************************************************************************************************************************************************************
10.53.207.208        >>>>>>      : ok=4    changed=0    unreachable=0   >>>>> failed=1  <<<<<  skipped=5    rescued=0    ignored=0   

Also updating corresponding unit test to expect failed task when template content is invalid and failed DCNM validation.