### PR TITLE
Update galaxy file license key

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,7 +10,7 @@ authors:
   - Mike Wiebe <mikewiebe>
   - Praveen Ramoorthy <praveenramoorthy>
 description: Ansible collection for the Cisco Nexus® Dashboard Fabric Controller (NDFC) - formerly DCNM
-license_file: LICENSE 
+license: LICENSE 
 tags: [cisco, ndfc, dcnm, nxos, networking, vxlan]
 dependencies:
   "ansible.netcommon": ">=2.6.1"


### PR DESCRIPTION
Change Reason:

If you want to display a license on your collection page in Automation Hub, you will need to use the `license` key in your galaxy.yml file, not the `license_file` key