### PR TITLE
Fix for issue 137 - merge state should merge the contents of aggregate members

### DIFF
--- a/tests/unit/modules/dcnm/fixtures/dcnm_intf_multi_intf_configs.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_intf_multi_intf_configs.json
@@ -191,6 +191,151 @@
       "deploy": "True"
     }],
 
+    "multi_intf_merged_config_exist" : [
+    {
+      "switch": [
+        "192.168.1.108"
+      ],
+      "profile": {
+        "description": "port channel acting as trunk",
+        "bpdu_guard": "True",
+        "sno": "SAL1819SAN8",
+        "mtu": "jumbo",
+        "pc_mode": "on",
+        "mode": "trunk",
+        "members": [
+          "e1/29"
+        ],
+        "port_type_fast": "True",
+        "policy": "int_port_channel_trunk_host_11_1",
+        "admin_state": "True",
+        "allowed_vlans": "none",
+        "cmds": [
+          "spanning-tree bpduguard enable"
+        ],
+        "ifname": "Port-channel300",
+        "fabric": "test_fabric"
+      },
+      "type": "pc",
+      "name": "po300",
+      "deploy": "True"
+    },
+    {
+      "profile": {
+        "peer2_pcid": 1,
+        "fabric": "test_fabric",
+        "bpdu_guard": "True",
+        "pc_mode": "on",
+        "peer1_members": [
+          "e1/24"
+        ],
+        "peer2_members": [
+          "e1/24"
+        ],
+        "peer2_cmds": [
+          "spanning-tree bpduguard enable"
+        ],
+        "peer1_pcid": 1,
+        "mtu": "jumbo",
+        "peer1_cmds": [
+          "spanning-tree bpduguard enable"
+        ],
+        "peer1_allowed_vlans": "none",
+        "mode": "trunk",
+        "policy": "int_vpc_trunk_host_11_1",
+        "port_type_fast": "True",
+        "peer2_description": "VPC acting as trunk peer2",
+        "admin_state": "True",
+        "ifname": "vPC301",
+        "peer1_description": "VPC acting as trunk peer1",
+        "sno": "FOX1821H035~SAL1819SAN8",
+        "peer2_allowed_vlans": "none"
+      },
+      "switch": [
+          "192.168.1.109",
+      "192.168.1.108"
+      ],
+      "type": "vpc",
+      "name": "vpc301",
+      "deploy": "True"
+    },
+    {
+      "type": "eth",
+      "switch": [
+        "192.168.1.108"
+      ],
+      "profile": {
+        "description": "eth interface  acting as trunk",
+        "bpdu_guard": "True",
+        "sno": "SAL1819SAN8",
+        "mtu": "jumbo",
+        "admin_state": "True",
+        "mode": "trunk",
+        "port_type_fast": "True",
+        "policy": "int_trunk_host_11_1",
+        "allowed_vlans": "none",
+        "cmds": [
+          "spanning-tree bpduguard enable"
+        ],
+        "speed": "auto",
+        "ifname": "Ethernet1/10",
+        "fabric": "test_fabric"
+      },
+      "name": "eth1/10",
+      "deploy": "True"
+    },
+    {
+      "switch": [
+        "192.168.1.108"
+      ],
+      "deploy": "True",
+      "type": "sub_int",
+      "name": "eth1/1.1",
+      "profile": {
+        "ipv6_addr": "",
+        "int_vrf": "",
+        "ipv4_mask_len": 24,
+        "ipv6_mask_len": 64,
+        "fabric": "test_fabric",
+        "sno": "SAL1819SAN8",
+        "vlan": 100,
+        "mtu": 9216,
+        "ipv4_addr": "1.1.1.1",
+        "mode": "subint",
+        "policy": "int_subif_11_1",
+        "admin_state": "True",
+        "ifname": "Ethernet1/1.1",
+        "cmds": [
+          "spanning-tree bpduguard enable"
+        ],
+        "description": "sub interface eth25/1.1 configuration"
+      }
+    },
+    {
+      "switch": [
+        "192.168.1.108"
+      ],
+      "profile": {
+        "ipv6_addr": "",
+        "int_vrf": "",
+        "description": "loopback interface 100 configuration",
+        "sno": "SAL1819SAN8",
+        "cmds": [
+          "spanning-tree bpduguard enable"
+        ],
+        "ipv4_addr": "100.10.10.1",
+        "mode": "lo",
+        "policy": "int_loopback_11_1",
+        "admin_state": "True",
+        "ifname": "Loopback303",
+        "route_tag": "",
+        "fabric": "test_fabric"
+      },
+      "type": "lo",
+      "name": "lo303",
+      "deploy": "True"
+    }],
+
     "missing_intf_elems_config" : [
     {
       "switch": [

--- a/tests/unit/modules/dcnm/fixtures/dcnm_intf_multi_intf_payloads.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_intf_multi_intf_payloads.json
@@ -1,38 +1,214 @@
 
 {
-	"pc_merged_trunk_payloads" : 
-	{
-		"MESSAGE": "OK",
-			"REQUEST_PATH": "https://10.122.197.6:443/rest/interface?serialNumber=SAL1819SAN8&ifName=Port-channel300",
-			"DATA": [
-			{
-				"policy": "int_port_channel_trunk_host_11_1",
-				"interfaces": [
-				{
-					"ifName": "port-channel300",
-					"serialNumber": "SAL1819SAN8",
-					"nvPairs": {
-						"MEMBER_INTERFACES": "e1/9",
-						"FABRIC_NAME": "test_fabric",
-						"PO_ID": "Port-channel300",
-						"MTU": "jumbo",
-						"SPEED": "auto",
-						"PRIORITY": "500",
-						"PORTTYPE_FAST_ENABLED": "True",
-						"PC_MODE": "on",
-						"POLICY_DESC": "",
-						"CONF": "no shutdown",
-						"BPDUGUARD_ENABLED": "True",
-						"ADMIN_STATE": "True",
-						"POLICY_ID": "POLICY-1849470",
-						"ALLOWED_VLANS": "none",
-						"DESC": "port channel acting as trunk"
-					}
-				}],
+  "pc_merged_trunk_payloads" :
+  {
+    "MESSAGE": "OK",
+      "REQUEST_PATH": "https://10.122.197.6:443/rest/interface?serialNumber=SAL1819SAN8&ifName=Port-channel300",
+      "DATA": [
+      {
+        "policy": "int_port_channel_trunk_host_11_1",
+        "interfaces": [
+        {
+          "ifName": "port-channel300",
+          "serialNumber": "SAL1819SAN8",
+          "nvPairs": {
+            "MEMBER_INTERFACES": "e1/9",
+            "FABRIC_NAME": "test_fabric",
+            "PO_ID": "Port-channel300",
+            "MTU": "jumbo",
+            "SPEED": "auto",
+            "PRIORITY": "500",
+            "PORTTYPE_FAST_ENABLED": "True",
+            "PC_MODE": "on",
+            "POLICY_DESC": "",
+            "CONF": "no shutdown",
+            "BPDUGUARD_ENABLED": "True",
+            "ADMIN_STATE": "True",
+            "POLICY_ID": "POLICY-1849470",
+            "ALLOWED_VLANS": "none",
+            "DESC": "port channel acting as trunk"
+          }
+        }],
         "skipResourceCheck": "True"
-			}
-		],
-		"RETURN_CODE": 200,
-		"METHOD": "GET"
-	}
+      }
+    ],
+    "RETURN_CODE": 200,
+    "METHOD": "GET"
+  },
+
+    "pc_payload":
+    {
+      "MESSAGE": "OK",
+      "REQUEST_PATH": "https://10.122.197.6:443/rest/interface?serialNumber=SAL1819SAN8",
+      "RETURN_CODE": 200,
+      "METHOD": "GET",
+      "DATA": [
+      {
+        "policy": "int_port_channel_trunk_host_11_1",
+        "interfaceType": "INTERFACE_PORT_CHANNEL",
+        "interfaces": [
+        {
+          "serialNumber": "SAL1819SAN8",
+          "interfaceType": "INTERFACE_PORT_CHANNEL",
+          "ifName": "Port-channel300",
+          "fabricName": "test_fabric",
+          "nvPairs": {
+            "SPEED": "Auto",
+            "MEMBER_INTERFACES": "e1/9",
+            "PC_MODE": "on",
+            "BPDUGUARD_ENABLED": "true",
+            "PORTTYPE_FAST_ENABLED": "true",
+            "MTU": "jumbo",
+            "ALLOWED_VLANS": "none",
+            "PO_ID": "Port-channel300",
+            "DESC": "port channel acting as trunk",
+            "CONF": "no shutdown",
+            "ADMIN_STATE": "true"
+          }
+        }
+        ],
+        "skipResourceCheck": "false"
+      }]
+    },
+    "vpc_payload":
+    {
+      "MESSAGE": "OK",
+      "REQUEST_PATH": "https://10.122.197.6:443/rest/interface?serialNumber=SAL1819SAN8",
+      "RETURN_CODE": 200,
+      "METHOD": "GET",
+      "DATA": [
+      {
+        "policy": "int_vpc_trunk_host_11_1",
+        "interfaceType": "INTERFACE_VPC",
+        "interfaces": [
+        {
+          "serialNumber": "FOX1821H035~SAL1819SAN8",
+          "interfaceType": "INTERFACE_VPC",
+          "ifName": "vPC301",
+          "fabricName": "test_fabric",
+          "nvPairs": {
+            "SPEED": "Auto",
+            "PEER1_MEMBER_INTERFACES": "e1/14",
+            "PEER2_MEMBER_INTERFACES": "e1/14",
+            "PC_MODE": "on",
+            "BPDUGUARD_ENABLED": "true",
+            "PORTTYPE_FAST_ENABLED": "true",
+            "MTU": "jumbo",
+            "PEER1_ALLOWED_VLANS": "none",
+            "PEER2_ALLOWED_VLANS": "none",
+            "PEER1_PCID": "1",
+            "PEER2_PCID": "1",
+            "PEER1_PO_DESC": "VPC acting as trunk peer1",
+            "PEER2_PO_DESC": "VPC acting as trunk peer2",
+            "PEER1_PO_CONF": "no shutdown",
+            "PEER2_PO_CONF": "no shutdown",
+            "ADMIN_STATE": "true",
+            "INTF_NAME": "vPC301"
+          }
+        }
+        ],
+        "skipResourceCheck": "false"
+      }]
+    },
+
+    "eth_payload":
+    {
+      "MESSAGE": "OK",
+      "REQUEST_PATH": "https://10.122.197.6:443/rest/interface?serialNumber=SAL1819SAN8",
+      "RETURN_CODE": 200,
+      "METHOD": "GET",
+      "DATA": [
+      {
+        "policy": "int_trunk_host_11_1",
+        "interfaceType": "INTERFACE_ETHERNET",
+        "interfaces": [
+        {
+          "serialNumber": "SAL1819SAN8",
+          "interfaceType": "INTERFACE_ETHERNET",
+          "ifName": "Ethernet1/10",
+          "fabricName": "test_fabric",
+          "nvPairs": {
+            "SPEED": "auto",
+            "BPDUGUARD_ENABLED": "true",
+            "PORTTYPE_FAST_ENABLED": "true",
+            "MTU": "jumbo",
+            "ALLOWED_VLANS": "none",
+            "INTF_NAME": "Ethernet1/10",
+            "DESC": "eth interface  acting as trunk",
+            "CONF": "no shutdown",
+            "ADMIN_STATE": "true"
+          }
+        }
+        ]
+      }]
+    },
+
+    "subint_payload":
+    {
+      "MESSAGE": "OK",
+      "REQUEST_PATH": "https://10.122.197.6:443/rest/interface?serialNumber=SAL1819SAN8",
+      "RETURN_CODE": 200,
+      "METHOD": "GET",
+      "DATA": [
+      {
+        "policy": "int_subif_11_1",
+        "interfaceType": "SUBINTERFACE",
+        "interfaces": [
+        {
+          "serialNumber": "SAL1819SAN8",
+          "interfaceType": "SUBINTERFACE",
+          "ifName": "Ethernet1/1.1",
+          "fabricName": "test_fabric",
+          "nvPairs": {
+            "SPEED": "Auto",
+            "VLAN": "100",
+            "INTF_VRF": "",
+            "IP": "1.1.1.1",
+            "PREFIX": "24",
+            "IPv6": "",
+            "IPv6_PREFIX": "",
+            "MTU": "9216",
+            "INTF_NAME": "Ethernet1/1.1",
+            "DESC": "sub interface eth25/1.1 configuration",
+            "CONF": "no shutdown",
+            "ADMIN_STATE": "true"
+          }
+        }
+        ],
+        "skipResourceCheck": "false"
+      }]
+    },
+
+    "lo_payload":
+    {
+      "MESSAGE": "OK",
+      "REQUEST_PATH": "https://10.122.197.6:443/rest/interface?serialNumber=SAL1819SAN8",
+      "RETURN_CODE": 200,
+      "METHOD": "GET",
+      "DATA": [
+      {
+        "policy": "int_loopback_11_1",
+        "interfaceType": "INTERFACE_LOOPBACK",
+        "interfaces": [
+        {
+          "serialNumber": "SAL1819SAN8",
+          "interfaceType": "INTERFACE_LOOPBACK",
+          "ifName": "Loopback303",
+          "fabricName": "test_fabric",
+          "nvPairs": {
+            "SPEED": "Auto",
+            "INTF_VRF": "",
+            "IP": "100.10.10.1",
+            "V6IP": "",
+            "ROUTE_MAP_TAG": "",
+            "INTF_NAME": "Loopback303",
+            "DESC": "loopback interface 100 configuration",
+            "CONF": "no shutdown",
+            "ADMIN_STATE": "true"
+          }
+        }
+        ],
+        "skipResourceCheck": "false"
+      }]
+    }
 }

--- a/tests/unit/modules/dcnm/test_dcnm_intf.py
+++ b/tests/unit/modules/dcnm/test_dcnm_intf.py
@@ -29,21 +29,17 @@ import json, copy
 class TestDcnmIntfModule(TestDcnmModule):
 
     module = dcnm_interface
-
     fd = None
 
     def init_data(self):
-        pass
+        self.fd = None
 
     def log_msg (self, msg):
 
-        if fd is None:
-            fd = open("intf-ut.log", "w")
+        if self.fd is None:
+            self.fd = open("intf-ut.log", "w")
         self.fd.write (msg)
         self.fd.flush()
-
-    def log_msg (self, msg):
-        self.fd.write (msg)
 
     def setUp(self):
 
@@ -80,6 +76,30 @@ class TestDcnmIntfModule(TestDcnmModule):
             playbook_subint_intf  = []
             playbook_lo_intf      = []
             playbook_eth_intf     = []
+            playbook_have_all_data  = self.have_all_payloads_data.get('payloads')
+            playbook_deployed_data  = self.have_all_payloads_data.get('deployed_payloads')
+
+            self.run_dcnm_send.side_effect = [self.playbook_mock_vpc_resp, self.playbook_mock_vpc_resp,
+                                              playbook_pc_intf, playbook_vpc_intf,
+                                              playbook_subint_intf, playbook_lo_intf,
+                                              playbook_eth_intf,
+                                              playbook_have_all_data, playbook_have_all_data,
+                                              self.playbook_mock_succ_resp, self.playbook_mock_succ_resp,
+                                              self.playbook_mock_succ_resp, self.playbook_mock_succ_resp,
+                                              self.playbook_mock_succ_resp, self.playbook_mock_succ_resp,
+                                              self.playbook_mock_succ_resp, self.playbook_mock_succ_resp,
+                                              self.playbook_mock_succ_resp, self.playbook_mock_succ_resp,
+                                              self.playbook_mock_succ_resp, self.playbook_mock_succ_resp,
+                                              self.playbook_mock_succ_resp, self.playbook_mock_succ_resp,
+                                              playbook_deployed_data]
+
+        if ('_multi_intf_merged_exist' in self._testMethodName):
+            # No I/F exists case
+            playbook_pc_intf  = self.payloads_data.get('pc_payload')
+            playbook_lo_intf  = self.payloads_data.get('lo_payload')
+            playbook_eth_intf = self.payloads_data.get('eth_payload')
+            playbook_subint_intf = self.payloads_data.get('subint_payload')
+            playbook_vpc_intf = self.payloads_data.get('vpc_payload')
             playbook_have_all_data  = self.have_all_payloads_data.get('payloads')
             playbook_deployed_data  = self.have_all_payloads_data.get('deployed_payloads')
 
@@ -924,6 +944,39 @@ class TestDcnmIntfModule(TestDcnmModule):
                                                       'Ethernet1/10',
                                                       'Loopback303']), True)
 
