### PR TITLE
Fix for issue 137 - merge aggregate objects instead of replacing them for merge state operation

### DIFF
--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -2110,7 +2110,7 @@ class DcnmIntf:
                 if intf_payload:
                     self.have.append(intf_payload)
 
-    def dcnm_intf_translate_elements (self, ie1, ie2):
+    def dcnm_intf_translate_elements(self, ie1, ie2):
 
         if sys.version_info[0] >= 3:
             # Python version 3 onwards trfeats unicode as strings. No special treatment is required
@@ -2131,7 +2131,7 @@ class DcnmIntf:
     def dcnm_intf_merge_want_and_have(self, key, wvalue, hvalue):
 
         comb_key = ""
-        e1, e2 = self.dcnm_intf_translate_elements (wvalue, hvalue)
+        e1, e2 = self.dcnm_intf_translate_elements(wvalue, hvalue)
 
         if "CONF" in key:
             if e1 == "":
@@ -2154,7 +2154,7 @@ class DcnmIntf:
         # unicode encoded strings must be decoded to get proper strings which is required
         # for comparison purposes
 
-        e1, e2 = self.dcnm_intf_translate_elements (ie1, ie2)
+        e1, e2 = self.dcnm_intf_translate_elements(ie1, ie2)
 
         # The keys in key_translate represent a concatenated string. We should split
         # these strings and then compare the values

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -1172,7 +1172,7 @@ class DcnmIntf:
     def log_msg(self, msg):
 
         if self.fd is None:
-            self.fd = open("interface.log", "a+")
+            self.fd = open("interface.log", "w+")
         if self.fd is not None:
             self.fd.write(msg)
             self.fd.write("\n")
@@ -1237,7 +1237,10 @@ class DcnmIntf:
 
                         c[ck]["fabric"] = self.dcnm_intf_facts["fabric"]
                         if cfg["type"] == "vpc":
