### PR TITLE
Uprev ansible supported version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This collection is intended for use with the following release versions:
 <!--start requires_ansible-->
 ## Ansible version compatibility
 
-This collection has been tested against following Ansible versions: **>=2.9.10,<2.13**.
+This collection has been tested against following Ansible versions: **>=2.9.10**.
 
 Plugins and modules within a collection may be tested with only specific Ansible versions.
 A collection may contain metadata that identifies these versions.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -3,7 +3,7 @@
 # will redirect to a common action plugin called cisco.dcnm.dcnm
 #
 #---
-requires_ansible: '>=2.9.10,<2.13'
+requires_ansible: ">=2.9.10"
 #plugin_routing:
 #  action:
 #    dcnm_inventory:


### PR DESCRIPTION
We need to upgrade the version of Ansible we support.  I made it consistent with the nxos ansible collection version and removed the upper bound.