### PR TITLE
Fix for issue 139 - description is empty during update with polict ID

### DIFF
--- a/tests/integration/targets/dcnm_policy/tests/dcnm/dcnm_policy_modify.yaml
+++ b/tests/integration/targets/dcnm_policy/tests/dcnm/dcnm_policy_modify.yaml
@@ -138,6 +138,15 @@
         index_var: my_idx
       register: result
 
+    # Assert for description being non-empty
+    - assert:
+        that:
+          - 'item["description"] != ""'
+      when: (my_idx < (result.results[0]["diff"][0]["merged"] | length))
+      loop: '{{ result.results[0]["diff"][0]["merged"] }}'
+      loop_control:
+        index_var: my_idx
+
     # Assert for Create responses
     - assert:
         that:

--- a/tests/unit/modules/dcnm/fixtures/dcnm_policy_configs.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_policy_configs.json
@@ -222,7 +222,7 @@
   "modify_policy_104_with_policy_id" : [
   {
     "create_additional_policy": false,
-    "description": "modifying policy with template name",
+    "description": "modifying policy with policy ID",
     "name": "POLICY-123840",
     "priority": 904
   },

--- a/tests/unit/modules/dcnm/test_dcnm_policy.py
+++ b/tests/unit/modules/dcnm/test_dcnm_policy.py
@@ -1154,6 +1154,8 @@ class TestDcnmPolicyModule(TestDcnmModule):
         )
         result = self.execute_module(changed=True, failed=False)
 
+        self.assertEqual(result["diff"][0]["merged"][0]["description"], "modifying policy with policy ID")
+
         self.assertEqual(len(result["diff"][0]["merged"]), 1)
         self.assertEqual(len(result["diff"][0]["deleted"]), 0)
         self.assertEqual(len(result["diff"][0]["query"]), 0)


### PR DESCRIPTION
ISSUE: https://github.com/CiscoDevNet/ansible-dcnm/issues/139

DESCRIPTION:

    When an existing  policy is updated with policy ID, the description filed is being set to empty.

FIX:

    - "description" field is appropriately updated during update policy
    - Another issue that is fixed in this PR is allowing additional policy create using an existing policy ID
    - Added UT and IT cases for the same