-                            c[ck]["sno"] = self.vpc_ip_sn[sw]
+                            if self.vpc_ip_sn.get(sw, None) is None:
+                                self.module.fail_json(msg="Switch '{}' is not part of VPC pair, but given I/F '{}' is of type VPC".format(sw, c['name']))
+                            else:
+                                c[ck]['sno'] = self.vpc_ip_sn[sw]
                         else:
                             c[ck]["sno"] = self.ip_sn[sw]
                         ifname, port_id = self.dcnm_intf_get_if_name(
@@ -2107,10 +2110,7 @@ class DcnmIntf:
                 if intf_payload:
                     self.have.append(intf_payload)
 
-    def dcnm_intf_compare_elements(self, name, sno, fabric, ie1, ie2, k, state):
-
-        # unicode encoded strings must be decoded to get proper strings which is required
-        # for comparison purposes
+    def dcnm_intf_translate_elements (self, ie1, ie2):
 
         if sys.version_info[0] >= 3:
             # Python version 3 onwards trfeats unicode as strings. No special treatment is required
@@ -2126,6 +2126,36 @@ class DcnmIntf:
             else:
                 e2 = ie2
 
+        return e1, e2
+
+    def dcnm_intf_merge_want_and_have(self, key, wvalue, hvalue):
+
+        comb_key = ""
+        e1, e2 = self.dcnm_intf_translate_elements (wvalue, hvalue)
+
+        if "CONF" in key:
+            if e1 == "":
+                comb_key = e2
+            elif e2 == "":
+                comb_key = e1
+            else:
+                comb_key = e2 + '\n' + e1
+        else:
+            if e1 == "":
+                comb_key = e2
+            elif e2 == "":
+                comb_key = e1
+            else:
+                comb_key = e2 + ',' + e1
+        return comb_key
+
+    def dcnm_intf_compare_elements(self, name, sno, fabric, ie1, ie2, k, state):
+
+        # unicode encoded strings must be decoded to get proper strings which is required
+        # for comparison purposes
+
+        e1, e2 = self.dcnm_intf_translate_elements (ie1, ie2)
+
         # The keys in key_translate represent a concatenated string. We should split
         # these strings and then compare the values
         key_translate = [
@@ -2137,6 +2167,8 @@ class DcnmIntf:
             "PEER2_PO_CONF",
         ]
 
+        merge = False
+
         # Some keys have values given as a list which is encoded into a
         # string. So split that up into list and then use 'set' to process
         # the same irrespective of the order of elements
@@ -2145,8 +2177,12 @@ class DcnmIntf:
             # MEMBER_INTERFACES, PEER1_MEMBER_INTERFACES, and PEER2_MEMBER_INTERFACES
             # have ',' joining differnet elements. So use a multi-delimiter split
             # to split with any delim
-            t_e1 = set(re.split(r"[\n,]", e1.strip()))
-            t_e2 = set(re.split(r"[\n,]", e2.strip()))
+            t_e1 = sorted(re.split(r"[\n,]", e1.strip()))
+            t_e2 = sorted(re.split(r"[\n,]", e2.strip()))
+
+            # Merging of aggregate objects (refer objects in key_translate at the top) should happen only for "merged" state.
+            if state == "merged":
+                merge = True
         else:
             if isinstance(e1, str):
                 t_e1 = e1.lower()
@@ -2185,6 +2221,8 @@ class DcnmIntf:
                     # values for non-mandatory objects.
                     return "copy_and_add"
                 else:
+                    if merge:
+                        return "merge_and_add"
                     return "add"
         return "dont_add"
 
@@ -2302,6 +2340,9 @@ class DcnmIntf:
                                         if res == "copy_and_add":
                                             want[k][0][ik][nk] = d[k][0][ik][nk]
                                             changed_dict[k][0][ik][nk] = d[k][0][ik][nk]
+                                        if (res == "merge_and_add"):
+                                            want[k][0][ik][nk] = self.dcnm_intf_merge_want_and_have(nk, want[k][0][ik][nk], d[k][0][ik][nk])
+                                            changed_dict[k][0][ik][nk] = want[k][0][ik][nk]
                                         if res != "dont_add":
                                             action = "update"
                                         else:
@@ -2326,6 +2367,9 @@ class DcnmIntf:
                                     if res == "copy_and_add":
                                         want[k][0][ik] = d[k][0][ik]
                                         changed_dict[k][0][ik] = d[k][0][ik]
+                                    if (res == "merge_and_add"):
+                                        want[k][0][ik] = self.dcnm_intf_merge_want_and_have(ik, want[k][0][ik], d[k][0][ik])
+                                        changed_dict[k][0][ik] = want[k][0][ik]
                                     if res != "dont_add":
                                         action = "update"
                                     else:
@@ -2340,6 +2384,9 @@ class DcnmIntf:
                             if res == "copy_and_add":
                                 want[k] = d[k]
                                 changed_dict[k] = d[k]
+                            if (res == "merge_and_add"):
+                                want[k] = self.dcnm_intf_merge_want_and_have(k, want[k], d[k])
+                                changed_dict[k] = want[k]
                             if res != "dont_add":
                                 action = "update"
                             else:

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -1238,7 +1238,7 @@ class DcnmIntf:
                         c[ck]["fabric"] = self.dcnm_intf_facts["fabric"]
                         if cfg["type"] == "vpc":
                             if self.vpc_ip_sn.get(sw, None) is None:
-                                self.module.fail_json(msg="Switch '{}' is not part of VPC pair, but given I/F '{}' is of type VPC".format(sw, c['name']))
+                                self.module.fail_json(msg="Switch '{0}' is not part of VPC pair, but given I/F '{1}' is of type VPC".format(sw, c['name']))
                             else:
                                 c[ck]['sno'] = self.vpc_ip_sn[sw]
                         else:

--- a/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_intf_multi_intf_merge.yaml
+++ b/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_intf_multi_intf_merge.yaml
@@ -509,4 +509,3 @@
           - 'item["RETURN_CODE"] == 200'  
       loop: '{{ result.response }}'
       when: IT_CONTEXT is not defined
-

--- a/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_intf_multi_intf_merge.yaml
+++ b/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_intf_multi_intf_merge.yaml
@@ -1,0 +1,512 @@
+##############################################
+##               SETUP                      ##
+##############################################
+
+- name: Remove local log file
+  local_action: command rm -f interface.log
+
+- name: Put the fabric to default state
+  cisco.dcnm.dcnm_interface:
+    check_deploy: True
+    fabric: "{{ ansible_it_fabric }}" 
+    state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
+  register: result  
+
+- assert:
+    that:
+      - 'item["RETURN_CODE"] == 200'  
+  loop: '{{ result.response }}'
+
+- block:
+
+##############################################
+##              MERGE                       ##
+##############################################
+
+    - name: Create eth/sub/lo interfaces
+      cisco.dcnm.dcnm_interface:
+        check_deploy: True
+        fabric: "{{ ansible_it_fabric }}" 
+        state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
+        config:
+          - name: "{{ ansible_eth_intf7 }}"   # should be of the form eth<port-id>
+            type: eth                         # choose from this list [pc, vpc, sub_int, lo, eth]
+            switch:
+              - "{{ ansible_switch1 }}"       # provide the switch information where the config is to be deployed
+            deploy: true                      # choose from [true, false]
+            profile:
+              admin_state: true               # choose from [true, false]
+              mode: trunk                     # choose from [trunk, access, routed, monitor, epl_routed]
+              speed: 'Auto'                   # choose from ['Auto', '100Mb', '1Gb', '10Gb', '25Gb', '40Gb', '100Gb' ]
+              bpdu_guard: true                # choose from [true, false, 'no']
+              port_type_fast: true            # choose from [true, false]
+              mtu: jumbo                      # choose from [default, jumbo]
+              allowed_vlans: none             # choose from [none, all, vlan range] 
+              cmds:                           # Freeform config
+                - no shutdown
+              description: "eth interface  acting as trunk"
+
+          - name: lo100                       # should be of the form lo<port-id>
+            type: lo                          # choose from this list [pc, vpc, sub_int, lo, eth]
+            switch:
+              - "{{ ansible_switch1 }}"       # provide the switch where to deploy the config
+            deploy: true                      # choose from [true, false]
+            profile:
+              admin_state: true               # choose from [true, false]
+              mode: lo                        # choose from [lo]
+              int_vrf: ""                     # VRF name
+              ipv4_addr: 192.168.1.1          # ipv4 address for the loopback interface
+              ipv6_addr: fd08::0201           # ipV6 address for the loopback interface
+              route_tag: ""                   # Routing Tag for the interface
+              cmds:                           # Freeform config
+                - no shutdown
+              description: "loopback interface 100 configuration"
+
+          - name: "{{ ansible_sub_intf1 }}"   # should be of the form eth<port-num>.<port-id>
+            type: sub_int                     # choose from this list [pc, vpc, sub_int, lo, eth]
+            switch:
+              - "{{ ansible_switch1 }}"       # provide the switch information where the config is to be deployed
+            deploy: true                      # choose from [true, false]
+            profile:
+              admin_state: true               # choose from [true, false]
+              mode: subint                    # choose from [subint]
+              vlan: 100                       # vlan ID [min:2, max:3967]
+              int_vrf: ""                     # VRF name
+              ipv4_addr: 192.168.30.1         # ipv4 address for the sub-interface
+              ipv4_mask_len: 24               # choose between [min:8, max:31]
+              ipv6_addr: fd0d::0401           # ipV6 address for the sub-interface
+              ipv6_mask_len: 64               # choose between [min:64, max:127]
+              mtu: 9216                       # choose between [min:576, max:9216]
+              cmds:                           # Freeform config
+                - no shutdown
+              description: "sub interface eth1/1.1 configuration"
+
+      register: result
+
+    - assert:
+        that:
+          - '(result["diff"][0]["merged"] | length) == 3'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["replaced"] | length) == 0'
+          - '(result["diff"][0]["overridden"] | length) == 0'
+          - '(result["diff"][0]["deploy"] | length) == 3'
+
+    - assert:
+        that:
+          - 'item["RETURN_CODE"] == 200'  
+      loop: '{{ result.response }}'
+
+    - name: Modify aggregate members like cmds
+      cisco.dcnm.dcnm_interface:
+        check_deploy: True
+        fabric: "{{ ansible_it_fabric }}" 
+        state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
+        config:
+          - name: "{{ ansible_eth_intf7 }}"   # should be of the form eth<port-id>
+            type: eth                         # choose from this list [pc, vpc, sub_int, lo, eth]
+            switch:
+              - "{{ ansible_switch1 }}"       # provide the switch information where the config is to be deployed
+            deploy: true                      # choose from [true, false]
+            profile:
+              admin_state: true               # choose from [true, false]
+              mode: trunk                     # choose from [trunk, access, routed, monitor, epl_routed]
+              speed: 'Auto'                   # choose from ['Auto', '100Mb', '1Gb', '10Gb', '25Gb', '40Gb', '100Gb' ]
+              bpdu_guard: true                # choose from [true, false, 'no']
+              port_type_fast: true            # choose from [true, false]
+              mtu: jumbo                      # choose from [default, jumbo]
+              allowed_vlans: none             # choose from [none, all, vlan range] 
+              cmds:                           # Freeform config
+                - spanning-tree bpduguard enable
+              description: "eth interface  acting as trunk"
+
+          - name: lo100                       # should be of the form lo<port-id>
+            type: lo                          # choose from this list [pc, vpc, sub_int, lo, eth]
+            switch:
+              - "{{ ansible_switch1 }}"       # provide the switch where to deploy the config
+            deploy: true                      # choose from [true, false]
+            profile:
+              admin_state: true               # choose from [true, false]
+              mode: lo                        # choose from [lo]
+              int_vrf: ""                     # VRF name
+              ipv4_addr: 192.168.1.1          # ipv4 address for the loopback interface
+              ipv6_addr: fd08::0201           # ipV6 address for the loopback interface
+              route_tag: ""                   # Routing Tag for the interface
+              cmds:                           # Freeform config
+                - spanning-tree bpduguard enable
+              description: "loopback interface 100 configuration"
+
+          - name: "{{ ansible_sub_intf1 }}"   # should be of the form eth<port-num>.<port-id>
+            type: sub_int                     # choose from this list [pc, vpc, sub_int, lo, eth]
+            switch:
+              - "{{ ansible_switch1 }}"       # provide the switch information where the config is to be deployed
+            deploy: true                      # choose from [true, false]
+            profile:
+              admin_state: true               # choose from [true, false]
+              mode: subint                    # choose from [subint]
+              vlan: 100                       # vlan ID [min:2, max:3967]
+              int_vrf: ""                     # VRF name
+              ipv4_addr: 192.168.30.1         # ipv4 address for the sub-interface
+              ipv4_mask_len: 24               # choose between [min:8, max:31]
+              ipv6_addr: fd0d::0401           # ipV6 address for the sub-interface
+              ipv6_mask_len: 64               # choose between [min:64, max:127]
+              mtu: 9216                       # choose between [min:576, max:9216]
+              cmds:                           # Freeform config
+                - spanning-tree bpduguard enable
+              description: "sub interface eth1/1.1 configuration"
+
+      register: result
+
+    - assert:
+        that:
+          - '(result["diff"][0]["merged"] | length) == 3'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["replaced"] | length) == 0'
+          - '(result["diff"][0]["overridden"] | length) == 0'
+          - '(result["diff"][0]["deploy"] | length) == 3'
+          - '(result["diff"][0]["merged"][0]["interfaces"][0]["nvPairs"]["CONF"].split("\n") | length) == 2'
+          - '(result["diff"][0]["merged"][1]["interfaces"][0]["nvPairs"]["CONF"].split("\n") | length) == 2'
+          - '(result["diff"][0]["merged"][2]["interfaces"][0]["nvPairs"]["CONF"].split("\n") | length) == 2'
+
+    - assert:
+        that:
+          - 'item["RETURN_CODE"] == 200'  
+      loop: '{{ result.response }}'
+
+
+##############################################
+##              MERGE                       ##
+##############################################
+
+    - name: Create po interfaces
+      cisco.dcnm.dcnm_interface:
+        check_deploy: True
+        fabric: "{{ ansible_it_fabric }}" 
+        state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
+        config:
+          - name: po300                       # should be of the form po<port-id>
+            type: pc                          # choose from this list [pc, vpc, sub_int, lo, eth]
+            switch:
+              - "{{ ansible_switch1 }}"       # provide the switch information where the config is to be deployed
+            deploy: true                      # choose from [true, false]
+            profile:
+              admin_state: true               # choose from [true, false]
+              mode: trunk                     # choose from [trunk, access, l3, monitor]
+              members:                        # member interfaces 
+                - "{{ ansible_eth_intf13 }}"
+              pc_mode: 'on'                   # choose from ['on', 'active', 'passive']
+              bpdu_guard: true                # choose from [true, false, no]
+              port_type_fast: true            # choose from [true, false]
+              mtu: jumbo                      # choose from [default, jumbo]
+              allowed_vlans: none             # choose from [none, all, vlan range] 
+              cmds:                           # Freeform config
+                - no shutdown
+              description: "port channel acting as trunk"
+
+          - name: po310                       # should be of the form po<port-id>
+            type: pc                          # choose from this list [pc, vpc, sub_int, lo, eth]
+            switch:
+              - "{{ ansible_switch1 }}"       # provide the switch information where the config is to be deployed
+            deploy: true                      # choose from [true, false]
+            profile:
+              admin_state: true               # choose from [true, false]
+              mode: trunk                     # choose from [trunk, access, l3, monitor]
+              pc_mode: 'on'                   # choose from ['on', 'active', 'passive']
+              bpdu_guard: true                # choose from [true, false, no]
+              port_type_fast: true            # choose from [true, false]
+              mtu: jumbo                      # choose from [default, jumbo]
+              allowed_vlans: none             # choose from [none, all, vlan range] 
+              description: "port channel acting as trunk"
+      register: result
+
+    - assert:
+        that:
+          - '(result["diff"][0]["merged"] | length) == 2'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["replaced"] | length) == 0'
+          - '(result["diff"][0]["overridden"] | length) == 0'
+          - '(result["diff"][0]["deploy"] | length) == 2'
+
+    - assert:
+        that:
+          - 'item["RETURN_CODE"] == 200'  
+      loop: '{{ result.response }}'
+
+    - name: Modify po300 - no aggregate members like members and cmds
+      cisco.dcnm.dcnm_interface:
+        check_deploy: True
+        fabric: "{{ ansible_it_fabric }}" 
+        state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
+        config:
+          - name: po300                       # should be of the form po<port-id>
+            type: pc                          # choose from this list [pc, vpc, sub_int, lo, eth]
+            switch:
+              - "{{ ansible_switch1 }}"       # provide the switch information where the config is to be deployed
+            deploy: true                      # choose from [true, false]
+            profile:
+              admin_state: true               # choose from [true, false]
+              mode: trunk                     # choose from [trunk, access, l3, monitor]
+              pc_mode: 'on'                   # choose from ['on', 'active', 'passive']
+              bpdu_guard: true                # choose from [true, false, no]
+              port_type_fast: true            # choose from [true, false]
+              mtu: jumbo                      # choose from [default, jumbo]
+              allowed_vlans: none             # choose from [none, all, vlan range] 
+              description: "port channel acting as trunk"
+      register: result
+
+    - assert:
+        that:
+          - '(result["diff"][0]["merged"] | length) == 1'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["replaced"] | length) == 0'
+          - '(result["diff"][0]["overridden"] | length) == 0'
+          - '(result["diff"][0]["deploy"] | length) == 1'
+          - '(result["diff"][0]["merged"][0]["interfaces"][0]["nvPairs"]["CONF"].split("\n") | length) == 1'
+          - '(result["diff"][0]["merged"][0]["interfaces"][0]["nvPairs"]["MEMBER_INTERFACES"].split(",") | length) == 1'
+
+    - assert:
+        that:
+          - 'item["RETURN_CODE"] == 200'  
+      loop: '{{ result.response }}'
+
+    - name: Modify po300 - new aggregate members like members and cmds
+      cisco.dcnm.dcnm_interface:
+        check_deploy: True
+        fabric: "{{ ansible_it_fabric }}" 
+        state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
+        config:
+          - name: po300                       # should be of the form po<port-id>
+            type: pc                          # choose from this list [pc, vpc, sub_int, lo, eth]
+            switch:
+              - "{{ ansible_switch1 }}"       # provide the switch information where the config is to be deployed
+            deploy: true                      # choose from [true, false]
+            profile:
+              admin_state: true               # choose from [true, false]
+              mode: trunk                     # choose from [trunk, access, l3, monitor]
+              members:                        # member interfaces 
+                - "{{ ansible_eth_intf14 }}"
+              pc_mode: 'on'                   # choose from ['on', 'active', 'passive']
+              bpdu_guard: true                # choose from [true, false, no]
+              port_type_fast: true            # choose from [true, false]
+              mtu: jumbo                      # choose from [default, jumbo]
+              allowed_vlans: none             # choose from [none, all, vlan range] 
+              cmds:                           # Freeform config
+                - spanning-tree bpduguard enable
+              description: "port channel acting as trunk"
+      register: result
+
+    - assert:
+        that:
+          - '(result["diff"][0]["merged"] | length) == 1'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["replaced"] | length) == 0'
+          - '(result["diff"][0]["overridden"] | length) == 0'
+          - '(result["diff"][0]["deploy"] | length) == 1'
+          - '(result["diff"][0]["merged"][0]["interfaces"][0]["nvPairs"]["CONF"].split("\n") | length) == 2'
+          - '(result["diff"][0]["merged"][0]["interfaces"][0]["nvPairs"]["MEMBER_INTERFACES"].split(",") | length) == 2'
+
+    - assert:
+        that:
+          - 'item["RETURN_CODE"] == 200'  
+      loop: '{{ result.response }}'
+
+    - name: Modify po310 - no aggregate members like members and cmds
+      cisco.dcnm.dcnm_interface:
+        check_deploy: True
+        fabric: "{{ ansible_it_fabric }}" 
+        state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
+        config:
+          - name: po310                       # should be of the form po<port-id>
+            type: pc                          # choose from this list [pc, vpc, sub_int, lo, eth]
+            switch:
+              - "{{ ansible_switch1 }}"       # provide the switch information where the config is to be deployed
+            deploy: true                      # choose from [true, false]
+            profile:
+              admin_state: true               # choose from [true, false]
+              mode: trunk                     # choose from [trunk, access, l3, monitor]
+              pc_mode: 'on'                   # choose from ['on', 'active', 'passive']
+              bpdu_guard: true                # choose from [true, false, no]
+              port_type_fast: true            # choose from [true, false]
+              mtu: jumbo                      # choose from [default, jumbo]
+              allowed_vlans: none             # choose from [none, all, vlan range] 
+              description: "port channel acting as trunk - updated"
+      register: result
+
+    - assert:
+        that:
+          - '(result["diff"][0]["merged"] | length) == 1'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["replaced"] | length) == 0'
+          - '(result["diff"][0]["overridden"] | length) == 0'
+          - '(result["diff"][0]["deploy"] | length) == 1'
+
+    - assert:
+        that:
+          - 'item["RETURN_CODE"] == 200'  
+      loop: '{{ result.response }}'
+
+    - name: Modify po310 - new aggregate members like members and cmds
+      cisco.dcnm.dcnm_interface:
+        check_deploy: True
+        fabric: "{{ ansible_it_fabric }}" 
+        state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
+        config:
+          - name: po310                       # should be of the form po<port-id>
+            type: pc                          # choose from this list [pc, vpc, sub_int, lo, eth]
+            switch:
+              - "{{ ansible_switch1 }}"       # provide the switch information where the config is to be deployed
+            deploy: true                      # choose from [true, false]
+            profile:
+              admin_state: true               # choose from [true, false]
+              mode: trunk                     # choose from [trunk, access, l3, monitor]
+              members:                        # member interfaces 
+                - "{{ ansible_eth_intf18 }}"
+              pc_mode: 'on'                   # choose from ['on', 'active', 'passive']
+              bpdu_guard: true                # choose from [true, false, no]
+              port_type_fast: true            # choose from [true, false]
+              mtu: jumbo                      # choose from [default, jumbo]
+              cmds:                           # Freeform config
+                - spanning-tree bpduguard enable
+              allowed_vlans: none             # choose from [none, all, vlan range] 
+              description: "port channel acting as trunk"
+      register: result
+
+    - assert:
+        that:
+          - '(result["diff"][0]["merged"] | length) == 1'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["replaced"] | length) == 0'
+          - '(result["diff"][0]["overridden"] | length) == 0'
+          - '(result["diff"][0]["deploy"] | length) == 1'
+          - '(result["diff"][0]["merged"][0]["interfaces"][0]["nvPairs"]["CONF"].split("\n") | length) == 1'
+          - '(result["diff"][0]["merged"][0]["interfaces"][0]["nvPairs"]["MEMBER_INTERFACES"].split(",") | length) == 1'
+
+    - assert:
+        that:
+          - 'item["RETURN_CODE"] == 200'  
+      loop: '{{ result.response }}'
+
+##############################################
+##              MERGE                       ##
+##############################################
+
+    - name: Create vpc interfaces
+      cisco.dcnm.dcnm_interface:
+        check_deploy: True
+        fabric: "{{ ansible_it_fabric }}" 
+        state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
+        config:
+          - name: vpc750                      # should be of the form vpc<port-id>
+            type: vpc                         # choose from this list [pc, vpc, sub_int, lo, eth]
+            switch:                           # provide switches of vPC pair
+              - "{{ ansible_switch1 }}"
+            deploy: true                      # choose from [true, false]
+            profile:
+              admin_state: true               # choose from [true, false]
+              mode: trunk                     # choose from [trunk, access]
+              peer1_pcid: 120                 # choose between [Min:1, Max:4096], if not given, will be VPC port-id
+              peer2_pcid: 120                 # choose between [Min:1, Max:4096], if not given, will be VPC port-id
+              peer1_members:                  # member interfaces on peer 1
+                - "{{ ansible_eth_intf15 }}"
+              peer2_members:                  # member interfaces on peer 2
+                - "{{ ansible_eth_intf15 }}"
+              pc_mode: 'active'               # choose from ['on', 'active', 'passive']
+              bpdu_guard: true                # choose from [true, false, 'no']
+              port_type_fast: true            # choose from [true, false]
+              mtu: jumbo                      # choose from [default, jumbo]
+              peer1_allowed_vlans: none       # choose from [none, all, vlan range] 
+              peer2_allowed_vlans: none       # choose from [none, all, vlan range] 
+              peer1_description: "VPC acting as trunk peer1"
+              peer2_description: "VPC acting as trunk peer2"
+              peer1_cmds:                     # Freeform config
+                - no shutdown
+              peer2_cmds:                     # Freeform config
+                - no shutdown
+      register: result
+
+    - assert:
+        that:
+          - '(result["diff"][0]["merged"] | length) == 1'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["replaced"] | length) == 0'
+          - '(result["diff"][0]["overridden"] | length) == 0'
+          - '(result["diff"][0]["deploy"] | length) == 1'
+
+    - assert:
+        that:
+          - 'item["RETURN_CODE"] == 200'  
+      loop: '{{ result.response }}'
+
+    - name: Modify aggregate members like peer1_cmds, peer2_cmds, peer1_members and peer2_members 
+      cisco.dcnm.dcnm_interface:
+        check_deploy: True
+        fabric: "{{ ansible_it_fabric }}" 
+        state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
+        config:
+          - name: vpc750                      # should be of the form vpc<port-id>
+            type: vpc                         # choose from this list [pc, vpc, sub_int, lo, eth]
+            switch:                           # provide switches of vPC pair
+              - "{{ ansible_switch1 }}"
+            deploy: true                      # choose from [true, false]
+            profile:
+              admin_state: true               # choose from [true, false]
+              mode: trunk                     # choose from [trunk, access]
+              peer1_pcid: 120                 # choose between [Min:1, Max:4096], if not given, will be VPC port-id
+              peer2_pcid: 120                 # choose between [Min:1, Max:4096], if not given, will be VPC port-id
+              peer1_members:                  # member interfaces on peer 1
+                - "{{ ansible_eth_intf16 }}"
+              peer2_members:                  # member interfaces on peer 2
+                - "{{ ansible_eth_intf16 }}"
+              pc_mode: 'active'               # choose from ['on', 'active', 'passive']
+              bpdu_guard: true                # choose from [true, false, 'no']
+              port_type_fast: true            # choose from [true, false]
+              mtu: jumbo                      # choose from [default, jumbo]
+              peer1_allowed_vlans: none       # choose from [none, all, vlan range] 
+              peer2_allowed_vlans: none       # choose from [none, all, vlan range] 
+              peer1_description: "VPC acting as trunk peer1"
+              peer2_description: "VPC acting as trunk peer2"
+              peer1_cmds:                     # Freeform config
+                - spanning-tree bpduguard enable
+              peer2_cmds:                     # Freeform config
+                - spanning-tree bpduguard enable
+
+
+      register: result
+
+    - assert:
+        that:
+          - '(result["diff"][0]["merged"] | length) == 1'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["replaced"] | length) == 0'
+          - '(result["diff"][0]["overridden"] | length) == 0'
+          - '(result["diff"][0]["deploy"] | length) == 1'
+          - '(result["diff"][0]["merged"][0]["interfaces"][0]["nvPairs"]["PEER1_PO_CONF"].split("\n") | length) == 2'
+          - '(result["diff"][0]["merged"][0]["interfaces"][0]["nvPairs"]["PEER2_PO_CONF"].split("\n") | length) == 2'
+          - '(result["diff"][0]["merged"][0]["interfaces"][0]["nvPairs"]["PEER1_MEMBER_INTERFACES"].split(",") | length) == 2'
+          - '(result["diff"][0]["merged"][0]["interfaces"][0]["nvPairs"]["PEER2_MEMBER_INTERFACES"].split(",") | length) == 2'
+
+    - assert:
+        that:
+          - 'item["RETURN_CODE"] == 200'  
+      loop: '{{ result.response }}'
+
+
+##############################################
+##             CLEANUP                      ##
+##############################################
+
+  always:
+
+    - name: Put fabric to default state
+      cisco.dcnm.dcnm_interface:
+        check_deploy: True
+        fabric: "{{ ansible_it_fabric }}" 
+        state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
+      register: result
+      when: IT_CONTEXT is not defined
+
+    - assert:
+        that:
+          - 'item["RETURN_CODE"] == 200'  
+      loop: '{{ result.response }}'
+      when: IT_CONTEXT is not defined
+

