### PR TITLE
Changes to add retry limit to send API on 401 return code scenarios

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -13,5 +13,5 @@ description: Ansible collection for the Cisco Nexus® Dashboard Fabric Controlle
 license_file: LICENSE 
 tags: [cisco, ndfc, dcnm, nxos, networking, vxlan]
 dependencies:
-  "ansible.netcommon": "*"
+  "ansible.netcommon": ">=2.6.1"
 repository: https://github.com/CiscoDevNet/ansible-dcnm

--- a/plugins/httpapi/dcnm.py
+++ b/plugins/httpapi/dcnm.py
@@ -42,7 +42,7 @@ class HttpApi(HttpApiBase):
         self.headers = {"Content-Type": "application/json"}
         self.txt_headers = {"Content-Type": "text/plain"}
         self.version = None
-        self.retrycnt = 5  # Retry count for send API
+        self.retrycnt = 5   #  Retry count for send API
 
     def get_version(self):
         return self.version

--- a/plugins/httpapi/dcnm.py
+++ b/plugins/httpapi/dcnm.py
@@ -42,7 +42,8 @@ class HttpApi(HttpApiBase):
         self.headers = {"Content-Type": "application/json"}
         self.txt_headers = {"Content-Type": "text/plain"}
         self.version = None
-        self.retrycnt = 5   #  Retry count for send API
+        # Retry count for send API
+        self.retrycnt = 5
 
     def get_version(self):
         return self.version

--- a/plugins/httpapi/dcnm.py
+++ b/plugins/httpapi/dcnm.py
@@ -43,7 +43,7 @@ class HttpApi(HttpApiBase):
         self.txt_headers = {"Content-Type": "text/plain"}
         self.version = None
         # Retry count for send API
-        self.retrycnt = 5
+        self.retrycount = 5
 
     def get_version(self):
         return self.version
@@ -282,10 +282,11 @@ class HttpApi(HttpApiBase):
                 msg = "Value of <path> does not appear to be formated properly"
                 raise ConnectionError(self._return_info(None, method, path, msg))
             response, rdata = self.connection.send(
-                path, json, self.retrycnt, method=method, headers=self.headers, force_basic_auth=True
+                path, json, self.retrycount, method=method, headers=self.headers, force_basic_auth=True
             )
             return self._verify_response(response, method, path, rdata)
         except Exception as e:
+            # In some cases netcommon raises execeptions without arguments, so check for exception args.
             if e.args:
                 eargs = e.args[0]
             else:
@@ -312,13 +313,14 @@ class HttpApi(HttpApiBase):
             response, rdata = self.connection.send(
                 path,
                 txt,
-                self.retrycnt,
+                self.retrycount,
                 method=method,
                 headers=self.txt_headers,
                 force_basic_auth=True,
             )
             return self._verify_response(response, method, path, rdata)
         except Exception as e:
+            # In some cases netcommon raises execeptions without arguments, so check for exception args.
             if e.args:
                 eargs = e.args[0]
             else:

--- a/plugins/httpapi/dcnm.py
+++ b/plugins/httpapi/dcnm.py
@@ -42,7 +42,7 @@ class HttpApi(HttpApiBase):
         self.headers = {"Content-Type": "application/json"}
         self.txt_headers = {"Content-Type": "text/plain"}
         self.version = None
-        self.retrycnt = 5 # Retry count for send API
+        self.retrycnt = 5  # Retry count for send API
 
     def get_version(self):
         return self.version


### PR DESCRIPTION
Fixes issue in #168 

DESCRIPTION:

DCNM return 401 for various scenarios like fabric not present. Current send call to net common retries continuously to login whenever 401 error is returned for a send request, and this happens until session timeout is reached.

FIX:

- Added retry count to send API, now send ill error out once the retry limit is reached. 
- Bumped min required netcommon(send API supports retry count from netcommon version 2.6.1 onwards)