### PR TITLE
Switch level deploy instead of fabric level deploy for policy module

### DIFF
--- a/docs/cisco.dcnm.dcnm_policy_module.rst
+++ b/docs/cisco.dcnm.dcnm_policy_module.rst
@@ -373,6 +373,8 @@ Examples
     #
     # Deleted:
     #   Policies defined in the playbook will be deleted in the target fabric.
+    #   
+    #   WARNING: Deleting a policy will deploy all pending configurations on the impacted switches.
     #
     # Query:
     #   Returns the current DCNM state for the policies listed in the playbook.

--- a/plugins/modules/dcnm_policy.py
+++ b/plugins/modules/dcnm_policy.py
@@ -367,7 +367,7 @@ class DcnmPolicy:
             "POLICY_DEPLOY": "/rest/control/policies/deploy",
             "POLICY_CFG_DEPLOY": "/rest/control/fabrics/{}/config-deploy/",
             "POLICY_WITH_POLICY_ID": "/rest/control/policies/{}",
-            "CONFIG_PREVIEW": "/rest/control/fabrics/{}/config-preview?forceShowRun=false&showBrief=true",
+            "CONFIG_PREVIEW": "/rest/control/fabrics/{}/config-preview/",
         },
         12: {
             "POLICY_WITH_ID": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/policies/{}",
@@ -377,7 +377,7 @@ class DcnmPolicy:
             "POLICY_DEPLOY": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/policies/deploy",
             "POLICY_CFG_DEPLOY": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{}/config-deploy/",
             "POLICY_WITH_POLICY_ID": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/policies/{}",
-            "CONFIG_PREVIEW": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{}/config-preview?forceShowRun=false&showBrief=true",
+            "CONFIG_PREVIEW": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{}/config-preview/",
         },
     }
 
@@ -1029,7 +1029,7 @@ class DcnmPolicy:
                 # Get the SYNC status of the switch. After deploy, the status
                 # MUST be "In-Sync". If not keep retrying
                 path = self.paths["CONFIG_PREVIEW"].format(self.fabric)
-                path = path + ",".join(del_snos)
+                path = path + ",".join(del_snos) + "?forceShowRun=false&showBrief=true"
 
                 cp_resp = dcnm_send(self.module, "GET", path, "")
 

--- a/plugins/modules/dcnm_policy.py
+++ b/plugins/modules/dcnm_policy.py
@@ -1286,8 +1286,6 @@ def main():
         dcnm_policy.config, dcnm_policy.ip_sn, dcnm_policy.hn_sn
     )
 
-    dcnm_policy.log_msg(f"MANAGABLE = {dcnm_policy.managable}\n")
-
     if module.params["state"] != "query":
         # Translate the given playbook config to some convenient format. Each policy should
         # have the switches to be deployed.

