### PR TITLE
Fix for mcast unicast issue

### DIFF
--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -2184,7 +2184,7 @@ class DcnmNetwork:
                 dhcp_srvr2_vrf=dict(type="str", length_max=32),
                 dhcp_srvr3_vrf=dict(type="str", length_max=32),
                 dhcp_loopback_id=dict(type="int", range_min=0, range_max=1023),
-                multicast_group_address=dict(type="ipv4", default="239.1.1.0"),
+                multicast_group_address=dict(type="ipv4"),
             )
             att_spec = dict(
                 ip_address=dict(required=True, type="str"),
@@ -2248,7 +2248,7 @@ class DcnmNetwork:
                 dhcp_srvr2_vrf=dict(type="str", length_max=32),
                 dhcp_srvr3_vrf=dict(type="str", length_max=32),
                 dhcp_loopback_id=dict(type="int", range_min=0, range_max=1023),
-                multicast_group_address=dict(type="ipv4", default="239.1.1.0"),
+                multicast_group_address=dict(type="ipv4"),
             )
             att_spec = dict(
                 ip_address=dict(required=True, type="str"),

--- a/tests/integration/targets/dcnm_network/tests/dcnm/self-contained-tests/sm_mcast_update.yaml
+++ b/tests/integration/targets/dcnm_network/tests/dcnm/self-contained-tests/sm_mcast_update.yaml
@@ -4,7 +4,7 @@
     state: deleted
 
 - name: Create network with initial DEFAULT mcast parameter value
-  cisco.dcnm.dcnm_network:
+  cisco.dcnm.dcnm_network: &create
     fabric: "{{ test_fabric }}"
     state: merged
     config:
@@ -29,18 +29,27 @@
   cisco.dcnm.dcnm_network:
     fabric: "{{ test_fabric }}"
     state: query
-  register: result
+  register: query_result
   until:
-    - "result.response[0].parent.networkStatus is search('DEPLOYED')"
+    - "query_result.response[0].parent.networkStatus is search('DEPLOYED')"
   retries: 30
   delay: 2
 
 - assert:
     that:
-    - "result.response[0].parent.networkTemplateConfig.mcastGroup is search('239.1.1.1|239.1.1.0')"
+    - 'result.changed == true'
+    - "query_result.response[0].parent.networkTemplateConfig.mcastGroup is search('239.1.1.1|239.1.1.0')"
+
+- name: Idempotence Check - Create network with initial DEFAULT mcast parameter value
+  cisco.dcnm.dcnm_network: *create
+  register: result
+
+- assert:
+    that:
+    - 'result.changed == false'
 
 - name: Change mcast parameter values
-  cisco.dcnm.dcnm_network:
+  cisco.dcnm.dcnm_network: &change
     fabric: "{{ test_fabric }}"
     state: merged
     config:
@@ -65,12 +74,21 @@
   cisco.dcnm.dcnm_network:
     fabric: "{{ test_fabric }}"
     state: query
-  register: result
+  register: query_result
   until:
-    - "result.response[0].parent.networkStatus is search('DEPLOYED')"
+    - "query_result.response[0].parent.networkStatus is search('DEPLOYED')"
   retries: 30
   delay: 2
 
 - assert:
     that:
-    - "result.response[0].parent.networkTemplateConfig.mcastGroup is search('230.55.24.155')"
+    - 'result.changed == true'
+    - "query_result.response[0].parent.networkTemplateConfig.mcastGroup is search('230.55.24.155')"
+
+- name: Idempotence Check - Change mcast parameter values
+  cisco.dcnm.dcnm_network: *change
+  register: result
+
+- assert:
+    that:
+    - 'result.changed == false'


### PR DESCRIPTION
This update removes the default value for the `multicast_group_address` property.  There are several issues that occur when we set a default value for this property:

* An error is generated for unicast only fabrics (Where the ingress-replication) setting is being used instead of mcast.
* The default value is set by the fabric creator in the fabric template so it does not make sense to pick one for the module.

Addresses issue: https://github.com/CiscoDevNet/ansible-dcnm/issues/185

Validation:
* Tested against dcnm 11.5
* Tested against ndfc 2.2(1h)
* Added idempotence tests for default and non-defaut mcast values