### PR TITLE
Release 3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.1.1] - 2023-03-17
+
+### Fixed
+
+* Restrict installs of netcommon to versions `>=2.6.1,<=4.1.0` due to issue: https://github.com/CiscoDevNet/ansible-dcnm/issues/209
+
 ## [3.1.0] - 2023-03-14
 
 ### Added
@@ -232,6 +238,7 @@ The Ansible Cisco Data Center Network Manager (DCNM) collection includes modules
 * cisco.dcnm.dcnm_network	 - Add and remove Networks from a DCNM managed VXLAN fabric.
 * cisco.dcnm.dcnm_interface - DCNM Ansible Module for managing interfaces.
 
+[3.1.1]: https://github.com/CiscoDevNet/ansible-dcnm/compare/3.1.0...3.1.1
 [3.1.0]: https://github.com/CiscoDevNet/ansible-dcnm/compare/3.0.0...3.1.0
 [3.0.0]: https://github.com/CiscoDevNet/ansible-dcnm/compare/2.4.0...3.0.0
 [2.4.0]: https://github.com/CiscoDevNet/ansible-dcnm/compare/2.3.0...2.4.0

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You can also include it in a `requirements.yml` file and install it with `ansibl
 ---
 collections:
   - name: cisco.dcnm
-    version: 3.1.0
+    version: 3.1.1
 ```
 ## Using this collection
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -13,5 +13,5 @@ description: Ansible collection for the Cisco Nexus® Dashboard Fabric Controlle
 license: Apache-2.0
 tags: [cisco, ndfc, dcnm, nxos, networking, vxlan]
 dependencies:
-  "ansible.netcommon": ">=2.6.1"
+  "ansible.netcommon": ">=2.6.1,<=4.1.0"
 repository: https://github.com/CiscoDevNet/ansible-dcnm

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: cisco
 name: dcnm
-version: 3.1.0
+version: 3.1.1
 readme: README.md
 authors:
   - Shrishail Kariyappanavar <nkshrishail>


### PR DESCRIPTION
This is a hotfix to restrict installs of netcommon to versions `>=2.6.1,<=4.1.0` due to issue: https://github.com/CiscoDevNet/ansible-dcnm/issues/209