+    def test_dcnm_intf_multi_intf_merged_exist(self):
+
+        # load the json from playbooks
+        self.config_data     = loadPlaybookData('dcnm_intf_multi_intf_configs')
+        self.have_all_payloads_data  = loadPlaybookData('dcnm_intf_have_all_payloads')
+        self.payloads_data   = loadPlaybookData('dcnm_intf_multi_intf_payloads')
+
+        # load required config data
+        self.playbook_config         = self.config_data.get('multi_intf_merged_config_exist')
+        self.playbook_mock_succ_resp = self.config_data.get('mock_succ_resp')
+        self.playbook_mock_vpc_resp  = self.config_data.get('mock_vpc_resp')
+        self.mock_ip_sn              = self.config_data.get('mock_ip_sn')
+        self.mock_fab_inv            = self.config_data.get('mock_fab_inv_data')
+
+        set_module_args(dict(state='merged',
+                             fabric='test_fabric',
+                             config=self.playbook_config))
+        result = self.execute_module(changed=True, failed=False)
+
+        self.assertEqual(len(result['diff'][0]['merged']), 5)
+        for d in result['diff'][0]['merged']:
+            for intf in d['interfaces']:
+                self.assertEqual ((intf['ifName'] in ['Port-channel300',
+                                                      'vPC301',
+                                                      'Ethernet1/1.1',
+                                                      'Ethernet1/10',
+                                                      'Loopback303']), True)
+                for key in intf["nvPairs"]:
+                    if "MEMBER_INTERFACES" in key:
+                        self.assertEqual (len(intf["nvPairs"][key].split(',')), 2)
+                    if "CONF" in key:
+                        self.assertEqual (len(intf["nvPairs"][key].split('\n')), 2)
+
     def test_dcnm_intf_missing_intf_elems_merged_new(self):
 
         # load the json from playbooks
