### PR TITLE
Fix in dcnm_policy module to consider deploy flag during DELETE operations

### DIFF
--- a/plugins/modules/dcnm_policy.py
+++ b/plugins/modules/dcnm_policy.py
@@ -416,7 +416,11 @@ class DcnmPolicy:
         )
 
         # Get all switches which are managable. Will be required to check deploy status.
-        self.managable = [self.inventory_data[key]["serialNumber"] for key in self.inventory_data.keys() if self.inventory_data[key]["managable"]]
+        self.managable = [
+            self.inventory_data[key]["serialNumber"]
+            for key in self.inventory_data.keys()
+            if self.inventory_data[key]["managable"]
+        ]
         self.ip_sn, self.hn_sn = get_ip_sn_dict(self.inventory_data)
 
         self.result = dict(changed=False, diff=[], response=[])
@@ -919,8 +923,10 @@ class DcnmPolicy:
         while retries < 3:
             resp = dcnm_send(self.module, command, path, json_payload)
 
-            if (resp.get("DATA", None) is not None) and (
-                resp["DATA"].get("failureList", None) is not None
+            if (
+                (resp.get("DATA", None) is not None)
+                and (isinstance(resp["DATA"], dict))
+                and (resp["DATA"].get("failureList", None) is not None)
             ):
                 if isinstance(resp["DATA"]["failureList"], list):
                     fl = resp["DATA"]["failureList"][0]
@@ -930,10 +936,6 @@ class DcnmPolicy:
                 if "is not unique" in fl.get("message", ""):
                     retries = retries + 1
                     continue
-
-                break
-
-            # Don't think we need two break statements here.  Test and remove.
             break
 
         self.result["response"].append(resp)
@@ -1036,7 +1038,11 @@ class DcnmPolicy:
                     # Get the SYNC status of the switch. After deploy, the status
                     # MUST be "In-Sync". If not keep retrying
                     path = self.paths["CONFIG_PREVIEW"].format(self.fabric)
-                    path = path + ",".join(del_snos) + "?forceShowRun=false&showBrief=true"
+                    path = (
+                        path
+                        + ",".join(del_snos)
+                        + "?forceShowRun=false&showBrief=true"
+                    )
 
                     cp_resp = dcnm_send(self.module, "GET", path, "")
 

--- a/plugins/modules/dcnm_policy.py
+++ b/plugins/modules/dcnm_policy.py
@@ -1015,68 +1015,60 @@ class DcnmPolicy:
                 self.result["response"].append(resp)
                 self.module.fail_json(msg=resp)
 
-        # Once all policies are deleted, do a switch level deploy so that the deleted policies are removed from the
-        # switch
-        if (snos != []) and (mark_delete_flag is True):
+        # Even for delete cases check the deploy flag and proceed
+        if self.deploy is True:
+            # Once all policies are deleted, do a switch level deploy so that the deleted policies are removed from the
+            # switch
+            if (snos != []) and (mark_delete_flag is True):
 
-            # make a copy of snos. We will be updating snos in the following loop. But snos will be required
-            # further down
-            del_snos = snos.copy()
-            retries = 0
-            while retries < 50:
+                # make a copy of snos. We will be updating snos in the following loop. But snos will be required
+                # further down
+                del_snos = snos.copy()
+                retries = 0
+                while retries < 50:
 
-                retries += 1
-                resp = self.dcnm_policy_deploy_to_switches(del_snos)
+                    retries += 1
+                    resp = self.dcnm_policy_deploy_to_switches(del_snos)
 
-                if resp and (resp["RETURN_CODE"] != 200):
-                    self.module.fail_json(msg=resp)
+                    if resp and (resp["RETURN_CODE"] != 200):
+                        self.module.fail_json(msg=resp)
 
-                # Get the SYNC status of the switch. After deploy, the status
-                # MUST be "In-Sync". If not keep retrying
-                path = self.paths["CONFIG_PREVIEW"].format(self.fabric)
-                path = path + ",".join(del_snos) + "?forceShowRun=false&showBrief=true"
+                    # Get the SYNC status of the switch. After deploy, the status
+                    # MUST be "In-Sync". If not keep retrying
+                    path = self.paths["CONFIG_PREVIEW"].format(self.fabric)
+                    path = path + ",".join(del_snos) + "?forceShowRun=false&showBrief=true"
 
-                cp_resp = dcnm_send(self.module, "GET", path, "")
+                    cp_resp = dcnm_send(self.module, "GET", path, "")
 
-                if cp_resp.get("RETURN_CODE", 0) == 200:
-                    match_data = [
-                        item
-                        for item in cp_resp.get("DATA", [])
-                        if item["switchId"] in del_snos
-                    ]
-                else:
-                    self.module.fail_json(msg=cp_resp)
-
-                retry = False
-                for item in match_data:
-                    if item["status"].lower() != "in-sync":
-                        retry = True
+                    if cp_resp.get("RETURN_CODE", 0) == 200:
+                        match_data = [
+                            item
+                            for item in cp_resp.get("DATA", [])
+                            if item["switchId"] in del_snos
+                        ]
                     else:
-                        # remove the sno which is in "in-sync" from del_snos list
-                        del_snos.remove(item["switchId"])
-                if retry:
-                    time.sleep(1)
-                else:
-                    break
+                        self.module.fail_json(msg=cp_resp)
 
-        # Now use 'DELETE' command to delete the policies on the DCNM server
-        for ditem in delete:
-            # First check if the policy to be deleted exist.
-            path = self.paths["POLICY_WITH_POLICY_ID"].format(ditem)
+                    retry = False
+                    for item in match_data:
+                        if item["status"].lower() != "in-sync":
+                            retry = True
+                        else:
+                            # remove the sno which is in "in-sync" from del_snos list
+                            del_snos.remove(item["switchId"])
+                    if retry:
+                        time.sleep(1)
+                    else:
+                        break
 
-            resp = dcnm_send(self.module, "GET", path, "")
+            # Now use 'DELETE' command to delete the policies on the DCNM server
+            for ditem in delete:
+                # First check if the policy to be deleted exist.
+                path = self.paths["POLICY_WITH_POLICY_ID"].format(ditem)
 
-            if resp and isinstance(resp, list):
-                resp = resp[0]
-            if (
-                resp
-                and (resp.get("DATA", None) is not None)
-                and (resp["RETURN_CODE"] == 200)
-                and resp["MESSAGE"] == "OK"
-            ):
-                resp = self.dcnm_policy_delete_policy(ditem, False)
+                resp = dcnm_send(self.module, "GET", path, "")
 
-                if isinstance(resp, list):
+                if resp and isinstance(resp, list):
                     resp = resp[0]
                 if (
                     resp
@@ -1084,16 +1076,26 @@ class DcnmPolicy:
                     and (resp["RETURN_CODE"] == 200)
                     and resp["MESSAGE"] == "OK"
                 ):
-                    if "Deleted successfully" in resp["DATA"]["message"]:
-                        delete_flag = True
-                        self.result["response"].append(resp)
+                    resp = self.dcnm_policy_delete_policy(ditem, False)
 
-        # Once all policies are deleted, do a switch level deploy so that the deleted policies are removed from the
-        # switch
-        if (snos != []) and (delete_flag is True):
-            self.dcnm_policy_deploy_to_switches(snos)
-            if resp and (resp["RETURN_CODE"] != 200):
-                self.module.fail_json(msg=resp)
+                    if isinstance(resp, list):
+                        resp = resp[0]
+                    if (
+                        resp
+                        and (resp.get("DATA", None) is not None)
+                        and (resp["RETURN_CODE"] == 200)
+                        and resp["MESSAGE"] == "OK"
+                    ):
+                        if "Deleted successfully" in resp["DATA"]["message"]:
+                            delete_flag = True
+                            self.result["response"].append(resp)
+
+            # Once all policies are deleted, do a switch level deploy so that the deleted policies are removed from the
+            # switch
+            if (snos != []) and (delete_flag is True):
+                self.dcnm_policy_deploy_to_switches(snos)
+                if resp and (resp["RETURN_CODE"] != 200):
+                    self.module.fail_json(msg=resp)
 
         for policy in self.diff_create:
             # POP the 'create_additional_policy' object before sending create
@@ -1136,11 +1138,7 @@ class DcnmPolicy:
                 and (resp["MESSAGE"] == "OK")
                 and (resp.get("DATA", None) is not None)
             ):