--- a/tests/unit/modules/dcnm/fixtures/dcnm_intf_multi_intf_configs.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_intf_multi_intf_configs.json
@@ -191,6 +191,151 @@
       "deploy": "True"
     }],
 
+    "multi_intf_merged_config_exist" : [
+    {
+      "switch": [
+        "192.168.1.108"
+      ],
+      "profile": {
+        "description": "port channel acting as trunk",
+        "bpdu_guard": "True",
+        "sno": "SAL1819SAN8",
+        "mtu": "jumbo",
+        "pc_mode": "on",
+        "mode": "trunk",
+        "members": [
+          "e1/29"
+        ],
+        "port_type_fast": "True",
+        "policy": "int_port_channel_trunk_host_11_1",
+        "admin_state": "True",
+        "allowed_vlans": "none",
+        "cmds": [
+          "spanning-tree bpduguard enable"
+        ],
+        "ifname": "Port-channel300",
+        "fabric": "test_fabric"
+      },
+      "type": "pc",
+      "name": "po300",
+      "deploy": "True"
+    },
+    {
+      "profile": {
+        "peer2_pcid": 1,
+        "fabric": "test_fabric",
+        "bpdu_guard": "True",
+        "pc_mode": "on",
+        "peer1_members": [
+          "e1/24"
+        ],
+        "peer2_members": [
+          "e1/24"
+        ],
+        "peer2_cmds": [
+          "spanning-tree bpduguard enable"
+        ],
+        "peer1_pcid": 1,
+        "mtu": "jumbo",
+        "peer1_cmds": [
+          "spanning-tree bpduguard enable"
+        ],
+        "peer1_allowed_vlans": "none",
+        "mode": "trunk",
+        "policy": "int_vpc_trunk_host_11_1",
+        "port_type_fast": "True",
+        "peer2_description": "VPC acting as trunk peer2",
+        "admin_state": "True",
+        "ifname": "vPC301",
+        "peer1_description": "VPC acting as trunk peer1",
+        "sno": "FOX1821H035~SAL1819SAN8",
+        "peer2_allowed_vlans": "none"
+      },
+      "switch": [
+          "192.168.1.109",
+      "192.168.1.108"
+      ],
+      "type": "vpc",
+      "name": "vpc301",
+      "deploy": "True"
+    },
+    {
+      "type": "eth",
+      "switch": [
+        "192.168.1.108"
+      ],
+      "profile": {
+        "description": "eth interface  acting as trunk",
+        "bpdu_guard": "True",
+        "sno": "SAL1819SAN8",
+        "mtu": "jumbo",
+        "admin_state": "True",
+        "mode": "trunk",
+        "port_type_fast": "True",
+        "policy": "int_trunk_host_11_1",
+        "allowed_vlans": "none",
+        "cmds": [
+          "spanning-tree bpduguard enable"
+        ],
+        "speed": "auto",
+        "ifname": "Ethernet1/10",
+        "fabric": "test_fabric"
+      },
+      "name": "eth1/10",
+      "deploy": "True"
+    },
+    {
+      "switch": [
+        "192.168.1.108"
+      ],
+      "deploy": "True",
+      "type": "sub_int",
+      "name": "eth1/1.1",
+      "profile": {
+        "ipv6_addr": "",
+        "int_vrf": "",
+        "ipv4_mask_len": 24,
+        "ipv6_mask_len": 64,
+        "fabric": "test_fabric",
+        "sno": "SAL1819SAN8",
+        "vlan": 100,
+        "mtu": 9216,
+        "ipv4_addr": "1.1.1.1",
+        "mode": "subint",
+        "policy": "int_subif_11_1",
+        "admin_state": "True",
+        "ifname": "Ethernet1/1.1",
+        "cmds": [
+          "spanning-tree bpduguard enable"
+        ],
+        "description": "sub interface eth25/1.1 configuration"
+      }
+    },
+    {
+      "switch": [
+        "192.168.1.108"
+      ],
+      "profile": {
+        "ipv6_addr": "",
+        "int_vrf": "",
+        "description": "loopback interface 100 configuration",
+        "sno": "SAL1819SAN8",
+        "cmds": [
+          "spanning-tree bpduguard enable"
+        ],
+        "ipv4_addr": "100.10.10.1",
+        "mode": "lo",
+        "policy": "int_loopback_11_1",
+        "admin_state": "True",
+        "ifname": "Loopback303",
+        "route_tag": "",
+        "fabric": "test_fabric"
+      },
+      "type": "lo",
+      "name": "lo303",
+      "deploy": "True"
+    }],
+
     "missing_intf_elems_config" : [
     {
       "switch": [

--- a/tests/unit/modules/dcnm/fixtures/dcnm_intf_multi_intf_payloads.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_intf_multi_intf_payloads.json
@@ -34,5 +34,181 @@
 		],
 		"RETURN_CODE": 200,
 		"METHOD": "GET"
-	}
+	},
+
+    "pc_payload":
+    {
+      "MESSAGE": "OK",
+      "REQUEST_PATH": "https://10.122.197.6:443/rest/interface?serialNumber=SAL1819SAN8",
+      "RETURN_CODE": 200,
+      "METHOD": "GET",
+      "DATA": [
+      {
+        "policy": "int_port_channel_trunk_host_11_1",
+        "interfaceType": "INTERFACE_PORT_CHANNEL",
+        "interfaces": [
+        {
+          "serialNumber": "SAL1819SAN8",
+          "interfaceType": "INTERFACE_PORT_CHANNEL",
+          "ifName": "Port-channel300",
+          "fabricName": "test_fabric",
+          "nvPairs": {
+            "SPEED": "Auto",
+            "MEMBER_INTERFACES": "e1/9",
+            "PC_MODE": "on",
+            "BPDUGUARD_ENABLED": "true",
+            "PORTTYPE_FAST_ENABLED": "true",
+            "MTU": "jumbo",
+            "ALLOWED_VLANS": "none",
+            "PO_ID": "Port-channel300",
+            "DESC": "port channel acting as trunk",
+            "CONF": "no shutdown",
+            "ADMIN_STATE": "true"
+          }
+        }
+        ],
+        "skipResourceCheck": "false"
+      }]
+    },
+    "vpc_payload":
+    {
+      "MESSAGE": "OK",
+      "REQUEST_PATH": "https://10.122.197.6:443/rest/interface?serialNumber=SAL1819SAN8",
+      "RETURN_CODE": 200,
+      "METHOD": "GET",
+      "DATA": [
+      {
+        "policy": "int_vpc_trunk_host_11_1",
+        "interfaceType": "INTERFACE_VPC",
+        "interfaces": [
+        {
+          "serialNumber": "FOX1821H035~SAL1819SAN8",
+          "interfaceType": "INTERFACE_VPC",
+          "ifName": "vPC301",
+          "fabricName": "test_fabric",
+          "nvPairs": {
+            "SPEED": "Auto",
+            "PEER1_MEMBER_INTERFACES": "e1/14",
+            "PEER2_MEMBER_INTERFACES": "e1/14",
+            "PC_MODE": "on",
+            "BPDUGUARD_ENABLED": "true",
+            "PORTTYPE_FAST_ENABLED": "true",
+            "MTU": "jumbo",
+            "PEER1_ALLOWED_VLANS": "none",
+            "PEER2_ALLOWED_VLANS": "none",
+            "PEER1_PCID": "1",
+            "PEER2_PCID": "1",
+            "PEER1_PO_DESC": "VPC acting as trunk peer1",
+            "PEER2_PO_DESC": "VPC acting as trunk peer2",
+            "PEER1_PO_CONF": "no shutdown",
+            "PEER2_PO_CONF": "no shutdown",
+            "ADMIN_STATE": "true",
+            "INTF_NAME": "vPC301"
+          }
+        }
+        ],
+        "skipResourceCheck": "false"
+      }]
+    },
+
+    "eth_payload":
+    {
+      "MESSAGE": "OK",
+      "REQUEST_PATH": "https://10.122.197.6:443/rest/interface?serialNumber=SAL1819SAN8",
+      "RETURN_CODE": 200,
+      "METHOD": "GET",
+      "DATA": [
+      {
+        "policy": "int_trunk_host_11_1",
+        "interfaceType": "INTERFACE_ETHERNET",
+        "interfaces": [
+        {
+          "serialNumber": "SAL1819SAN8",
+          "interfaceType": "INTERFACE_ETHERNET",
+          "ifName": "Ethernet1/10",
+          "fabricName": "test_fabric",
+          "nvPairs": {
+            "SPEED": "auto",
+            "BPDUGUARD_ENABLED": "true",
+            "PORTTYPE_FAST_ENABLED": "true",
+            "MTU": "jumbo",
+            "ALLOWED_VLANS": "none",
+            "INTF_NAME": "Ethernet1/10",
+            "DESC": "eth interface  acting as trunk",
+            "CONF": "no shutdown",
+            "ADMIN_STATE": "true"
+          }
+        }
+        ]
+      }]
+    },
+
+    "subint_payload":
+    {
+      "MESSAGE": "OK",
+      "REQUEST_PATH": "https://10.122.197.6:443/rest/interface?serialNumber=SAL1819SAN8",
+      "RETURN_CODE": 200,
+      "METHOD": "GET",
+      "DATA": [
+      {
+        "policy": "int_subif_11_1",
+        "interfaceType": "SUBINTERFACE",
+        "interfaces": [
+        {
+          "serialNumber": "SAL1819SAN8",
+          "interfaceType": "SUBINTERFACE",
+          "ifName": "Ethernet1/1.1",
+          "fabricName": "test_fabric",
+          "nvPairs": {
+            "SPEED": "Auto",
+            "VLAN": "100",
+            "INTF_VRF": "",
+            "IP": "1.1.1.1",
+            "PREFIX": "24",
+            "IPv6": "",
+            "IPv6_PREFIX": "",
+            "MTU": "9216",
+            "INTF_NAME": "Ethernet1/1.1",
+            "DESC": "sub interface eth25/1.1 configuration",
+            "CONF": "no shutdown",
+            "ADMIN_STATE": "true"
+          }
+        }
+        ],
+        "skipResourceCheck": "false"
+      }]
+    },
+
+    "lo_payload":
+    {
+      "MESSAGE": "OK",
+      "REQUEST_PATH": "https://10.122.197.6:443/rest/interface?serialNumber=SAL1819SAN8",
+      "RETURN_CODE": 200,
+      "METHOD": "GET",
+      "DATA": [
+      {
+        "policy": "int_loopback_11_1",
+        "interfaceType": "INTERFACE_LOOPBACK",
+        "interfaces": [
+        {
+          "serialNumber": "SAL1819SAN8",
+          "interfaceType": "INTERFACE_LOOPBACK",
+          "ifName": "Loopback303",
+          "fabricName": "test_fabric",
+          "nvPairs": {
+            "SPEED": "Auto",
+            "INTF_VRF": "",
+            "IP": "100.10.10.1",
+            "V6IP": "",
+            "ROUTE_MAP_TAG": "",
+            "INTF_NAME": "Loopback303",
+            "DESC": "loopback interface 100 configuration",
+            "CONF": "no shutdown",
+            "ADMIN_STATE": "true"
+          }
+        }
+        ],
+        "skipResourceCheck": "false"
+      }]
+    }
 }