--- a/plugins/modules/dcnm_policy.py
+++ b/plugins/modules/dcnm_policy.py
@@ -177,7 +177,7 @@ EXAMPLES = """
 #
 # Deleted:
 #   Policies defined in the playbook will be deleted in the target fabric.
-#   
+#
 #   WARNING: Deleting a policy will deploy all pending configurations on the impacted switches.
 #
 # Query:

--- a/tests/integration/targets/dcnm_policy/tests/dcnm/dcnm_policy_delete.yaml
+++ b/tests/integration/targets/dcnm_policy/tests/dcnm/dcnm_policy_delete.yaml
@@ -2,6 +2,9 @@
 ##               SETUP                      ##
 ##############################################
 
+- name: Remove local log file
+  local_action: command rm -f policy.log
+
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_policy:
     fabric: "{{ ansible_it_fabric }}"

--- a/tests/integration/targets/dcnm_policy/tests/dcnm/dcnm_policy_merge.yaml
+++ b/tests/integration/targets/dcnm_policy/tests/dcnm/dcnm_policy_merge.yaml
@@ -2,6 +2,9 @@
 ##               SETUP                      ##
 ##############################################
 
+- name: Remove local log file
+  local_action: command rm -f policy.log
+
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_policy:
     fabric: "{{ ansible_it_fabric }}"

--- a/tests/integration/targets/dcnm_policy/tests/dcnm/dcnm_policy_merge_multi_switch.yaml
+++ b/tests/integration/targets/dcnm_policy/tests/dcnm/dcnm_policy_merge_multi_switch.yaml
@@ -2,6 +2,9 @@
 ##               SETUP                      ##
 ##############################################
 
+- name: Remove local log file
+  local_action: command rm -f policy.log
+
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_policy:
     fabric: "{{ ansible_it_fabric }}"

--- a/tests/integration/targets/dcnm_policy/tests/dcnm/dcnm_policy_merge_same_template.yaml
+++ b/tests/integration/targets/dcnm_policy/tests/dcnm/dcnm_policy_merge_same_template.yaml
@@ -2,6 +2,9 @@
 ##               SETUP                      ##
 ##############################################
 
+- name: Remove local log file
+  local_action: command rm -f policy.log
+
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_policy:
     fabric: "{{ ansible_it_fabric }}"

--- a/tests/integration/targets/dcnm_policy/tests/dcnm/dcnm_policy_modify.yaml
+++ b/tests/integration/targets/dcnm_policy/tests/dcnm/dcnm_policy_modify.yaml
@@ -2,6 +2,9 @@
 ##               SETUP                      ##
 ##############################################
 
+- name: Remove local log file
+  local_action: command rm -f policy.log
+
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_policy:
     fabric: "{{ ansible_it_fabric }}"

--- a/tests/integration/targets/dcnm_policy/tests/dcnm/dcnm_policy_query.yaml
+++ b/tests/integration/targets/dcnm_policy/tests/dcnm/dcnm_policy_query.yaml
@@ -2,6 +2,9 @@
 ##               SETUP                      ##
 ##############################################
 
+- name: Remove local log file
+  local_action: command rm -f policy.log
+
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_policy:
     fabric: "{{ ansible_it_fabric }}"

--- a/tests/integration/targets/dcnm_policy/tests/dcnm/dcnm_policy_with_vars_merge.yaml
+++ b/tests/integration/targets/dcnm_policy/tests/dcnm/dcnm_policy_with_vars_merge.yaml
@@ -2,6 +2,9 @@
 ##               SETUP                      ##
 ##############################################
 
+- name: Remove local log file
+  local_action: command rm -f policy.log
+
 - name: Put the fabric to default state
   cisco.dcnm.dcnm_policy:
     fabric: "{{ ansible_it_fabric }}"

--- a/tests/integration/targets/prepare_dcnm_policy/tasks/main.yaml
+++ b/tests/integration/targets/prepare_dcnm_policy/tasks/main.yaml
@@ -106,7 +106,7 @@
                   path sys/ch depth unbounded
                 subscription 3
                   dst-grp 3
-                  snsr-grp 2 sample-interval 30000
+                  snsr-grp 3 sample-interval 30000
 
           - name: template_104
             description: "Template_104"

--- a/tests/unit/modules/dcnm/fixtures/dcnm_policy_payloads.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_policy_payloads.json
@@ -1,4 +1,19 @@
 {
+  "mock_fab_inv": {
+      "10.10.10.224": {
+        "managable": true,
+        "serialNumber": "XYZKSJHSMK1"
+      },
+      "10.10.10.225": {
+        "managable": true,
+        "serialNumber": "XYZKSJHSMK2"
+      },
+      "10.10.10.226": {
+        "managable": true,
+        "serialNumber": "XYZKSJHSMK3"
+      }
+  },
+
   "mock_ip_sn" : {
     "10.10.10.224": "XYZKSJHSMK1",
       "10.10.10.225": "XYZKSJHSMK2",

--- a/tests/unit/modules/dcnm/test_dcnm_policy.py
+++ b/tests/unit/modules/dcnm/test_dcnm_policy.py
@@ -532,7 +532,7 @@ class TestDcnmPolicyModule(TestDcnmModule):
         self.payloads_data = loadPlaybookData("dcnm_policy_payloads")
 
         # get mock ip_sn and fabric_inventory_details
-        self.mock_fab_inv = []
+        self.mock_fab_inv = self.payloads_data.get("mock_fab_inv")
         self.mock_ip_sn = self.payloads_data.get("mock_ip_sn")
 
         # load required config data
@@ -580,7 +580,7 @@ class TestDcnmPolicyModule(TestDcnmModule):
         self.payloads_data = loadPlaybookData("dcnm_policy_payloads")
 
         # get mock ip_sn and fabric_inventory_details
-        self.mock_fab_inv = []
+        self.mock_fab_inv = self.payloads_data.get("mock_fab_inv")
         self.mock_ip_sn = self.payloads_data.get("mock_ip_sn")
 
         # load required config data
@@ -628,7 +628,7 @@ class TestDcnmPolicyModule(TestDcnmModule):
         self.payloads_data = loadPlaybookData("dcnm_policy_payloads")
 
         # get mock ip_sn and fabric_inventory_details
-        self.mock_fab_inv = []
+        self.mock_fab_inv = self.payloads_data.get("mock_fab_inv")
         self.mock_ip_sn = self.payloads_data.get("mock_ip_sn")
 
         # load required config data
@@ -659,7 +659,7 @@ class TestDcnmPolicyModule(TestDcnmModule):
         self.payloads_data = loadPlaybookData("dcnm_policy_payloads")
 
         # get mock ip_sn and fabric_inventory_details
-        self.mock_fab_inv = []
+        self.mock_fab_inv = self.payloads_data.get("mock_fab_inv")
         self.mock_ip_sn = self.payloads_data.get("mock_ip_sn")
 
         # load required config data
@@ -703,7 +703,7 @@ class TestDcnmPolicyModule(TestDcnmModule):
         self.payloads_data = loadPlaybookData("dcnm_policy_payloads")
 
         # get mock ip_sn and fabric_inventory_details
-        self.mock_fab_inv = []
+        self.mock_fab_inv = self.payloads_data.get("mock_fab_inv")
         self.mock_ip_sn = self.payloads_data.get("mock_ip_sn")
 
         # load required config data
@@ -751,7 +751,7 @@ class TestDcnmPolicyModule(TestDcnmModule):
         self.payloads_data = loadPlaybookData("dcnm_policy_payloads")
 
         # get mock ip_sn and fabric_inventory_details
-        self.mock_fab_inv = []
+        self.mock_fab_inv = self.payloads_data.get("mock_fab_inv")
         self.mock_ip_sn = self.payloads_data.get("mock_ip_sn")
 
         # load required config data
@@ -796,7 +796,7 @@ class TestDcnmPolicyModule(TestDcnmModule):
         self.payloads_data = loadPlaybookData("dcnm_policy_payloads")
 
         # get mock ip_sn and fabric_inventory_details
-        self.mock_fab_inv = []
+        self.mock_fab_inv = self.payloads_data.get("mock_fab_inv")
         self.mock_ip_sn = self.payloads_data.get("mock_ip_sn")
 
         # load required config data
@@ -846,7 +846,7 @@ class TestDcnmPolicyModule(TestDcnmModule):
         self.payloads_data = loadPlaybookData("dcnm_policy_payloads")
 
         # get mock ip_sn and fabric_inventory_details
-        self.mock_fab_inv = []
+        self.mock_fab_inv = self.payloads_data.get("mock_fab_inv")
         self.mock_ip_sn = self.payloads_data.get("mock_ip_sn")
 
         # load required config data
@@ -896,7 +896,7 @@ class TestDcnmPolicyModule(TestDcnmModule):
         self.payloads_data = loadPlaybookData("dcnm_policy_payloads")
 
         # get mock ip_sn and fabric_inventory_details
-        self.mock_fab_inv = []
+        self.mock_fab_inv = self.payloads_data.get("mock_fab_inv")
         self.mock_ip_sn = self.payloads_data.get("mock_ip_sn")
 
         # load required config data
@@ -952,7 +952,7 @@ class TestDcnmPolicyModule(TestDcnmModule):
         self.payloads_data = loadPlaybookData("dcnm_policy_payloads")
 
         # get mock ip_sn and fabric_inventory_details
-        self.mock_fab_inv = []
+        self.mock_fab_inv = self.payloads_data.get("mock_fab_inv")
         self.mock_ip_sn = self.payloads_data.get("mock_ip_sn")
 
         # load required config data
@@ -995,7 +995,7 @@ class TestDcnmPolicyModule(TestDcnmModule):
         self.payloads_data = loadPlaybookData("dcnm_policy_payloads")
 
         # get mock ip_sn and fabric_inventory_details
-        self.mock_fab_inv = []
+        self.mock_fab_inv = self.payloads_data.get("mock_fab_inv")
         self.mock_ip_sn = self.payloads_data.get("mock_ip_sn")
 
         # load required config data
@@ -1040,7 +1040,7 @@ class TestDcnmPolicyModule(TestDcnmModule):
         self.payloads_data = loadPlaybookData("dcnm_policy_payloads")
 
         # get mock ip_sn and fabric_inventory_details
-        self.mock_fab_inv = []
+        self.mock_fab_inv = self.payloads_data.get("mock_fab_inv")
         self.mock_ip_sn = self.payloads_data.get("mock_ip_sn")
 
         # load required config data
@@ -1088,7 +1088,7 @@ class TestDcnmPolicyModule(TestDcnmModule):
         self.payloads_data = loadPlaybookData("dcnm_policy_payloads")
 
         # get mock ip_sn and fabric_inventory_details
-        self.mock_fab_inv = []
+        self.mock_fab_inv = self.payloads_data.get("mock_fab_inv")
         self.mock_ip_sn = self.payloads_data.get("mock_ip_sn")
 
         # load required config data
@@ -1138,7 +1138,7 @@ class TestDcnmPolicyModule(TestDcnmModule):
         self.payloads_data = loadPlaybookData("dcnm_policy_payloads")
 
         # get mock ip_sn and fabric_inventory_details
-        self.mock_fab_inv = []
+        self.mock_fab_inv = self.payloads_data.get("mock_fab_inv")
         self.mock_ip_sn = self.payloads_data.get("mock_ip_sn")
 
         # load required config data
@@ -1189,7 +1189,7 @@ class TestDcnmPolicyModule(TestDcnmModule):
         self.payloads_data = loadPlaybookData("dcnm_policy_payloads")
 
         # get mock ip_sn and fabric_inventory_details
-        self.mock_fab_inv = []
+        self.mock_fab_inv = self.payloads_data.get("mock_fab_inv")
         self.mock_ip_sn = self.payloads_data.get("mock_ip_sn")
 
         # load required config data
@@ -1238,7 +1238,7 @@ class TestDcnmPolicyModule(TestDcnmModule):
         self.payloads_data = loadPlaybookData("dcnm_policy_payloads")
 
         # get mock ip_sn and fabric_inventory_details
-        self.mock_fab_inv = []
+        self.mock_fab_inv = self.payloads_data.get("mock_fab_inv")
         self.mock_ip_sn = self.payloads_data.get("mock_ip_sn")
 
         # load required config data
@@ -1290,7 +1290,7 @@ class TestDcnmPolicyModule(TestDcnmModule):
         self.payloads_data = loadPlaybookData("dcnm_policy_payloads")
 
         # get mock ip_sn and fabric_inventory_details
-        self.mock_fab_inv = []
+        self.mock_fab_inv = self.payloads_data.get("mock_fab_inv")
         self.mock_ip_sn = self.payloads_data.get("mock_ip_sn")
 
         # load required config data
@@ -1340,7 +1340,7 @@ class TestDcnmPolicyModule(TestDcnmModule):
         self.payloads_data = loadPlaybookData("dcnm_policy_payloads")
 
         # get mock ip_sn and fabric_inventory_details
-        self.mock_fab_inv = []
+        self.mock_fab_inv = self.payloads_data.get("mock_fab_inv")
         self.mock_ip_sn = self.payloads_data.get("mock_ip_sn")
 
         # load required config data
@@ -1390,7 +1390,7 @@ class TestDcnmPolicyModule(TestDcnmModule):
         self.payloads_data = loadPlaybookData("dcnm_policy_payloads")
 
         # get mock ip_sn and fabric_inventory_details
-        self.mock_fab_inv = []
+        self.mock_fab_inv = self.payloads_data.get("mock_fab_inv")
         self.mock_ip_sn = self.payloads_data.get("mock_ip_sn")
 
         # load required config data
@@ -1426,7 +1426,7 @@ class TestDcnmPolicyModule(TestDcnmModule):
         self.payloads_data = loadPlaybookData("dcnm_policy_payloads")
 
         # get mock ip_sn and fabric_inventory_details
-        self.mock_fab_inv = []
+        self.mock_fab_inv = self.payloads_data.get("mock_fab_inv")
         self.mock_ip_sn = self.payloads_data.get("mock_ip_sn")
 
         # load required config data
@@ -1456,7 +1456,7 @@ class TestDcnmPolicyModule(TestDcnmModule):
         self.payloads_data = loadPlaybookData("dcnm_policy_payloads")
 
         # get mock ip_sn and fabric_inventory_details
-        self.mock_fab_inv = []
+        self.mock_fab_inv = self.payloads_data.get("mock_fab_inv")
         self.mock_ip_sn = self.payloads_data.get("mock_ip_sn")
 
         # load required config data
@@ -1486,7 +1486,7 @@ class TestDcnmPolicyModule(TestDcnmModule):
         self.payloads_data = loadPlaybookData("dcnm_policy_payloads")
 
         # get mock ip_sn and fabric_inventory_details
-        self.mock_fab_inv = []
+        self.mock_fab_inv = self.payloads_data.get("mock_fab_inv")
         self.mock_ip_sn = self.payloads_data.get("mock_ip_sn")
 
         # load required config data
@@ -1516,7 +1516,7 @@ class TestDcnmPolicyModule(TestDcnmModule):
         self.payloads_data = loadPlaybookData("dcnm_policy_payloads")
 
         # get mock ip_sn and fabric_inventory_details
-        self.mock_fab_inv = []
+        self.mock_fab_inv = self.payloads_data.get("mock_fab_inv")
         self.mock_ip_sn = self.payloads_data.get("mock_ip_sn")
 
         # load required config data
@@ -1546,7 +1546,7 @@ class TestDcnmPolicyModule(TestDcnmModule):
         self.payloads_data = loadPlaybookData("dcnm_policy_payloads")
 
         # get mock ip_sn and fabric_inventory_details
-        self.mock_fab_inv = []
+        self.mock_fab_inv = self.payloads_data.get("mock_fab_inv")
         self.mock_ip_sn = self.payloads_data.get("mock_ip_sn")
 
         # load required config data


### PR DESCRIPTION
In the DCNM module there is no option to push individual policy changes during DELETE operations. In the current implementation, a Fabric level config deploy is executed after DELETE of Policies. In large fabrics this may take considerable time (because of fabric level deploy) even if the DELETE operation is restricted to a few switches. 
To solve this problem, once a Policy is deleted, deploy operation is executed only for the specific switches which are impacted by the DELETE. This way the operation will be much quicker.

NOTE: Even if a single policy is deleted, a switch level deploy will deploy all the pending configuration with respect to the switch. 