### PR TITLE
Fix for network module traceback

### DIFF
--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -2415,9 +2415,9 @@ class DcnmNetwork:
 
         if cfg.get("is_l2only", None) is None:
             json_to_dict_want["isLayer2Only"] = json_to_dict_have["isLayer2Only"]
-            if json_to_dict_want["isLayer2Only"].lower() == "true":
+            if str(json_to_dict_want["isLayer2Only"]).lower() == "true":
                 json_to_dict_want["isLayer2Only"] = True
-            elif json_to_dict_want["isLayer2Only"].lower() == "false":
+            elif str(json_to_dict_want["isLayer2Only"]).lower() == "false":
                 json_to_dict_want["isLayer2Only"] = False
 
         if cfg.get("vlan_name", None) is None:
@@ -2433,9 +2433,9 @@ class DcnmNetwork:
 
         if cfg.get("arp_suppress", None) is None:
             json_to_dict_want["suppressArp"] = json_to_dict_have["suppressArp"]
-            if json_to_dict_want["suppressArp"].lower() == "true":
+            if str(json_to_dict_want["suppressArp"]).lower() == "true":
                 json_to_dict_want["suppressArp"] = True
-            elif json_to_dict_want["suppressArp"].lower() == "false":
+            elif str(json_to_dict_want["suppressArp"]).lower() == "false":
                 json_to_dict_want["suppressArp"] = False
 
         if cfg.get("dhcp_srvr1_ip", None) is None:


### PR DESCRIPTION
Fixes the issue in #169 

DESCRIPTION:

DCNM network module generates traceback on attaching switches to an existing network.

FIX:

- 'isLayer2Only' and 'suppressArp' are bool params, but were treated as string params. Fixed  it