--- a/tests/unit/modules/dcnm/test_dcnm_intf.py
+++ b/tests/unit/modules/dcnm/test_dcnm_intf.py
@@ -120,13 +120,13 @@ class TestDcnmIntfModule(TestDcnmModule):
 
         if ("_multi_intf_merged_exist" in self._testMethodName):
             # No I/F exists case
-            playbook_pc_intf  = self.payloads_data.get("pc_payload")
-            playbook_lo_intf  = self.payloads_data.get("lo_payload")
+            playbook_pc_intf = self.payloads_data.get("pc_payload")
+            playbook_lo_intf = self.payloads_data.get("lo_payload")
             playbook_eth_intf = self.payloads_data.get("eth_payload")
             playbook_subint_intf = self.payloads_data.get("subint_payload")
             playbook_vpc_intf = self.payloads_data.get("vpc_payload")
-            playbook_have_all_data  = self.have_all_payloads_data.get("payloads")
-            playbook_deployed_data  = self.have_all_payloads_data.get("deployed_payloads")
+            playbook_have_all_data = self.have_all_payloads_data.get("payloads")
+            playbook_deployed_data = self.have_all_payloads_data.get("deployed_payloads")
 
             self.run_dcnm_send.side_effect = [
                 self.playbook_mock_vpc_resp,
@@ -1399,16 +1399,16 @@ class TestDcnmIntfModule(TestDcnmModule):
     def test_dcnm_intf_multi_intf_merged_exist(self):
 
         # load the json from playbooks
-        self.config_data     = loadPlaybookData("dcnm_intf_multi_intf_configs")
-        self.have_all_payloads_data  = loadPlaybookData("dcnm_intf_have_all_payloads")
-        self.payloads_data   = loadPlaybookData("dcnm_intf_multi_intf_payloads")
+        self.config_data = loadPlaybookData("dcnm_intf_multi_intf_configs")
+        self.have_all_payloads_data = loadPlaybookData("dcnm_intf_have_all_payloads")
+        self.payloads_data = loadPlaybookData("dcnm_intf_multi_intf_payloads")
 
         # load required config data
-        self.playbook_config         = self.config_data.get("multi_intf_merged_config_exist")
+        self.playbook_config = self.config_data.get("multi_intf_merged_config_exist")
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
-        self.playbook_mock_vpc_resp  = self.config_data.get("mock_vpc_resp")
-        self.mock_ip_sn              = self.config_data.get("mock_ip_sn")
-        self.mock_fab_inv            = self.config_data.get("mock_fab_inv_data")
+        self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
+        self.mock_ip_sn = self.config_data.get("mock_ip_sn")
+        self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
 
         set_module_args(dict(state="merged",
                              fabric="test_fabric",
@@ -1418,16 +1418,16 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.assertEqual(len(result["diff"][0]["merged"]), 5)
         for d in result["diff"][0]["merged"]:
             for intf in d["interfaces"]:
-                self.assertEqual ((intf["ifName"] in ["Port-channel300",
-                                                      "vPC301",
-                                                      "Ethernet1/1.1",
-                                                      "Ethernet1/10",
-                                                      "Loopback303"]), True)
+                self.assertEqual((intf["ifName"] in ["Port-channel300",
+                                                     "vPC301",
+                                                     "Ethernet1/1.1",
+                                                     "Ethernet1/10",
+                                                     "Loopback303"]), True)
                 for key in intf["nvPairs"]:
                     if "MEMBER_INTERFACES" in key:
-                        self.assertEqual (len(intf["nvPairs"][key].split(",")), 2)
+                        self.assertEqual(len(intf["nvPairs"][key].split(",")), 2)
                     if "CONF" in key:
-                        self.assertEqual (len(intf["nvPairs"][key].split("\n")), 2)
+                        self.assertEqual(len(intf["nvPairs"][key].split("\n")), 2)
 
     def test_dcnm_intf_missing_intf_elems_merged_new(self):
 

--- a/tests/unit/modules/dcnm/test_dcnm_intf.py
+++ b/tests/unit/modules/dcnm/test_dcnm_intf.py
@@ -31,21 +31,17 @@ import copy
 class TestDcnmIntfModule(TestDcnmModule):
 
     module = dcnm_interface
-
     fd = None
 
     def init_data(self):
-        pass
+        self.fd = None
 
     def log_msg(self, msg):
 
-        if fd is None:
-            fd = open("intf-ut.log", "w")
+        if self.fd is None:
+            self.fd = open("intf-ut.log", "w")
         self.fd.write(msg)
         self.fd.flush()
-
-    def log_msg(self, msg):
-        self.fd.write(msg)
 
     def setUp(self):
 
@@ -121,6 +117,42 @@ class TestDcnmIntfModule(TestDcnmModule):
                 self.playbook_mock_succ_resp,
                 playbook_deployed_data,
             ]
+
+        if ("_multi_intf_merged_exist" in self._testMethodName):
+            # No I/F exists case
+            playbook_pc_intf  = self.payloads_data.get("pc_payload")
+            playbook_lo_intf  = self.payloads_data.get("lo_payload")
+            playbook_eth_intf = self.payloads_data.get("eth_payload")
+            playbook_subint_intf = self.payloads_data.get("subint_payload")
+            playbook_vpc_intf = self.payloads_data.get("vpc_payload")
+            playbook_have_all_data  = self.have_all_payloads_data.get("payloads")
+            playbook_deployed_data  = self.have_all_payloads_data.get("deployed_payloads")
+
+            self.run_dcnm_send.side_effect = [
+                self.playbook_mock_vpc_resp,
+                self.playbook_mock_vpc_resp,
+                playbook_pc_intf,
+                playbook_vpc_intf,
+                playbook_subint_intf,
+                playbook_lo_intf,
+                playbook_eth_intf,
+                playbook_have_all_data,
+                playbook_have_all_data,
+                self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+                playbook_deployed_data]
 
     def load_missing_intf_elems_fixtures(self):
 
@@ -1364,6 +1396,39 @@ class TestDcnmIntfModule(TestDcnmModule):
                     True,
                 )
 
+    def test_dcnm_intf_multi_intf_merged_exist(self):
+
+        # load the json from playbooks
+        self.config_data     = loadPlaybookData("dcnm_intf_multi_intf_configs")
+        self.have_all_payloads_data  = loadPlaybookData("dcnm_intf_have_all_payloads")
+        self.payloads_data   = loadPlaybookData("dcnm_intf_multi_intf_payloads")
+
+        # load required config data
+        self.playbook_config         = self.config_data.get("multi_intf_merged_config_exist")
+        self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
+        self.playbook_mock_vpc_resp  = self.config_data.get("mock_vpc_resp")
+        self.mock_ip_sn              = self.config_data.get("mock_ip_sn")
+        self.mock_fab_inv            = self.config_data.get("mock_fab_inv_data")
+
+        set_module_args(dict(state="merged",
+                             fabric="test_fabric",
+                             config=self.playbook_config))
+        result = self.execute_module(changed=True, failed=False)
+
+        self.assertEqual(len(result["diff"][0]["merged"]), 5)
+        for d in result["diff"][0]["merged"]:
+            for intf in d["interfaces"]:
+                self.assertEqual ((intf["ifName"] in ["Port-channel300",
+                                                      "vPC301",
+                                                      "Ethernet1/1.1",
+                                                      "Ethernet1/10",
+                                                      "Loopback303"]), True)
+                for key in intf["nvPairs"]:
+                    if "MEMBER_INTERFACES" in key:
+                        self.assertEqual (len(intf["nvPairs"][key].split(",")), 2)
+                    if "CONF" in key:
+                        self.assertEqual (len(intf["nvPairs"][key].split("\n")), 2)
+
     def test_dcnm_intf_missing_intf_elems_merged_new(self):
 
         # load the json from playbooks
@@ -1593,6 +1658,7 @@ class TestDcnmIntfModule(TestDcnmModule):
             "PREFIX",
             "ROUTING_TAG",
             "SPEED",
+            "CONF"
         ]
 
         for d in result["diff"][0]["replaced"]:
@@ -2436,7 +2502,9 @@ class TestDcnmIntfModule(TestDcnmModule):
             "PEER2_ACCESS_VLAN",
             "PEER1_CONF",
             "PEER2_CONF",
-            "INTF_NAME",
+            "PEER1_PO_CONF",
+            "PEER2_PO_CONF",
+            "INTF_NAME"
         ]
 
         for d in result["diff"][0]["replaced"]:


### PR DESCRIPTION
ISSUE: #137

DESCRIPTION:

    During merge operation for an existing interface, aggregate objects like member interfaces, freeform config etc are being replaced. This issue was raised to change this behaviour.

FIX:

    This code change will enable merge of aggregate objects instead of replacing them during merge. This is only applicable to aggregate objects (lists) and behaviour in the case of all other objects remains the same