-                if resp["DATA"].get("successList", None) is not None:
-                    if "is created successfully" in resp["DATA"][
-                        "successList"
-                    ][0].get("message"):
-                        create_flag = True
+                create_flag = True
             else:
                 self.module.fail_json(msg=resp)
 

--- a/tests/integration/targets/dcnm_policy/tests/dcnm/dcnm_policy_delete.yaml
+++ b/tests/integration/targets/dcnm_policy/tests/dcnm/dcnm_policy_delete.yaml
@@ -393,6 +393,94 @@
       loop_control:
         index_var: my_idx
 
+    - name: Create policy for a template - to check for delete without deploy
+      cisco.dcnm.dcnm_policy:
+        fabric: "{{ ansible_it_fabric }}"
+        state: merged
+        config:
+          - name: template_101  # name is mandatory
+            create_additional_policy: false  # Create a policy even if it already exists
+
+          - switch:
+              - ip: "{{ ansible_switch1 }}"
+
+      register: result
+
+    - assert:
+        that:
+          - 'result.changed == true'
+          - '(result["diff"][0]["merged"] | length) == 1'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["query"] | length) == 0'
+          - '(result["diff"][0]["deploy"] | length) == 1'
+
+    # Assert for Create responses
+    - assert:
+        that:
+          - 'item["RETURN_CODE"] == 200'
+          - '"is created successfully" in item["DATA"]["successList"][0]["message"]'
+      when: (my_idx < (result["diff"][0]["merged"] | length))
+      loop: '{{ result.response }}'
+      loop_control:
+        index_var: my_idx
+
+    # Assert for deploy responses
+    - assert:
+        that:
+          - 'item["RETURN_CODE"] == 200'
+          - '(item["DATA"][0]["successPTIList"].split(",") | length) == 1'
+      when: (my_idx == (result["diff"][0]["merged"] | length))
+      loop: '{{ result.response }}'
+      loop_control:
+        index_var: my_idx
+
+    - name: Delete policy using template name - without deploy
+      cisco.dcnm.dcnm_policy:
+        fabric: "{{ ansible_it_fabric }}"
+        deploy: false
+        state: deleted                     # only choose form [merged, deleted, query]
+        config:
+          - name: template_101  # This can either be a policy name like POLICY-xxxxx or template name
+          - switch:
+             - ip: "{{ ansible_switch1 }}"
+      register: result
+
+    - assert:
+        that:
+          - 'result.changed == true'
+          - '(result["diff"][0]["merged"] | length) == 0'
+          - '(result["diff"][0]["deleted"] | length) == 1'
+          - '(result["diff"][0]["query"] | length) == 0'
+          - '(result["response"] | length) == 1'
+
+    - assert:
+        that:
+          - 'result["response"][0]["RETURN_CODE"] == 200'
+          - 'result["response"][0]["MESSAGE"] == "OK"'
+
+    - name: Delete policy using template name - with deploy
+      cisco.dcnm.dcnm_policy:
+        fabric: "{{ ansible_it_fabric }}"
+        state: deleted                     # only choose form [merged, deleted, query]
+        config:
+          - name: template_101  # This can either be a policy name like POLICY-xxxxx or template name
+          - switch:
+             - ip: "{{ ansible_switch1 }}"
+      register: result
+
+    - assert:
+        that:
+          - 'result.changed == true'
+          - '(result["diff"][0]["merged"] | length) == 0'
+          - '(result["diff"][0]["deleted"] | length) == 1'
+          - '(result["diff"][0]["query"] | length) == 0'
+          - '(result["response"] | length) == 2'
+
+    - assert:
+        that:
+          - 'result["response"][0]["RETURN_CODE"] == 200'
+          - 'result["response"][0]["MESSAGE"] == "OK"'
+
 ##############################################
 ##                CLEANUP                   ##
 ##############################################


### PR DESCRIPTION
This PR includes code changes in

    - Policy module to check for deploy flag even during delete operations
    - IT test cases to check for delete without and with deploy flag being set