@@ -1096,7 +1149,7 @@ class TestDcnmIntfModule(TestDcnmModule):
         changed_objs = ['MEMBER_INTERFACES', 'PC_MODE', 'BPDUGUARD_ENABLED',
                         'PORTTYPE_FAST_ENABLED', 'MTU', 'ALLOWED_VLANS',
                         'DESC', 'ADMIN_STATE', 'INTF_VRF', 'IP', 'PREFIX',
-                        'ROUTING_TAG', 'SPEED']
+                        'ROUTING_TAG', 'SPEED', 'CONF']
 
         for d in result['diff'][0]['replaced']:
             for intf in d['interfaces']:
@@ -1814,7 +1867,7 @@ class TestDcnmIntfModule(TestDcnmModule):
                         'PORTTYPE_FAST_ENABLED', 'MTU', 'PEER1_ALLOWED_VLANS',
                         'PEER2_ALLOWED_VLANS', 'PEER1_PO_DESC','PEER2_PO_DESC', 'ADMIN_STATE',
                         'PEER1_ACCESS_VLAN', 'PEER2_ACCESS_VLAN',
-                        'PEER1_CONF', 'PEER2_CONF', 'INTF_NAME']
+                        'PEER1_CONF', 'PEER2_CONF', 'PEER1_PO_CONF', 'PEER2_PO_CONF', 'INTF_NAME']
 
         for d in result['diff'][0]['replaced']:
             for intf in d['interfaces']:


### PR DESCRIPTION
ISSUE:  137     

DESCRIPTION:
    Aggregate members like member interfaces and freeform commands must be merged with existing values for merge state. Current code replaces the existing  ones with new values.

FIX:
    Code is now updated to merge the existing values with the new values provided.  Merge action for other non-aggregate members remains the same as before