### PR TITLE
Added checks for fabric monitoring status and switch's managable attributes during deploy

### DIFF
--- a/plugins/modules/dcnm_links.py
+++ b/plugins/modules/dcnm_links.py
@@ -790,6 +790,7 @@ class DcnmLinks:
             "LINKS_GET_BY_FABRIC": "/rest/control/links/fabrics/{}",
             "LINKS_CFG_DEPLOY": "/rest/control/fabrics/{}/config-deploy/",
             "CONFIG_PREVIEW": "/rest/control/fabrics/{}/config-preview/",
+            "FABRIC_ACCESS_MODE": "/rest/control/fabrics/{}/accessmode",
         },
         12: {
             "LINKS_GET_BY_SWITCH_PAIR": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/links",
@@ -799,6 +800,7 @@ class DcnmLinks:
             "LINKS_GET_BY_FABRIC": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/links/fabrics/{}",
             "LINKS_CFG_DEPLOY": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{}/config-deploy/",
             "CONFIG_PREVIEW": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{}/config-preview/",
+            "FABRIC_ACCESS_MODE": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{}/accessmode",
         },
     }
 
@@ -865,6 +867,8 @@ class DcnmLinks:
         self.diff_modify = []
         self.diff_delete = []
         self.diff_deploy = {}
+        self.monitoring = []
+        self.meta_switches = []
         self.fd = None
         self.changed_dict = [
             {
@@ -900,6 +904,46 @@ class DcnmLinks:
             self.fd.write(msg)
             self.fd.write("\n")
             self.fd.flush()
+
+    def dcnm_dump_have_db(self):
+
+        lhave = []
+
+        for have in self.have:
+            lhave.append(
+                {
+                    "UUID": have["link-uuid"],
+                    "SRC FABRIC": have["sw1-info"]["fabric-name"],
+                    "SRC IF NAME": have["sw1-info"]["if-name"],
+                    "SRC SNO": have["sw1-info"]["sw-serial-number"],
+                    "SRC SYS NAME": have["sw1-info"]["sw-sys-name"],
+                    "DST FABRIC": have["sw2-info"]["fabric-name"],
+                    "DST IF NAME": have["sw2-info"]["if-name"],
+                    "DST SNO": have["sw2-info"]["sw-serial-number"],
+                    "DST SYS NAME": have["sw2-info"]["sw-sys-name"],
+                }
+            )
+        self.log_msg(f"HAVE = {lhave}\n")
+
+    def dcnm_print_have(self, have):
+
+        lhave = []
+
+        lhave.append(
+            {
+                "UUID": have["link-uuid"],
+                "SRC FABRIC": have["sw1-info"]["fabric-name"],
+                "SRC IF NAME": have["sw1-info"]["if-name"],
+                "SRC SNO": have["sw1-info"]["sw-serial-number"],
+                "SRC SYS NAME": have["sw1-info"]["sw-sys-name"],
+                "DST FABRIC": have["sw2-info"]["fabric-name"],
+                "DST IF NAME": have["sw2-info"]["if-name"],
+                "DST SNO": have["sw2-info"]["sw-serial-number"],
+                "DST SYS NAME": have["sw2-info"]["sw-sys-name"],
+            }
+        )
+
+        self.log_msg(f"have = {lhave}\n")
 
     def dcnm_links_compare_ip_addresses(self, addr1, addr2):
 
@@ -1375,19 +1419,44 @@ class DcnmLinks:
             "destinationFabric": link.get("dst_fabric"),
             "sourceInterface": link.get("src_interface"),
             "destinationInterface": link.get("dst_interface"),
-            "sourceDevice": self.ip_sn[link.get("src_device")],
-            "destinationDevice": self.ip_sn[link.get("dst_device")],
         }
+
+        if link.get("src_device") in self.ip_sn:
+            link_payload["sourceDevice"] = self.ip_sn[link.get("src_device")]
+        else:
+            link_payload["sourceDevice"] = self.hn_sn.get(
+                link["src_device"], ""
+            )
+
+        if link.get("dst_device") in self.ip_sn:
+            link_payload["destinationDevice"] = self.ip_sn[
+                link.get("dst_device")
+            ]
+        else:
+            link_payload["destinationDevice"] = self.hn_sn.get(
+                link["dst_device"], ""
+            )
+
+        # At this point link_payload will have sourceDevice set to proper SNO and destinationDevice is either
+        # set to a proper SNO or "".
+
+        if link_payload["sourceDevice"] in self.sn_hn:
+            link_payload["sourceSwitchName"] = self.sn_hn.get(
+                link_payload["sourceDevice"], "Switch1"
+            )
+        else:
+            link_payload["sourceSwitchName"] = link.get("src_device")
+
+        if link_payload["destinationDevice"] in self.sn_hn:
+            link_payload["destinationSwitchName"] = self.sn_hn.get(
+                link_payload["destinationDevice"], "Switch2"
+            )
+        else:
+            link_payload["destinationSwitchName"] = link.get("dst_device")
 
         if self.module.params["state"] == "deleted":
             return link_payload
 
-        link_payload["sourceSwitchName"] = self.sn_hn.get(
-            link_payload["sourceDevice"], "Switch1"
-        )
-        link_payload["destinationSwitchName"] = self.sn_hn.get(
-            link_payload["destinationDevice"], "Switch2"
-        )
         link_payload["templateName"] = link.get("template")
 
         # Intra and Inter fabric payloads are different. Build them separately
@@ -1918,10 +1987,27 @@ class DcnmLinks:
                     and (cfg["dst_fabric"] == want["destinationFabric"])
                     and (cfg["src_interface"] == want["sourceInterface"])
                     and (cfg["dst_interface"] == want["destinationInterface"])
-                    and (self.ip_sn[cfg["src_device"]] == want["sourceDevice"])
                     and (
-                        self.ip_sn[cfg["dst_device"]]
-                        == want["destinationDevice"]
+                        cfg["src_device"] in self.ip_sn
+                        and self.ip_sn[cfg["src_device"]]
+                        == want["sourceDevice"]
+                    )
+                    or (
+                        cfg["src_device"] in self.hn_sn
+                        and self.hn_sn[cfg["src_device"]]
+                        == want["sourceDevice"]
+                    )
+                    and (
+                        (
+                            cfg["dst_device"] in self.ip_sn
+                            and self.ip_sn[cfg["dst_device"]]
+                            == want["destinationDevice"]
+                        )
+                        or (
+                            cfg["dst_device"] in self.hn_sn
+                            and self.hn_sn[cfg["dst_device"]]
+                            == want["destinationDevice"]
+                        )
                     )
                     and (cfg["template"] == want["templateName"])
                 )
@@ -1978,14 +2064,22 @@ class DcnmLinks:
         """
 
         # link object is from self.want. These objets would have translated devices to serial numbers already.
-        path = self.paths[
-            "LINKS_GET_BY_SWITCH_PAIR"
-        ] + "?switch1Sn={0}&switch2Sn={1}".format(
-            link["sourceDevice"], link["destinationDevice"]
-        )
-        path = path + "&switch1IfName={0}&switch2IfName={1}".format(
-            link["sourceInterface"], link["destinationInterface"]
-        )
+
+        if (
+            link["sourceDevice"] in self.ip_sn.values()
+            and link["destinationDevice"] in self.ip_sn.values()
+        ):
+            path = self.paths[
+                "LINKS_GET_BY_SWITCH_PAIR"
+            ] + "?switch1Sn={0}&switch2Sn={1}".format(
+                link["sourceDevice"], link["destinationDevice"]
+            )
+            path = path + "&switch1IfName={0}&switch2IfName={1}".format(
+                link["sourceInterface"], link["destinationInterface"]
+            )
+        else:
+            # If devices are not managable, the path should not include them
+            path = self.paths["LINKS_GET_BY_SWITCH_PAIR"]
 
         resp = dcnm_send(self.module, "GET", path)
 
@@ -2014,6 +2108,31 @@ class DcnmLinks:
                     and (
                         link_elem["sw2-info"]["fabric-name"]
                         == link["destinationFabric"]
+                    )
+                    and (
+                        link["sourceDevice"]
+                        == link_elem["sw1-info"]["sw-serial-number"]
+                    )
+                    and (
+                        (
+                            link["destinationDevice"] in self.ip_sn.values()
+                            and link["destinationDevice"]
+                            == link_elem["sw2-info"]["sw-serial-number"]
+                        )
+                        or (
+                            link["destinationSwitchName"]
+                            + "-"
+                            + link["destinationFabric"]
+                            == link_elem["sw2-info"]["sw-serial-number"]
+                        )
+                    )
+                    and (
+                        link["sourceInterface"]
+                        == link_elem["sw1-info"]["if-name"]
+                    )
+                    and (
+                        link["destinationInterface"]
+                        == link_elem["sw2-info"]["if-name"]
                     )
                 )
             ]
@@ -2747,12 +2866,15 @@ class DcnmLinks:
                 )
                 and (
                     have["sw2-info"]["sw-serial-number"]
-                    == want["destinationDevice"]
+                    == want["destinationDevice"] or
+                    have["sw2-info"]["sw-serial-number"]
+                    == want["destinationSwitchName"] + "-" + want["destinationFabric"]
                 )
             )
         ]
 
         for mlink in match_have:
+
             if want["sourceFabric"] == want["destinationFabric"]:
                 return self.dcnm_links_compare_intra_fabric_link_params(
                     want, mlink
@@ -2816,7 +2938,7 @@ class DcnmLinks:
         if self.diff_deploy.get(fabric, "") == "":
             self.diff_deploy[fabric] = []
 
-        if device not in self.diff_deploy[fabric]:
+        if device != "" and device not in self.diff_deploy[fabric]:
             self.diff_deploy[fabric].append(device)
 
     def dcnm_links_get_diff_merge(self):
@@ -2867,12 +2989,37 @@ class DcnmLinks:
             #       If "deploy" flag is set to "true", then all pending configurations on the source and
             #       destination devices will be deployed.
             if self.deploy:
-                self.dcnm_links_update_diff_deploy(
-                    self.fabric, link["sourceDevice"]
-                )
-                self.dcnm_links_update_diff_deploy(
-                    link["destinationFabric"], link["destinationDevice"]
-                )
+
+                if (
+                    self.fabric not in self.monitoring
+                    and link["sourceDevice"] in self.managable.values()
+                ):
+                    self.dcnm_links_update_diff_deploy(
+                        self.fabric, link["sourceDevice"]
+                    )
+                else:
+                    self.dcnm_links_update_diff_deploy(self.fabric, "")
+
+                # If source swithces are not manageable, then do not deploy anything on destination fabric to
+                # avoid inconsitencies.
+                if link["sourceDevice"] in self.managable.values():
+                    if (
+                        link["destinationFabric"] not in self.monitoring
+                        and link["destinationDevice"]
+                        in self.managable.values()
+                    ):
+                        self.dcnm_links_update_diff_deploy(
+                            link["destinationFabric"],
+                            link["destinationDevice"],
+                        )
+                    else:
+                        self.dcnm_links_update_diff_deploy(
+                            link["destinationFabric"], ""
+                        )
+                else:
+                    self.dcnm_links_update_diff_deploy(
+                        link["destinationFabric"], ""
+                    )
 
         if self.diff_deploy != {}:
             self.changed_dict[0]["deploy"].append(
@@ -2893,6 +3040,7 @@ class DcnmLinks:
             None
         """
 
+        match_links = []
         for link in self.links_info:
 
             match_links = [
@@ -2904,12 +3052,18 @@ class DcnmLinks:
                     and (have["sw1-info"]["if-name"] == link["src_interface"])
                     and (have["sw2-info"]["if-name"] == link["dst_interface"])
                     and (
-                        have["sw1-info"]["sw-serial-number"]
-                        == self.ip_sn[link["src_device"]]
+                        link["src_device"] in self.ip_sn
+                        and have["sw1-info"]["sw-serial-number"]
+                        == self.ip_sn.get(link["src_device"], "")
+                        or have["sw1-info"]["sw-serial-number"]
+                        == self.hn_sn.get(link["src_device"], "")
                     )
                     and (
-                        have["sw2-info"]["sw-serial-number"]
-                        == self.ip_sn[link["dst_device"]]
+                        link["dst_device"] in self.ip_sn
+                        and have["sw2-info"]["sw-serial-number"]
+                        == self.ip_sn.get(link["dst_device"], "")
+                        or have["sw2-info"]["sw-serial-number"]
+                        == self.hn_sn.get(link["dst_device"], "")
                     )
                 )
             ]
@@ -2928,12 +3082,28 @@ class DcnmLinks:
                     }
                 )
 
-                self.dcnm_links_update_diff_deploy(
-                    self.fabric, self.ip_sn[link["src_device"]]
-                )
-                self.dcnm_links_update_diff_deploy(
-                    link["dst_fabric"], self.ip_sn[link["dst_device"]]
-                )
+                if self.deploy:
+                    if (
+                        self.fabric not in self.monitoring
+                        and link["src_device"] in self.managable
+                    ):
+                        self.dcnm_links_update_diff_deploy(
+                            self.fabric, self.ip_sn[link["src_device"]]
+                        )
+                    else:
+                        self.dcnm_links_update_diff_deploy(self.fabric, "")
+
+                    if (
+                        link["dst_fabric"] not in self.monitoring
+                        and link["dst_device"] in self.managable
+                    ):
+                        self.dcnm_links_update_diff_deploy(
+                            link["dst_fabric"], self.ip_sn[link["dst_device"]]
+                        )
+                    else:
+                        self.dcnm_links_update_diff_deploy(
+                            link["dst_fabric"], ""
+                        )
 
         if self.diff_deploy != {}:
             self.changed_dict[0]["deploy"].append(
@@ -2998,15 +3168,27 @@ class DcnmLinks:
                         and (
                             (link["src_device"] == "")
                             or (
-                                rlink["sw1-info"]["sw-serial-number"]
+                                link["src_device"] in self.ip_sn
+                                and rlink["sw1-info"]["sw-serial-number"]
                                 == self.ip_sn[link["src_device"]]
+                            )
+                            or (
+                                link["src_device"] in self.hn_sn
+                                and rlink["sw1-info"]["sw-serial-number"]
+                                == self.hn_sn[link["src_device"]]
                             )
                         )
                         and (
                             (link["dst_device"] == "")
                             or (
-                                rlink["sw2-info"]["sw-serial-number"]
+                                link["dst_device"] in self.ip_sn
+                                and rlink["sw2-info"]["sw-serial-number"]
                                 == self.ip_sn[link["dst_device"]]
+                            )
+                            or (
+                                link["dst_device"] in self.hn_sn
+                                and rlink["sw2-info"]["sw-serial-number"]
+                                == self.hn_sn[link["dst_device"]]
                             )
                         )
                         and (
@@ -3028,7 +3210,7 @@ class DcnmLinks:
         resp = {}
         resp["RETURN_CODE"] = 200
 
-        for fabric in self.diff_deploy.keys():
+        for fabric in self.diff_deploy:
             if self.diff_deploy[fabric] != []:
 
                 deploy_path = self.paths["LINKS_CFG_DEPLOY"].format(fabric)
@@ -3048,7 +3230,7 @@ class DcnmLinks:
 
         retry = False
 
-        for fabric in self.diff_deploy.keys():
+        for fabric in self.diff_deploy:
 
             if self.diff_deploy[fabric] != []:
 
@@ -3198,7 +3380,6 @@ class DcnmLinks:
         processed_fabrics.append(self.fabric)
 
         for cfg in self.config:
-
             # For every fabric included in the playbook, get the inventory details. This info is required
             # to get ip_sn, hn_sn and sn_hn details
             if cfg.get("dst_fabric", "") != "":
@@ -3209,9 +3390,51 @@ class DcnmLinks:
                     )
                     self.inventory_data.update(inv_data)
 
+        # Get all switches which are managable. Deploy must be avoided to all switches which are not part of this list
+        managable_ip = [
+            (key, self.inventory_data[key]["serialNumber"])
+            for key in self.inventory_data
+            if str(self.inventory_data[key]["managable"]).lower() == "true"
+        ]
+        managable_hosts = [
+            (
+                self.inventory_data[key]["logicalName"],
+                self.inventory_data[key]["serialNumber"],
+            )
+            for key in self.inventory_data
+            if str(self.inventory_data[key]["managable"]).lower() == "true"
+        ]
+        self.managable = dict(managable_ip + managable_hosts)
+
+        self.meta_switches = [
+            self.inventory_data[key]["logicalName"]
+            for key in self.inventory_data
+            if self.inventory_data[key]["switchRoleEnum"] is None
+        ]
+
+        # Get all fabrics which are in monitoring mode. Deploy must be avoided to all fabrics which are part of this list
+        for fabric in processed_fabrics:
+            path = self.paths["FABRIC_ACCESS_MODE"].format(fabric)
+            resp = dcnm_send(self.module, "GET", path)
+
+            if resp and resp["RETURN_CODE"] == 200:
+                if str(resp["DATA"]["readonly"]).lower() == "true":
+                    self.monitoring.append(fabric)
+
+        # Checkif source fabric is in monitoring mode. If so return an error, since fabrics in monitoring mode do not allow
+        # create/modify/delete and deploy operations.
+        if self.fabric in self.monitoring:
+            self.module.fail_json(
+                msg="Error: Source Fabric '{0}' is in Monitoring mode, No changes are allowed on the fabric\n".format(
+                    self.fabric
+                )
+            )
+
         # Based on the updated inventory_data, update ip_sn, hn_sn and sn_hn objects
         self.ip_sn, self.hn_sn = get_ip_sn_dict(self.inventory_data)
-        self.sn_hn = dict([(value, key) for key, value in self.hn_sn.items()])
+        self.sn_hn = dict(
+            [(value, key) for key, value in self.hn_sn.items() if value != ""]
+        )
 
     def dcnm_links_translate_playbook_info(self, config, ip_sn, hn_sn):
 
@@ -3236,13 +3459,22 @@ class DcnmLinks:
         for cfg in config:
 
             if cfg.get("src_device", "") != "":
-                cfg["src_device"] = dcnm_get_ip_addr_info(
-                    self.module, cfg["src_device"], ip_sn, hn_sn
-                )
+                if (
+                    cfg["src_device"] in self.ip_sn
+                    or cfg["src_device"] in self.hn_sn
+                ):
+                    cfg["src_device"] = dcnm_get_ip_addr_info(
+                        self.module, cfg["src_device"], ip_sn, hn_sn
+                    )
             if cfg.get("dst_device", "") != "":
-                cfg["dst_device"] = dcnm_get_ip_addr_info(
-                    self.module, cfg["dst_device"], ip_sn, hn_sn
-                )
+                if (
+                    cfg["dst_device"] in self.ip_sn
+                    or cfg["dst_device"] in self.hn_sn
+                    and cfg["dst_device"] not in self.meta_switches
+                ):
+                    cfg["dst_device"] = dcnm_get_ip_addr_info(
+                        self.module, cfg["dst_device"], ip_sn, hn_sn
+                    )
 
             if cfg.get("template", None) is not None:
                 cfg["template"] = self.templates.get(
@@ -3282,7 +3514,6 @@ def main():
             )
 
     dcnm_links.dcnm_links_update_inventory_data()
-
     dcnm_links.dcnm_links_translate_playbook_info(
         dcnm_links.config, dcnm_links.ip_sn, dcnm_links.hn_sn
     )
@@ -3312,6 +3543,12 @@ def main():
         dcnm_links.dcnm_links_get_diff_query()
 
     dcnm_links.result["diff"] = dcnm_links.changed_dict
+    dcnm_links.changed_dict[0]["debugs"].append(
+        {"Managable": dcnm_links.managable}
+    )
+    dcnm_links.changed_dict[0]["debugs"].append(
+        {"Monitoring": dcnm_links.monitoring}
+    )
 
     if dcnm_links.diff_create or dcnm_links.diff_delete:
         dcnm_links.result["changed"] = True

--- a/tests/integration/targets/dcnm_links/tests/dcnm/dcnm_links_misc.yaml
+++ b/tests/integration/targets/dcnm_links/tests/dcnm/dcnm_links_misc.yaml
@@ -1,0 +1,900 @@
+##############################################
+##               SETUP                      ##
+##############################################
+
+- name: Remove local log file
+  local_action: command rm -f dcnm_links.log
+
+- block:
+
+#############################################
+#               DELETE                     ##
+#############################################
+
+    - name: Initial setup - Delete Links on numbered fabric
+      cisco.dcnm.dcnm_links: &links_delete
+        state: deleted                                           # choose from [merged, replaced, deleted, query]
+        src_fabric: "{{ ansible_num_fabric }}"
+        config:
+          - dst_fabric: "{{ ansible_num_fabric }}"               # Destination fabric
+            src_interface: "{{ intf_1_3 }}"                      # Interface on the Source fabric
+            dst_interface: "{{ intf_1_3 }}"                      # Interface on the Destination fabric
+            src_device: "dummy-switch-1"                         # Device on the Source fabric
+            dst_device: "{{ ansible_num_switch1 }}"              # Device on the Destination fabric
+            template: ext_fabric_setup                           # template to be applied, choose from 
+                                                                 #   [ ext_fabric_setup, ext_multisite_underlay_setup,
+                                                                 #     ext_evpn_multisite_overlay_setup ]
+          - dst_fabric: "{{ ansible_svi_fabric }}"               # Destination fabric
+            src_interface: "{{ intf_1_3 }}"                      # Interface on the Source fabric
+            dst_interface: "{{ intf_1_3 }}"                      # Interface on the Destination fabric
+            src_device: "n9kv-test-sw1"                          # Device on the Source fabric
+            dst_device: "n9kv-test-sw3"                          # Device on the Destination fabric
+            template: ext_fabric_setup                           # template to be applied, choose from 
+                                                                 #   [ ext_fabric_setup, ext_multisite_underlay_setup,
+                                                                 #     ext_evpn_multisite_overlay_setup ]
+          - dst_fabric: "{{ ansible_svi_fabric }}"               # Destination fabric
+            src_interface: "{{ intf_1_4 }}"                      # Interface on the Source fabric
+            dst_interface: "{{ intf_1_4 }}"                      # Interface on the Destination fabric
+            src_device: "n9kv-test-sw1"                          # Device on the Source fabric
+            dst_device: "n9kv-test-sw100"                        # Device on the Destination fabric
+            template: ext_fabric_setup                           # template to be applied, choose from 
+                                                                 #   [ ext_fabric_setup, ext_multisite_underlay_setup,
+                                                                 #     ext_evpn_multisite_overlay_setup ]
+          - dst_fabric: "{{ ansible_svi_fabric }}"               # Destination fabric
+            src_interface: "{{ intf_1_5 }}"                      # Interface on the Source fabric
+            dst_interface: "{{ intf_1_5 }}"                      # Interface on the Destination fabric
+            src_device: "n9kv-test-sw1"                          # Device on the Source fabric
+            dst_device: "n9kv-svi1"                              # Device on the Destination fabric
+            template: ext_fabric_setup                           # template to be applied, choose from 
+                                                                 #   [ ext_fabric_setup, ext_multisite_underlay_setup,
+                                                                 #     ext_evpn_multisite_overlay_setup ]
+          - dst_fabric: "{{ ansible_svi_fabric }}"               # Destination fabric
+            src_interface: "{{ intf_1_6 }}"                      # Interface on the Source fabric
+            dst_interface: "{{ intf_1_6 }}"                      # Interface on the Destination fabric
+            src_device: "n9kv-num-1"                             # Device on the Source fabric
+            dst_device: "n9kv-test-sw3"                          # Device on the Destination fabric
+            template: ext_fabric_setup                           # template to be applied, choose from 
+                                                                 #   [ ext_fabric_setup, ext_multisite_underlay_setup,
+                                                                 #     ext_evpn_multisite_overlay_setup ]
+          - dst_fabric: "{{ ansible_svi_fabric }}"               # Destination fabric
+            src_interface: "{{ intf_1_7 }}"                      # Interface on the Source fabric
+            dst_interface: "{{ intf_1_7 }}"                      # Interface on the Destination fabric
+            src_device: "n9kv-num-1"                             # Device on the Source fabric
+            dst_device: "n9kv-svi1"                              # Device on the Destination fabric
+            template: ext_fabric_setup                           # template to be applied, choose from 
+                                                                 #   [ ext_fabric_setup, ext_multisite_underlay_setup,
+                                                                 #     ext_evpn_multisite_overlay_setup ]
+          - dst_fabric: "{{ ansible_ext_fabric }}"               # Destination fabric
+            src_interface: "{{ intf_1_8 }}"                      # Interface on the Source fabric
+            dst_interface: "{{ intf_1_8 }}"                      # Interface on the Destination fabric
+            src_device: "n9kv-test-sw1"                          # Device on the Source fabric
+            dst_device: "n9kv-test-sw4"                          # Device on the Destination fabric
+            template: ext_fabric_setup                           # template to be applied, choose from 
+                                                                 #   [ ext_fabric_setup, ext_multisite_underlay_setup,
+                                                                 #     ext_evpn_multisite_overlay_setup ]
+          - dst_fabric: "{{ ansible_unnum_fabric }}"             # Destination fabric
+            src_interface: "{{ intf_1_9 }}"                      # Interface on the Source fabric
+            dst_interface: "{{ intf_1_9 }}"                      # Interface on the Destination fabric
+            src_device: "n9kv-test-sw1"                          # Device on the Source fabric
+            dst_device: "n9kv-unnum-1"                           # Device on the Destination fabric
+            template: ext_fabric_setup                           # template to be applied, choose from 
+                                                                 #   [ ext_fabric_setup, ext_multisite_underlay_setup,
+                                                                 #     ext_evpn_multisite_overlay_setup ]
+          - dst_fabric: "{{ ansible_ext_fabric }}"               # Destination fabric
+            src_interface: "{{ intf_1_10 }}"                     # Interface on the Source fabric
+            dst_interface: "{{ intf_1_10 }}"                     # Interface on the Destination fabric
+            src_device: "n9kv-num-1"                             # Device on the Source fabric
+            dst_device: "n9kv-ext-sw1"                           # Device on the Destination fabric
+            template: ext_fabric_setup                           # template to be applied, choose from 
+                                                                 #   [ ext_fabric_setup, ext_multisite_underlay_setup,
+                                                                 #     ext_evpn_multisite_overlay_setup ]
+          - dst_fabric: "{{ ansible_unnum_fabric }}"             # Destination fabric
+            src_interface: "{{ intf_1_11 }}"                     # Interface on the Source fabric
+            dst_interface: "{{ intf_1_11 }}"                     # Interface on the Destination fabric
+            src_device: "n9kv-num-1"                             # Device on the Source fabric
+            dst_device: "n9kv-unnum-1"                           # Device on the Destination fabric
+            template: ext_fabric_setup                           # template to be applied, choose from 
+                                                                 #   [ ext_fabric_setup, ext_multisite_underlay_setup,
+                                                                 #     ext_evpn_multisite_overlay_setup ]
+      register: result
+
+    - assert:
+        that:
+          - 'item["RETURN_CODE"] == 200'
+      loop: '{{ result.response }}'
+
+#############################################
+#                MERGE                     ##
+#############################################
+
+    - name: Create Links - Source Fabric in Monitoring mode
+      cisco.dcnm.dcnm_links: 
+        state: merged                                            # choose from [merged, replaced, deleted, query]
+        src_fabric: "{{ ansible_extmon_fabric }}"
+        config:
+          - dst_fabric: "{{ ansible_num_fabric }}"               # Destination fabric
+            src_interface: "{{ intf_1_3 }}"                      # Interface on the Source fabric
+            dst_interface: "{{ intf_1_3 }}"                      # Interface on the Destination fabric
+            src_device: "dummy-switch-1"                         # Device on the Source fabric
+            dst_device: "{{ ansible_num_switch1 }}"              # Device on the Destination fabric
+            template: ext_fabric_setup                           # template to be applied, choose from 
+                                                                 #   [ ext_fabric_setup, ext_multisite_underlay_setup,
+                                                                 #     ext_evpn_multisite_overlay_setup ]
+            profile:
+              ipv4_subnet: 193.168.1.1/24                        # IP address of interface in src fabric with mask
+              neighbor_ip: 193.168.1.2                           # IP address of the interface in dst fabric
+              src_asn: "{{ ansible_extmon_asn }}"                # BGP ASN in source fabric
+              dst_asn: "{{ ansible_num_asn }}"                   # BGP ASN in destination fabric
+      register: result
+      ignore_errors: yes          
+
+    - assert:
+        that:
+          - '("Monitoring mode" in result["msg"])'
+          - '("No changes are allowed on the fabric" in result["msg"])'
+          - '("{{ ansible_extmon_fabric }}" in result["msg"])'
+
+    - name: Create Links - Destination Fabric - Monitoring, Source Switches Not Managable and Destination Switches Not Managable (in POAP)
+      cisco.dcnm.dcnm_links: &links_create1
+        state: merged                                            # choose from [merged, replaced, deleted, query]
+        src_fabric: "{{ ansible_num_fabric }}"
+        config:
+          - dst_fabric: "{{ ansible_svi_fabric }}"               # Destination fabric
+            src_interface: "{{ intf_1_3 }}"                      # Interface on the Source fabric
+            dst_interface: "{{ intf_1_3 }}"                      # Interface on the Destination fabric
+            src_device: "n9kv-test-sw1"                          # Device on the Source fabric
+            dst_device: "n9kv-test-sw3"                          # Device on the Destination fabric
+            template: ext_fabric_setup                           # template to be applied, choose from 
+                                                                 #   [ ext_fabric_setup, ext_multisite_underlay_setup,
+                                                                 #     ext_evpn_multisite_overlay_setup ]
+            profile:
+              ipv4_subnet: 193.168.2.1/24                        # IP address of interface in src fabric with mask
+              neighbor_ip: 193.168.2.2                           # IP address of the interface in dst fabric
+              src_asn: "{{ ansible_num_asn }}"                   # BGP ASN in source fabric
+              dst_asn: "{{ ansible_svi_asn }}"                   # BGP ASN in destination fabric
+      register: result
+      ignore_errors: yes          
+
+    - assert:
+        that:
+          - 'result.changed == true'
+          - '(result["diff"][0]["merged"] | length) == 1'
+          - '(result["diff"][0]["modified"] | length) == 0'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["query"] | length) == 0'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_num_fabric }}" ] | length) == 0'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_svi_fabric }}" ] | length) == 0'
+
+############################################
+#             IDEMPOTENCE                  #
+############################################
+
+    - name: Create Links - Idempotence
+      cisco.dcnm.dcnm_links: *links_create1
+      register: result
+
+    - assert:
+        that:
+          - 'result.changed == true'
+          - '(result["diff"][0]["merged"] | length) == 0'
+          - '(result["diff"][0]["modified"] | length) == 0'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["query"] | length) == 0'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_num_fabric }}" ] | length) == 0'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_svi_fabric }}" ] | length) == 0'
+
+###############################################
+###             QUERY                        ##
+###############################################
+
+    - name: Query Links
+      cisco.dcnm.dcnm_links: 
+        state: query                                             # choose from [merged, replaced, deleted, query]
+        src_fabric: "{{ ansible_num_fabric }}"
+        config:
+          - dst_fabric: "{{ ansible_svi_fabric }}"               # Destination fabric
+            src_interface: "{{ intf_1_3 }}"                      # Interface on the Source fabric
+            dst_interface: "{{ intf_1_3 }}"                      # Interface on the Destination fabric
+            src_device: "n9kv-test-sw1"                          # Device on the Source fabric
+            dst_device: "n9kv-test-sw3"                          # Device on the Destination fabric
+            template: ext_fabric_setup                           # template to be applied, choose from 
+                                                                 #   [ ext_fabric_setup, ext_multisite_underlay_setup,
+                                                                 #     ext_evpn_multisite_overlay_setup ]
+      register: result
+
+    - assert:
+        that:
+          '(result["response"] | length) >= 1'
+
+#############################################
+#                MERGE                     ##
+#############################################
+
+    - name: Create Links - Destination Fabric - Monitoring, Source Switches Not Managable and Destination Switches Not Managable (not present)
+      cisco.dcnm.dcnm_links: &links_create2
+        state: merged                                            # choose from [merged, replaced, deleted, query]
+        src_fabric: "{{ ansible_num_fabric }}"
+        config:
+          - dst_fabric: "{{ ansible_svi_fabric }}"               # Destination fabric
+            src_interface: "{{ intf_1_4 }}"                      # Interface on the Source fabric
+            dst_interface: "{{ intf_1_4 }}"                      # Interface on the Destination fabric
+            src_device: "n9kv-test-sw1"                          # Device on the Source fabric
+            dst_device: "n9kv-test-sw100"                        # Device on the Destination fabric
+            template: ext_fabric_setup                           # template to be applied, choose from 
+                                                                 #   [ ext_fabric_setup, ext_multisite_underlay_setup,
+                                                                 #     ext_evpn_multisite_overlay_setup ]
+            profile:
+              ipv4_subnet: 193.168.3.1/24                        # IP address of interface in src fabric with mask
+              neighbor_ip: 193.168.3.2                           # IP address of the interface in dst fabric
+              src_asn: "{{ ansible_num_asn }}"                   # BGP ASN in source fabric
+              dst_asn: "{{ ansible_svi_asn }}"                   # BGP ASN in destination fabric
+              peer1_description: "Description of source"         # optional, default is ""
+              peer2_description: "Description of dest"           # optional, default is ""
+      register: result
+      ignore_errors: yes          
+
+    - assert:
+        that:
+          - 'result.changed == true'
+          - '(result["diff"][0]["merged"] | length) == 1'
+          - '(result["diff"][0]["modified"] | length) == 0'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["query"] | length) == 0'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_num_fabric }}" ] | length) == 0'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_svi_fabric }}" ] | length) == 0'
+
+    - name: Merge Links - Destination Fabric - Monitoring, Source Switches Not Managable and Destination Switches Not Managable (not present)
+      cisco.dcnm.dcnm_links:
+        state: merged                                            # choose from [merged, replaced, deleted, query]
+        src_fabric: "{{ ansible_num_fabric }}"
+        config:
+          - dst_fabric: "{{ ansible_svi_fabric }}"               # Destination fabric
+            src_interface: "{{ intf_1_4 }}"                      # Interface on the Source fabric
+            dst_interface: "{{ intf_1_4 }}"                      # Interface on the Destination fabric
+            src_device: "n9kv-test-sw1"                          # Device on the Source fabric
+            dst_device: "n9kv-test-sw100"                        # Device on the Destination fabric
+            template: ext_fabric_setup                           # template to be applied, choose from 
+                                                                 #   [ ext_fabric_setup, ext_multisite_underlay_setup,
+                                                                 #     ext_evpn_multisite_overlay_setup ]
+            profile:
+              ipv4_subnet: 193.168.20.1/24                        # IP address of interface in src fabric with mask
+              neighbor_ip: 193.168.20.2                           # IP address of the interface in dst fabric
+              src_asn: "{{ ansible_num_asn }}"                   # BGP ASN in source fabric
+              dst_asn: "{{ ansible_svi_asn }}"                   # BGP ASN in destination fabric
+              peer1_description: "Description of source - REP"   # optional, default is ""
+              peer2_description: "Description of dest - REP"     # optional, default is ""
+      register: result
+      ignore_errors: yes          
+
+    - assert:
+        that:
+          - 'result.changed == true'
+          - '(result["diff"][0]["merged"] | length) == 0'
+          - '(result["diff"][0]["modified"] | length) == 1'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["query"] | length) == 0'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_num_fabric }}" ] | length) == 0'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_svi_fabric }}" ] | length) == 0'
+
+    - name: Merge Links - Destination Fabric - Monitoring, Source Switches Not Managable and Destination Switches Not Managable (not present)
+      cisco.dcnm.dcnm_links:
+        state: replaced                                          # choose from [merged, replaced, deleted, query]
+        src_fabric: "{{ ansible_num_fabric }}"
+        config:
+          - dst_fabric: "{{ ansible_svi_fabric }}"               # Destination fabric
+            src_interface: "{{ intf_1_4 }}"                      # Interface on the Source fabric
+            dst_interface: "{{ intf_1_4 }}"                      # Interface on the Destination fabric
+            src_device: "n9kv-test-sw1"                          # Device on the Source fabric
+            dst_device: "n9kv-test-sw100"                        # Device on the Destination fabric
+            template: ext_fabric_setup                           # template to be applied, choose from 
+                                                                 #   [ ext_fabric_setup, ext_multisite_underlay_setup,
+                                                                 #     ext_evpn_multisite_overlay_setup ]
+            profile:
+              ipv4_subnet: 193.168.20.1/24                        # IP address of interface in src fabric with mask
+              neighbor_ip: 193.168.20.2                           # IP address of the interface in dst fabric
+              src_asn: "{{ ansible_num_asn }}"                   # BGP ASN in source fabric
+              dst_asn: "{{ ansible_svi_asn }}"                   # BGP ASN in destination fabric
+              peer1_description: "Description of source - REP"   # optional, default is ""
+              peer2_description: "Description of dest - REP"     # optional, default is ""
+      register: result
+      ignore_errors: yes          
+
+    - assert:
+        that:
+          - 'result.changed == true'
+          - '(result["diff"][0]["merged"] | length) == 0'
+          - '(result["diff"][0]["modified"] | length) == 1'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["query"] | length) == 0'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_num_fabric }}" ] | length) == 0'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_svi_fabric }}" ] | length) == 0'
+
+#############################################
+#             IDEMPOTENCE                  ##
+#############################################
+
+    - name: Create Links - Idempotence
+      cisco.dcnm.dcnm_links: *links_create2
+      register: result
+
+    - assert:
+        that:
+          - 'result.changed == true'
+          - '(result["diff"][0]["merged"] | length) == 0'
+          - '(result["diff"][0]["modified"] | length) == 1'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["query"] | length) == 0'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_num_fabric }}" ] | length) == 0'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_svi_fabric }}" ] | length) == 0'
+
+###############################################
+###             QUERY                        ##
+###############################################
+
+    - name: Query Links
+      cisco.dcnm.dcnm_links: 
+        state: query                                             # choose from [merged, replaced, deleted, query]
+        src_fabric: "{{ ansible_num_fabric }}"
+        config:
+          - dst_fabric: "{{ ansible_svi_fabric }}"               # Destination fabric
+            src_interface: "{{ intf_1_4 }}"                      # Interface on the Source fabric
+            dst_interface: "{{ intf_1_4 }}"                      # Interface on the Destination fabric
+            src_device: "n9kv-test-sw1"                          # Device on the Source fabric
+            dst_device: "n9kv-test-sw100"                        # Device on the Destination fabric
+            template: ext_fabric_setup                           # template to be applied, choose from 
+                                                                 #   [ ext_fabric_setup, ext_multisite_underlay_setup,
+                                                                 #     ext_evpn_multisite_overlay_setup ]
+      register: result
+
+    - assert:
+        that:
+          '(result["response"] | length) >= 1'
+
+#############################################
+#                MERGE                     ##
+#############################################
+
+    - name: Create Links - Destination Fabric - Monitoring, Source Switches Not Managable and Destination Switches Managable
+      cisco.dcnm.dcnm_links: &links_create3
+        state: merged                                            # choose from [merged, replaced, deleted, query]
+        src_fabric: "{{ ansible_num_fabric }}"
+        config:
+          - dst_fabric: "{{ ansible_svi_fabric }}"               # Destination fabric
+            src_interface: "{{ intf_1_5 }}"                      # Interface on the Source fabric
+            dst_interface: "{{ intf_1_5 }}"                      # Interface on the Destination fabric
+            src_device: "n9kv-test-sw1"                          # Device on the Source fabric
+            dst_device: "n9kv-svi1"                              # Device on the Destination fabric
+            template: ext_fabric_setup                           # template to be applied, choose from 
+                                                                 #   [ ext_fabric_setup, ext_multisite_underlay_setup,
+                                                                 #     ext_evpn_multisite_overlay_setup ]
+            profile:
+              ipv4_subnet: 193.168.4.1/24                        # IP address of interface in src fabric with mask
+              neighbor_ip: 193.168.4.2                           # IP address of the interface in dst fabric
+              src_asn: "{{ ansible_num_asn }}"                   # BGP ASN in source fabric
+              dst_asn: "{{ ansible_svi_asn }}"                   # BGP ASN in destination fabric
+      register: result
+      ignore_errors: yes          
+
+    - assert:
+        that:
+          - 'result.changed == true'
+          - '(result["diff"][0]["merged"] | length) == 1'
+          - '(result["diff"][0]["modified"] | length) == 0'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["query"] | length) == 0'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_num_fabric }}" ] | length) == 0'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_svi_fabric }}" ] | length) == 0'
+
+#############################################
+#             IDEMPOTENCE                  ##
+#############################################
+
+    - name: Create Links - Idempotence
+      cisco.dcnm.dcnm_links: *links_create3
+      register: result
+
+    - assert:
+        that:
+          - 'result.changed == true'
+          - '(result["diff"][0]["merged"] | length) == 0'
+          - '(result["diff"][0]["modified"] | length) == 0'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["query"] | length) == 0'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_num_fabric }}" ] | length) == 0'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_svi_fabric }}" ] | length) == 0'
+
+###############################################
+###             QUERY                        ##
+###############################################
+
+    - name: Query Links
+      cisco.dcnm.dcnm_links: 
+        state: query                                             # choose from [merged, replaced, deleted, query]
+        src_fabric: "{{ ansible_num_fabric }}"
+        config:
+          - dst_fabric: "{{ ansible_svi_fabric }}"               # Destination fabric
+            src_interface: "{{ intf_1_5 }}"                      # Interface on the Source fabric
+            dst_interface: "{{ intf_1_5 }}"                      # Interface on the Destination fabric
+            src_device: "n9kv-test-sw1"                          # Device on the Source fabric
+            dst_device: "n9kv-svi1"                              # Device on the Destination fabric
+            template: ext_fabric_setup                           # template to be applied, choose from 
+                                                                 #   [ ext_fabric_setup, ext_multisite_underlay_setup,
+                                                                 #     ext_evpn_multisite_overlay_setup ]
+      register: result
+
+    - assert:
+        that:
+          '(result["response"] | length) >= 1'
+
+#############################################
+#                MERGE                     ##
+#############################################
+
+    - name: Create Links - Destination Fabric - Monitoring, Source Switches Managable and Destination Switches Not Managable
+      cisco.dcnm.dcnm_links: &links_create4
+        state: merged                                            # choose from [merged, replaced, deleted, query]
+        src_fabric: "{{ ansible_num_fabric }}"
+        config:
+          - dst_fabric: "{{ ansible_svi_fabric }}"               # Destination fabric
+            src_interface: "{{ intf_1_6 }}"                      # Interface on the Source fabric
+            dst_interface: "{{ intf_1_6 }}"                      # Interface on the Destination fabric
+            src_device: "n9kv-num-1"                             # Device on the Source fabric
+            dst_device: "n9kv-test-sw3"                          # Device on the Destination fabric
+            template: ext_fabric_setup                           # template to be applied, choose from 
+                                                                 #   [ ext_fabric_setup, ext_multisite_underlay_setup,
+                                                                 #     ext_evpn_multisite_overlay_setup ]
+            profile:
+              ipv4_subnet: 193.168.5.1/24                        # IP address of interface in src fabric with mask
+              neighbor_ip: 193.168.5.2                           # IP address of the interface in dst fabric
+              src_asn: "{{ ansible_num_asn }}"                   # BGP ASN in source fabric
+              dst_asn: "{{ ansible_svi_asn }}"                   # BGP ASN in destination fabric
+      register: result
+      ignore_errors: yes          
+
+    - assert:
+        that:
+          - 'result.changed == true'
+          - '(result["diff"][0]["merged"] | length) == 1'
+          - '(result["diff"][0]["modified"] | length) == 0'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["query"] | length) == 0'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_num_fabric }}" ] | length) == 1'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_svi_fabric }}" ] | length) == 0'
+
+#############################################
+#             IDEMPOTENCE                  ##
+#############################################
+
+    - name: Create Links - Idempotence
+      cisco.dcnm.dcnm_links: *links_create4
+      register: result
+
+    - assert:
+        that:
+          - 'result.changed == true'
+          - '(result["diff"][0]["merged"] | length) == 0'
+          - '(result["diff"][0]["modified"] | length) == 0'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["query"] | length) == 0'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_num_fabric }}" ] | length) == 1'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_svi_fabric }}" ] | length) == 0'
+
+###############################################
+###             QUERY                        ##
+###############################################
+
+    - name: Query Links
+      cisco.dcnm.dcnm_links: 
+        state: query                                             # choose from [merged, replaced, deleted, query]
+        src_fabric: "{{ ansible_num_fabric }}"
+        config:
+          - dst_fabric: "{{ ansible_svi_fabric }}"               # Destination fabric
+            src_interface: "{{ intf_1_6 }}"                      # Interface on the Source fabric
+            dst_interface: "{{ intf_1_6 }}"                      # Interface on the Destination fabric
+            src_device: "n9kv-num-1"                             # Device on the Source fabric
+            dst_device: "n9kv-test-sw3"                          # Device on the Destination fabric
+            template: ext_fabric_setup                           # template to be applied, choose from 
+                                                                 #   [ ext_fabric_setup, ext_multisite_underlay_setup,
+                                                                 #     ext_evpn_multisite_overlay_setup ]
+      register: result
+
+    - assert:
+        that:
+          '(result["response"] | length) >= 1'
+
+#############################################
+#                MERGE                     ##
+#############################################
+
+    - name: Create Links - Destination Fabric - Monitoring, Source Switches Managable and Destination Switches Managable
+      cisco.dcnm.dcnm_links: &links_create5
+        state: merged                                            # choose from [merged, replaced, deleted, query]
+        src_fabric: "{{ ansible_num_fabric }}"
+        config:
+          - dst_fabric: "{{ ansible_svi_fabric }}"               # Destination fabric
+            src_interface: "{{ intf_1_7 }}"                      # Interface on the Source fabric
+            dst_interface: "{{ intf_1_7 }}"                      # Interface on the Destination fabric
+            src_device: "n9kv-num-1"                             # Device on the Source fabric
+            dst_device: "n9kv-svi1"                              # Device on the Destination fabric
+            template: ext_fabric_setup                           # template to be applied, choose from 
+                                                                 #   [ ext_fabric_setup, ext_multisite_underlay_setup,
+                                                                 #     ext_evpn_multisite_overlay_setup ]
+            profile:
+              ipv4_subnet: 193.168.6.1/24                        # IP address of interface in src fabric with mask
+              neighbor_ip: 193.168.6.2                           # IP address of the interface in dst fabric
+              src_asn: "{{ ansible_num_asn }}"                   # BGP ASN in source fabric
+              dst_asn: "{{ ansible_svi_asn }}"                   # BGP ASN in destination fabric
+      register: result
+      ignore_errors: yes          
+
+    - assert:
+        that:
+          - 'result.changed == true'
+          - '(result["diff"][0]["merged"] | length) == 1'
+          - '(result["diff"][0]["modified"] | length) == 0'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["query"] | length) == 0'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_num_fabric }}" ] | length) == 1'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_svi_fabric }}" ] | length) == 0'
+
+#############################################
+#             IDEMPOTENCE                  ##
+#############################################
+
+    - name: Create Links - Idempotence
+      cisco.dcnm.dcnm_links: *links_create5
+      register: result
+
+    - assert:
+        that:
+          - 'result.changed == true'
+          - '(result["diff"][0]["merged"] | length) == 0'
+          - '(result["diff"][0]["modified"] | length) == 0'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["query"] | length) == 0'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_num_fabric }}" ] | length) == 1'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_svi_fabric }}" ] | length) == 0'
+
+###############################################
+###             QUERY                        ##
+###############################################
+
+    - name: Query Links
+      cisco.dcnm.dcnm_links: 
+        state: query                                             # choose from [merged, replaced, deleted, query]
+        src_fabric: "{{ ansible_num_fabric }}"
+        config:
+          - dst_fabric: "{{ ansible_svi_fabric }}"               # Destination fabric
+            src_interface: "{{ intf_1_7 }}"                      # Interface on the Source fabric
+            dst_interface: "{{ intf_1_7 }}"                      # Interface on the Destination fabric
+            src_device: "n9kv-num-1"                             # Device on the Source fabric
+            dst_device: "n9kv-svi1"                              # Device on the Destination fabric
+            template: ext_fabric_setup                           # template to be applied, choose from 
+                                                                 #   [ ext_fabric_setup, ext_multisite_underlay_setup,
+                                                                 #     ext_evpn_multisite_overlay_setup ]
+      register: result
+
+    - assert:
+        that:
+          '(result["response"] | length) >= 1'
+
+#############################################
+#                MERGE                     ##
+#############################################
+
+    - name: Create Links - Source Switches Not Managable and Destination Switches Not Managable
+      cisco.dcnm.dcnm_links: &links_create6
+        state: merged                                            # choose from [merged, replaced, deleted, query]
+        src_fabric: "{{ ansible_num_fabric }}"
+        config:
+          - dst_fabric: "{{ ansible_ext_fabric }}"               # Destination fabric
+            src_interface: "{{ intf_1_8 }}"                      # Interface on the Source fabric
+            dst_interface: "{{ intf_1_8 }}"                      # Interface on the Destination fabric
+            src_device: "n9kv-test-sw1"                          # Device on the Source fabric
+            dst_device: "n9kv-test-sw4"                          # Device on the Destination fabric
+            template: ext_fabric_setup                           # template to be applied, choose from 
+                                                                 #   [ ext_fabric_setup, ext_multisite_underlay_setup,
+                                                                 #     ext_evpn_multisite_overlay_setup ]
+            profile:
+              ipv4_subnet: 193.168.7.1/24                        # IP address of interface in src fabric with mask
+              neighbor_ip: 193.168.7.2                           # IP address of the interface in dst fabric
+              src_asn: "{{ ansible_num_asn }}"                   # BGP ASN in source fabric
+              dst_asn: "{{ ansible_ext_asn }}"                   # BGP ASN in destination fabric
+      register: result
+      ignore_errors: yes          
+
+    - assert:
+        that:
+          - 'result.changed == true'
+          - '(result["diff"][0]["merged"] | length) == 1'
+          - '(result["diff"][0]["modified"] | length) == 0'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["query"] | length) == 0'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_num_fabric }}" ] | length) == 0'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_ext_fabric }}" ] | length) == 0'
+
+#############################################
+#             IDEMPOTENCE                  ##
+#############################################
+
+    - name: Create Links - Idempotence
+      cisco.dcnm.dcnm_links: *links_create6
+      register: result
+
+    - assert:
+        that:
+          - 'result.changed == true'
+          - '(result["diff"][0]["merged"] | length) == 0'
+          - '(result["diff"][0]["modified"] | length) == 0'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["query"] | length) == 0'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_num_fabric }}" ] | length) == 0'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_ext_fabric }}" ] | length) == 0'
+
+###############################################
+###             QUERY                        ##
+###############################################
+
+    - name: Query Links
+      cisco.dcnm.dcnm_links: 
+        state: query                                             # choose from [merged, replaced, deleted, query]
+        src_fabric: "{{ ansible_num_fabric }}"
+        config:
+          - dst_fabric: "{{ ansible_ext_fabric }}"               # Destination fabric
+            src_interface: "{{ intf_1_8 }}"                      # Interface on the Source fabric
+            dst_interface: "{{ intf_1_8 }}"                      # Interface on the Destination fabric
+            src_device: "n9kv-test-sw1"                          # Device on the Source fabric
+            dst_device: "n9kv-test-sw4"                          # Device on the Destination fabric
+            template: ext_fabric_setup                           # template to be applied, choose from 
+                                                                 #   [ ext_fabric_setup, ext_multisite_underlay_setup,
+                                                                 #     ext_evpn_multisite_overlay_setup ]
+      register: result
+
+    - assert:
+        that:
+          '(result["response"] | length) >= 1'
+
+#############################################
+#                MERGE                     ##
+#############################################
+
+    - name: Create Links - Source Switches Not Managable and Destination Switches Managable
+      cisco.dcnm.dcnm_links: &links_create7
+        state: merged                                            # choose from [merged, replaced, deleted, query]
+        src_fabric: "{{ ansible_num_fabric }}"
+        config:
+          - dst_fabric: "{{ ansible_unnum_fabric }}"             # Destination fabric
+            src_interface: "{{ intf_1_9 }}"                      # Interface on the Source fabric
+            dst_interface: "{{ intf_1_9 }}"                      # Interface on the Destination fabric
+            src_device: "n9kv-test-sw1"                          # Device on the Source fabric
+            dst_device: "n9kv-unnum-1"                           # Device on the Destination fabric
+            template: ext_fabric_setup                           # template to be applied, choose from 
+                                                                 #   [ ext_fabric_setup, ext_multisite_underlay_setup,
+                                                                 #     ext_evpn_multisite_overlay_setup ]
+            profile:
+              ipv4_subnet: 193.168.8.1/24                        # IP address of interface in src fabric with mask
+              neighbor_ip: 193.168.8.2                           # IP address of the interface in dst fabric
+              src_asn: "{{ ansible_num_asn }}"                   # BGP ASN in source fabric
+              dst_asn: "{{ ansible_unnum_asn }}"                 # BGP ASN in destination fabric
+      register: result
+      ignore_errors: yes          
+
+    - assert:
+        that:
+          - 'result.changed == true'
+          - '(result["diff"][0]["merged"] | length) == 1'
+          - '(result["diff"][0]["modified"] | length) == 0'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["query"] | length) == 0'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_num_fabric }}" ] | length) == 0'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_unnum_fabric }}" ] | length) == 0'
+
+#############################################
+#             IDEMPOTENCE                  ##
+#############################################
+
+    - name: Create Links - Idempotence
+      cisco.dcnm.dcnm_links: *links_create7
+      register: result
+
+    - assert:
+        that:
+          - 'result.changed == true'
+          - '(result["diff"][0]["merged"] | length) == 0'
+          - '(result["diff"][0]["modified"] | length) == 0'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["query"] | length) == 0'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_num_fabric }}" ] | length) == 0'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_unnum_fabric }}" ] | length) == 0'
+
+###############################################
+###             QUERY                        ##
+###############################################
+
+    - name: Query Links
+      cisco.dcnm.dcnm_links: 
+        state: query                                             # choose from [merged, replaced, deleted, query]
+        src_fabric: "{{ ansible_num_fabric }}"
+        config:
+          - dst_fabric: "{{ ansible_unnum_fabric }}"             # Destination fabric
+            src_interface: "{{ intf_1_9 }}"                      # Interface on the Source fabric
+            dst_interface: "{{ intf_1_9 }}"                      # Interface on the Destination fabric
+            src_device: "n9kv-test-sw1"                          # Device on the Source fabric
+            dst_device: "n9kv-unnum-1"                           # Device on the Destination fabric
+            template: ext_fabric_setup                           # template to be applied, choose from 
+                                                                 #   [ ext_fabric_setup, ext_multisite_underlay_setup,
+                                                                 #     ext_evpn_multisite_overlay_setup ]
+      register: result
+
+    - assert:
+        that:
+          '(result["response"] | length) >= 1'
+
+#############################################
+#                MERGE                     ##
+#############################################
+
+    - name: Create Links - Source Switches Managable and Destination Switches Not Managable (not present in Fabric)
+      cisco.dcnm.dcnm_links: &links_create8
+        state: merged                                            # choose from [merged, replaced, deleted, query]
+        src_fabric: "{{ ansible_num_fabric }}"
+        config:
+          - dst_fabric: "{{ ansible_ext_fabric }}"               # Destination fabric
+            src_interface: "{{ intf_1_10 }}"                     # Interface on the Source fabric
+            dst_interface: "{{ intf_1_10 }}"                     # Interface on the Destination fabric
+            src_device: "n9kv-num-1"                             # Device on the Source fabric
+            dst_device: "n9kv-ext-sw1"                           # Device on the Destination fabric
+            template: ext_fabric_setup                           # template to be applied, choose from 
+                                                                 #   [ ext_fabric_setup, ext_multisite_underlay_setup,
+                                                                 #     ext_evpn_multisite_overlay_setup ]
+            profile:
+              ipv4_subnet: 193.168.9.1/24                        # IP address of interface in src fabric with mask
+              neighbor_ip: 193.168.9.2                           # IP address of the interface in dst fabric
+              src_asn: "{{ ansible_num_asn }}"                   # BGP ASN in source fabric
+              dst_asn: "{{ ansible_ext_asn }}"                 # BGP ASN in destination fabric
+      register: result
+      ignore_errors: yes          
+
+    - assert:
+        that:
+          - 'result.changed == true'
+          - '(result["diff"][0]["merged"] | length) == 1'
+          - '(result["diff"][0]["modified"] | length) == 0'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["query"] | length) == 0'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_num_fabric }}" ] | length) == 1'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_ext_fabric }}" ] | length) == 0'
+
+#############################################
+#             IDEMPOTENCE                  ##
+#############################################
+
+    - name: Create Links - Idempotence
+      cisco.dcnm.dcnm_links: *links_create8
+      register: result
+
+    - assert:
+        that:
+          - 'result.changed == true'
+          - '(result["diff"][0]["merged"] | length) == 0'
+          - '(result["diff"][0]["modified"] | length) == 0'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["query"] | length) == 0'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_num_fabric }}" ] | length) == 1'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_ext_fabric }}" ] | length) == 0'
+
+###############################################
+###             QUERY                        ##
+###############################################
+
+    - name: Query Links
+      cisco.dcnm.dcnm_links: 
+        state: query                                             # choose from [merged, replaced, deleted, query]
+        src_fabric: "{{ ansible_num_fabric }}"
+        config:
+          - dst_fabric: "{{ ansible_ext_fabric }}"               # Destination fabric
+            src_interface: "{{ intf_1_10 }}"                     # Interface on the Source fabric
+            dst_interface: "{{ intf_1_10 }}"                     # Interface on the Destination fabric
+            src_device: "n9kv-num-1"                             # Device on the Source fabric
+            dst_device: "n9kv-ext-sw1"                           # Device on the Destination fabric
+            template: ext_fabric_setup                           # template to be applied, choose from 
+                                                                 #   [ ext_fabric_setup, ext_multisite_underlay_setup,
+                                                                 #     ext_evpn_multisite_overlay_setup ]
+      register: result
+
+    - assert:
+        that:
+          '(result["response"] | length) >= 1'
+
+#############################################
+#                MERGE                     ##
+#############################################
+
+    - name: Create Links - Source Switches Managable and Destination Switches Managable
+      cisco.dcnm.dcnm_links: &links_create9
+        state: merged                                            # choose from [merged, replaced, deleted, query]
+        src_fabric: "{{ ansible_num_fabric }}"
+        config:
+          - dst_fabric: "{{ ansible_unnum_fabric }}"             # Destination fabric
+            src_interface: "{{ intf_1_11 }}"                     # Interface on the Source fabric
+            dst_interface: "{{ intf_1_11 }}"                     # Interface on the Destination fabric
+            src_device: "n9kv-num-1"                             # Device on the Source fabric
+            dst_device: "n9kv-unnum-1"                           # Device on the Destination fabric
+            template: ext_fabric_setup                           # template to be applied, choose from 
+                                                                 #   [ ext_fabric_setup, ext_multisite_underlay_setup,
+                                                                 #     ext_evpn_multisite_overlay_setup ]
+            profile:
+              ipv4_subnet: 193.168.10.1/24                       # IP address of interface in src fabric with mask
+              neighbor_ip: 193.168.10.2                          # IP address of the interface in dst fabric
+              src_asn: "{{ ansible_num_asn }}"                   # BGP ASN in source fabric
+              dst_asn: "{{ ansible_unnum_asn }}"                 # BGP ASN in destination fabric
+      register: result
+      ignore_errors: yes          
+
+    - assert:
+        that:
+          - 'result.changed == true'
+          - '(result["diff"][0]["merged"] | length) == 1'
+          - '(result["diff"][0]["modified"] | length) == 0'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["query"] | length) == 0'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_num_fabric }}" ] | length) == 1'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_unnum_fabric }}" ] | length) == 1'
+
+#############################################
+#             IDEMPOTENCE                  ##
+#############################################
+
+    - name: Create Links - Idempotence
+      cisco.dcnm.dcnm_links: *links_create9
+      register: result
+
+    - assert:
+        that:
+          - 'result.changed == true'
+          - '(result["diff"][0]["merged"] | length) == 0'
+          - '(result["diff"][0]["modified"] | length) == 0'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["query"] | length) == 0'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_num_fabric }}" ] | length) == 1'
+          - '(result["diff"][0]["deploy"][0][ "{{ ansible_unnum_fabric }}" ] | length) == 1'
+
+###############################################
+###             QUERY                        ##
+###############################################
+
+    - name: Query Links
+      cisco.dcnm.dcnm_links: 
+        state: query                                             # choose from [merged, replaced, deleted, query]
+        src_fabric: "{{ ansible_num_fabric }}"
+        config:
+          - dst_fabric: "{{ ansible_unnum_fabric }}"             # Destination fabric
+            src_interface: "{{ intf_1_11 }}"                     # Interface on the Source fabric
+            dst_interface: "{{ intf_1_11 }}"                     # Interface on the Destination fabric
+            src_device: "n9kv-num-1"                             # Device on the Source fabric
+            dst_device: "n9kv-unnum-1"                           # Device on the Destination fabric
+            template: ext_fabric_setup                           # template to be applied, choose from 
+                                                                 #   [ ext_fabric_setup, ext_multisite_underlay_setup,
+                                                                 #     ext_evpn_multisite_overlay_setup ]
+      register: result
+
+    - assert:
+        that:
+          '(result["response"] | length) >= 1'
+
+#############################################
+#             CLEANUP                      ##
+#############################################
+
+  always:
+
+    - name: Cleanup - Delete Links 
+      cisco.dcnm.dcnm_links: *links_delete
+      register: result
+      when: IT_CONTEXT is not defined
+
+    - assert:
+        that:
+          - 'item["RETURN_CODE"] == 200'
+      loop: '{{ result.response }}'
+      when: IT_CONTEXT is not defined

--- a/tests/unit/modules/dcnm/fixtures/dcnm_links_configs.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_links_configs.json
@@ -2199,5 +2199,149 @@
     "src_interface": "Ethernet1/1",
     "template": "ext_evpn_multisite_overlay_setup"
   }
-  ]
+  ],
+
+  "inter_src_fab_ro_config": [
+  {
+    "dst_device": "10.64.78.231",
+    "dst_fabric": "mmudigon-dst-fab-ro",
+    "dst_interface": "Ethernet1/1",
+    "profile": {
+      "dst_asn": 1001,
+      "ipv4_subnet": "193.168.1.1/24",
+      "neighbor_ip": "193.168.1.2",
+      "src_asn": 1000
+    },
+    "src_device": "10.64.78.227",
+    "src_interface": "Ethernet1/1",
+    "template": "ext_fabric_setup"
+  }],
+
+  "inter_dst_fab_ro_dst_sw_non_mgbl_config": [
+  {
+    "dst_device": "n9kv-1",
+    "dst_fabric": "mmudigon-dst-fab-ro",
+    "dst_interface": "Ethernet1/1",
+    "profile": {
+      "dst_asn": 1001,
+      "ipv4_subnet": "193.168.1.1/24",
+      "neighbor_ip": "193.168.1.2",
+      "src_asn": 1000
+    },
+    "src_device": "n9kv-num-1",
+    "src_interface": "Ethernet1/1",
+    "template": "ext_fabric_setup"
+  }],
+
+  "inter_dst_fab_ro_src_sw_non_mgbl_config": [
+  {
+    "dst_device": "n9kv-num-1",
+    "dst_fabric": "mmudigon-dst-fab-ro",
+    "dst_interface": "Ethernet1/1",
+    "profile": {
+      "dst_asn": 1001,
+      "ipv4_subnet": "193.168.1.1/24",
+      "neighbor_ip": "193.168.1.2",
+      "src_asn": 1000
+    },
+    "src_device": "n9kv-2",
+    "src_interface": "Ethernet1/1",
+    "template": "ext_fabric_setup"
+  }],
+
+  "inter_dst_fab_ro_src_dst_sw_non_mgbl_config": [
+  {
+    "dst_device": "n9kv-1",
+    "dst_fabric": "mmudigon-dst-fab-ro",
+    "dst_interface": "Ethernet1/1",
+    "profile": {
+      "dst_asn": 1001,
+      "ipv4_subnet": "193.168.1.1/24",
+      "neighbor_ip": "193.168.1.2",
+      "src_asn": 1000
+    },
+    "src_device": "n9kv-2",
+    "src_interface": "Ethernet1/1",
+    "template": "ext_fabric_setup"
+  }],
+
+  "inter_dst_fab_ro_src_dst_sw_mgbl_config": [
+  {
+    "dst_device": "n9kv-num-1",
+    "dst_fabric": "mmudigon-dst-fab-ro",
+    "dst_interface": "Ethernet1/1",
+    "profile": {
+      "dst_asn": 1001,
+      "ipv4_subnet": "193.168.1.1/24",
+      "neighbor_ip": "193.168.1.2",
+      "src_asn": 1000
+    },
+    "src_device": "n9kv-unnum-1",
+    "src_interface": "Ethernet1/1",
+    "template": "ext_fabric_setup"
+  }],
+
+  "inter_dst_fab_rw_dst_sw_non_mgbl_config": [
+  {
+    "dst_device": "n9kv-1",
+    "dst_fabric": "mmudigon-dst-fab-rw",
+    "dst_interface": "Ethernet1/1",
+    "profile": {
+      "dst_asn": 1001,
+      "ipv4_subnet": "193.168.1.1/24",
+      "neighbor_ip": "193.168.1.2",
+      "src_asn": 1000
+    },
+    "src_device": "n9kv-num-1",
+    "src_interface": "Ethernet1/1",
+    "template": "ext_fabric_setup"
+  }],
+
+  "inter_dst_fab_rw_src_sw_non_mgbl_config": [
+  {
+    "dst_device": "n9kv-num-1",
+    "dst_fabric": "mmudigon-dst-fab-rw",
+    "dst_interface": "Ethernet1/1",
+    "profile": {
+      "dst_asn": 1001,
+      "ipv4_subnet": "193.168.1.1/24",
+      "neighbor_ip": "193.168.1.2",
+      "src_asn": 1000
+    },
+    "src_device": "n9kv-2",
+    "src_interface": "Ethernet1/1",
+    "template": "ext_fabric_setup"
+  }],
+
+  "inter_dst_fab_rw_src_dst_sw_non_mgbl_config": [
+  {
+    "dst_device": "n9kv-1",
+    "dst_fabric": "mmudigon-dst-fab-rw",
+    "dst_interface": "Ethernet1/1",
+    "profile": {
+      "dst_asn": 1001,
+      "ipv4_subnet": "193.168.1.1/24",
+      "neighbor_ip": "193.168.1.2",
+      "src_asn": 1000
+    },
+    "src_device": "n9kv-2",
+    "src_interface": "Ethernet1/1",
+    "template": "ext_fabric_setup"
+  }],
+
+  "inter_dst_fab_rw_src_dst_sw_mgbl_config": [
+  {
+    "dst_device": "n9kv-num-1",
+    "dst_fabric": "mmudigon-dst-fab-rw",
+    "dst_interface": "Ethernet1/1",
+    "profile": {
+      "dst_asn": 1001,
+      "ipv4_subnet": "193.168.1.1/24",
+      "neighbor_ip": "193.168.1.2",
+      "src_asn": 1000
+    },
+    "src_device": "n9kv-unnum-1",
+    "src_interface": "Ethernet1/1",
+    "template": "ext_fabric_setup"
+  }]
 }

--- a/tests/unit/modules/dcnm/fixtures/dcnm_links_payloads.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_links_payloads.json
@@ -19,60 +19,178 @@
 
     "mock_fab_inv_data": {
       "192.168.123.150": {
+        "logicalName": "n9kv-100",
+        "serialNumber": "9M99N34RDED",
         "isVpcConfigured": "True",
-        "vpcDomain": 1
+        "vpcDomain": 1,
+        "switchRoleEnum": "Leaf",
+        "managable": "True"
       },
       "192.168.123.151": {
+        "logicalName": "n9kv-200",
+        "serialNumber": "9NXHSNTEO6C",
         "isVpcConfigured": "True",
-        "vpcDomain": 1
+        "vpcDomain": 1,
+        "switchRoleEnum": "Leaf",
+        "managable": "True"
       },
       "192.168.123.156": {
+        "logicalName": "n9kv-ipv6-1",
+        "serialNumber": "9BH0813WFWT",
         "isVpcConfigured": "True",
-        "vpcDomain": 1
+        "vpcDomain": 1,
+        "switchRoleEnum": "Leaf",
+        "managable": "True"
       },
       "192.168.123.157": {
+        "logicalName": "n9kv-ipv6-2",
+        "serialNumber": "9ITWBH9OIAH",
         "isVpcConfigured": "True",
-        "vpcDomain": 1
+        "vpcDomain": 1,
+        "switchRoleEnum": "Leaf",
+        "managable": "True"
       },
       "192.168.123.160": {
+        "logicalName": "n9kv-num-1",
+        "serialNumber": "9IF87L089SZ",
         "isVpcConfigured": "True",
-        "vpcDomain": 1
+        "vpcDomain": 1,
+        "switchRoleEnum": "Leaf",
+        "managable": "True"
       },
       "192.168.123.161": {
+        "logicalName": "n9kv-num-2",
+        "serialNumber": "9FX7O3TU2QM",
         "isVpcConfigured": "True",
-        "vpcDomain": 1
+        "vpcDomain": 1,
+        "switchRoleEnum": "Leaf",
+        "managable": "True"
       },
       "192.168.123.170": {
+        "logicalName": "n9kv-unnum-1",
+        "serialNumber": "9EFX823RUL3",
         "isVpcConfigured": "True",
-        "vpcDomain": 1
+        "vpcDomain": 1,
+        "switchRoleEnum": "Leaf",
+        "managable": "True"
       },
       "192.168.123.171": {
+        "logicalName": "n9kv-unnum-2",
+        "serialNumber": "9AF3VNZYAKS",
         "isVpcConfigured": "True",
-        "vpcDomain": 1
+        "vpcDomain": 1,
+        "switchRoleEnum": "Leaf",
+        "managable": "True"
       },
       "10.64.78.225": {
+        "logicalName": "n9kv-test1",
+        "serialNumber": "98YWRN9WCSC",
         "isVpcConfigured": "True",
-        "vpcDomain": 1
+        "vpcDomain": 1,
+        "switchRoleEnum": "Leaf",
+        "managable": "True"
       },
       "10.64.78.226": {
+        "logicalName": "n9kv-test2",
+        "serialNumber": "94UTIRVSX58",
         "isVpcConfigured": "True",
-        "vpcDomain": 1
+        "vpcDomain": 1,
+        "switchRoleEnum": "Leaf",
+        "managable": "True"
       },
       "10.64.78.227": {
+        "logicalName": "n9kv-227",
+        "serialNumber": "953E68OKK1L",
         "isVpcConfigured": "True",
-        "vpcDomain": 1
+        "vpcDomain": 1,
+        "switchRoleEnum": "Leaf",
+        "managable": "True"
       },
       "10.64.78.228": {
+        "logicalName": "n9kv-228",
+        "serialNumber": "9WCPR0JUV6M",
         "isVpcConfigured": "True",
-        "vpcDomain": 1
+        "vpcDomain": 1,
+        "switchRoleEnum": "Leaf",
+        "managable": "True"
       },
       "10.64.78.230": {
+        "logicalName": "test11",
+        "serialNumber": "9XLP8I4TPPM",
         "isVpcConfigured": "True",
-        "vpcDomain": 1
+        "vpcDomain": 1,
+        "switchRoleEnum": "Leaf",
+        "managable": "True"
       },
       "10.64.78.231": {
+        "logicalName": "test22",
+        "serialNumber": "9E15XSEM5MS",
         "isVpcConfigured": "True",
-        "vpcDomain": 1
+        "vpcDomain": 1,
+        "switchRoleEnum": "Leaf",
+        "managable": "True"
+      },
+      "10.69.69.1": {
+        "logicalName": "n9kv-1",
+        "serialNumber": "TEST-SNO-1",
+        "isVpcConfigured": "True",
+        "vpcDomain": 1,
+        "switchRoleEnum": "None",
+        "managable": "False"
+      },
+      "10.69.69.2": {
+        "logicalName": "n9kv-2",
+        "serialNumber": "TEST-SNO-2",
+        "isVpcConfigured": "True",
+        "vpcDomain": 1,
+        "switchRoleEnum": "None",
+        "managable": "False"
+      },
+      "10.69.69.3": {
+        "logicalName": "n9kv-3",
+        "serialNumber": "TEST-SNO-3",
+        "isVpcConfigured": "True",
+        "vpcDomain": 1,
+        "switchRoleEnum": "None",
+        "managable": "False"
+      },
+      "10.69.69.4": {
+        "logicalName": "n9kv-4",
+        "serialNumber": "TEST-SNO-4",
+        "isVpcConfigured": "True",
+        "vpcDomain": 1,
+        "switchRoleEnum": "None",
+        "managable": "False"
+      },
+      "10.69.69.5": {
+        "logicalName": "n9kv-5",
+        "serialNumber": "TEST-SNO-5",
+        "isVpcConfigured": "True",
+        "vpcDomain": 1,
+        "switchRoleEnum": "None",
+        "managable": "False"
+      },
+      "10.69.69.6": {
+        "logicalName": "n9kv-6",
+        "serialNumber": "TEST-SNO-6",
+        "isVpcConfigured": "True",
+        "vpcDomain": 1,
+        "switchRoleEnum": "None",
+        "managable": "False"
+      }
+    },
+
+    "mock_monitor_true_resp": {
+      "RETURN_CODE": 200,
+      "DATA":{
+        "readonly": "True"
+      }
+    },
+
+    "mock_monitor_false_resp": {
+      "RETURN_CODE": 200,
+      "DATA":{
+        "readonly": "False"
       }
     },
 
@@ -211,6 +329,7 @@
         "sw2-info": {
           "fabric-name": "mmudigon-numbered",
           "if-name": "Ethernet1/1",
+          "sw-sys-name": "n9kv-num-2",
           "sw-serial-number": "9FX7O3TU2QM"
         },
         "link-dbid": 1856090,
@@ -241,6 +360,7 @@
         "sw1-info": {
           "fabric-name": "mmudigon-numbered",
           "if-name": "Ethernet1/1",
+          "sw-sys-name": "n9kv-num-1",
           "sw-serial-number": "9IF87L089SZ"
         },
         "fabricName": "mmudigon-numbered"
@@ -258,6 +378,7 @@
         "sw2-info": {
           "fabric-name": "mmudigon-numbered",
           "if-name": "Ethernet1/2",
+          "sw-sys-name": "n9kv-num-2",
           "sw-serial-number": "9FX7O3TU2QM"
         },
         "link-dbid": 1856250,
@@ -268,6 +389,7 @@
         "sw1-info": {
           "fabric-name": "mmudigon-numbered",
           "if-name": "Ethernet1/2",
+          "sw-sys-name": "n9kv-num-1",
           "sw-serial-number": "9IF87L089SZ"
         },
         "fabricName": "mmudigon-numbered"
@@ -285,6 +407,7 @@
         "sw2-info": {
           "fabric-name": "mmudigon-numbered",
           "if-name": "Ethernet1/3",
+          "sw-sys-name": "n9kv-num-2",
           "sw-serial-number": "9FX7O3TU2QM"
         },
         "nvPairs": {
@@ -309,6 +432,7 @@
         "sw1-info": {
           "fabric-name": "mmudigon-numbered",
           "if-name": "Ethernet1/3",
+          "sw-sys-name": "n9kv-num-1",
           "sw-serial-number": "9IF87L089SZ"
         },
         "fabricName": "mmudigon-numbered"
@@ -326,6 +450,7 @@
         "sw2-info": {
           "fabric-name": "mmudigon-unnumbered",
           "if-name": "Ethernet1/1",
+          "sw-sys-name": "n9kv-unnum-2",
           "sw-serial-number": "9AF3VNZYAKS"
         },
         "nvPairs": {
@@ -351,6 +476,7 @@
         "sw1-info": {
           "fabric-name": "mmudigon-unnumbered",
           "if-name": "Ethernet1/1",
+          "sw-sys-name": "n9kv-unnum-1",
           "sw-serial-number": "9EFX823RUL3"
         },
         "fabricName": "mmudigon-unnumbered"
@@ -368,6 +494,7 @@
         "sw2-info": {
           "fabric-name": "mmudigon-unnumbered",
           "if-name": "Ethernet1/2",
+          "sw-sys-name": "n9kv-unnum-2",
           "sw-serial-number": "9AF3VNZYAKS"
         },
         "nvPairs": {
@@ -376,6 +503,7 @@
         "sw1-info": {
           "fabric-name": "mmudigon-unnumbered",
           "if-name": "Ethernet1/2",
+          "sw-sys-name": "n9kv-unnum-1",
           "sw-serial-number": "9EFX823RUL3"
         },
         "fabricName": "mmudigon-unnumbered"
@@ -393,6 +521,7 @@
         "sw2-info": {
           "fabric-name": "mmudigon-ipv6-underlay",
           "if-name": "Ethernet1/1",
+          "sw-sys-name": "n9kv-ipv6-2",
           "sw-serial-number": "9ITWBH9OIAH"
         },
         "nvPairs": {
@@ -418,6 +547,7 @@
         "sw1-info": {
           "fabric-name": "mmudigon-ipv6-underlay",
           "if-name": "Ethernet1/1",
+          "sw-sys-name": "n9kv-ipv6-1",
           "sw-serial-number": "9BH0813WFWT"
         },
         "fabricName": "mmudigon-ipv6-underlay"
@@ -435,6 +565,7 @@
         "sw2-info": {
           "fabric-name": "mmudigon-ipv6-underlay",
           "if-name": "Ethernet1/2",
+          "sw-sys-name": "n9kv-ipv6-2",
           "sw-serial-number": "9ITWBH9OIAH"
         },
         "link-dbid": 1859550,
@@ -444,6 +575,7 @@
         "sw1-info": {
           "fabric-name": "mmudigon-ipv6-underlay",
           "if-name": "Ethernet1/2",
+          "sw-sys-name": "n9kv-ipv6-1",
           "sw-serial-number": "9BH0813WFWT"
         },
         "fabricName": "mmudigon-ipv6-underlay"
@@ -461,6 +593,7 @@
         "sw2-info": {
           "fabric-name": "mmudigon-ipv6-underlay",
           "if-name": "Ethernet1/3",
+          "sw-sys-name": "n9kv-ipv6-2",
           "sw-serial-number": "9ITWBH9OIAH"
         },
         "nvPairs": {
@@ -491,6 +624,7 @@
         "sw1-info": {
           "fabric-name": "mmudigon-ipv6-underlay",
           "if-name": "Ethernet1/3",
+          "sw-sys-name": "n9kv-ipv6-1",
           "sw-serial-number": "9BH0813WFWT"
         },
         "fabricName": "mmudigon-ipv6-underlay"
@@ -508,6 +642,7 @@
         "sw2-info": {
           "fabric-name": "mmudigon",
           "if-name": "Ethernet1/4",
+          "sw-sys-name": "n9kv-200",
           "sw-serial-number": "9NXHSNTEO6C"
         },
         "link-dbid": 1862750,
@@ -535,6 +670,7 @@
         "sw1-info": {
           "fabric-name": "mmudigon",
           "if-name": "Ethernet1/4",
+          "sw-sys-name": "n9kv-100",
           "sw-serial-number": "9M99N34RDED"
         },
         "fabricName": "mmudigon"
@@ -552,12 +688,14 @@
         "templateName": "ext_fabric_setup",
         "sw2-info": {
           "if-name": "Ethernet1/3",
+          "sw-sys-name": "test22",
           "sw-serial-number": "9E15XSEM5MS",
           "fabric-name": "test_net"
         },
         "sw1-info": {
           "fabric-name": "mmudigon-numbered",
           "if-name": "Ethernet1/3",
+          "sw-sys-name": "n9kv-227",
           "sw-serial-number": "953E68OKK1L"
         },
         "nvPairs": {

--- a/tests/unit/modules/dcnm/test_dcnm_links.py
+++ b/tests/unit/modules/dcnm/test_dcnm_links.py
@@ -111,6 +111,134 @@ class TestDcnmLinksModule(TestDcnmModule):
         ):
             self.run_dcnm_fabric_info.side_effect = [self.mock_ipv6_fab_info]
 
+        # -------------------------- INTER-MISC --------------------------------------
+
+        if "test_dcnm_inter_links_src_fab_ro" in self._testMethodName:
+            self.run_dcnm_send.side_effect = [self.mock_monitor_true_resp, self.mock_monitor_true_resp]
+
+        if "test_dcnm_inter_links_dst_fab_ro_dst_sw_non_mgbl" in self._testMethodName:
+
+            merge_links_resp = self.payloads_data.get(
+                "merge_links_fabric_response"
+            )
+            deploy_resp = self.payloads_data.get("deploy_resp")
+            config_preview_resp = self.payloads_data.get("config_preview_resp")
+
+            self.run_dcnm_send.side_effect = [self.mock_monitor_false_resp,
+                                              self.mock_monitor_true_resp,
+                                              [],
+                                              merge_links_resp,
+                                              deploy_resp,
+                                              config_preview_resp]
+
+        if "test_dcnm_inter_links_dst_fab_ro_src_sw_non_mgbl" in self._testMethodName:
+
+            merge_links_resp = self.payloads_data.get(
+                "merge_links_fabric_response"
+            )
+            deploy_resp = self.payloads_data.get("deploy_resp")
+            config_preview_resp = self.payloads_data.get("config_preview_resp")
+
+            self.run_dcnm_send.side_effect = [self.mock_monitor_false_resp,
+                                              self.mock_monitor_true_resp,
+                                              [],
+                                              merge_links_resp,
+                                              deploy_resp,
+                                              config_preview_resp]
+
+        if "test_dcnm_inter_links_dst_fab_ro_src_dst_sw_non_mgbl" in self._testMethodName:
+
+            merge_links_resp = self.payloads_data.get(
+                "merge_links_fabric_response"
+            )
+            deploy_resp = self.payloads_data.get("deploy_resp")
+            config_preview_resp = self.payloads_data.get("config_preview_resp")
+
+            self.run_dcnm_send.side_effect = [self.mock_monitor_false_resp,
+                                              self.mock_monitor_true_resp,
+                                              [],
+                                              merge_links_resp,
+                                              deploy_resp,
+                                              config_preview_resp]
+
+        if "test_dcnm_inter_links_dst_fab_ro_src_dst_sw_mgbl" in self._testMethodName:
+
+            merge_links_resp = self.payloads_data.get(
+                "merge_links_fabric_response"
+            )
+            deploy_resp = self.payloads_data.get("deploy_resp")
+            config_preview_resp = self.payloads_data.get("config_preview_resp")
+
+            self.run_dcnm_send.side_effect = [self.mock_monitor_false_resp,
+                                              self.mock_monitor_true_resp,
+                                              [],
+                                              merge_links_resp,
+                                              deploy_resp,
+                                              config_preview_resp]
+
+        if "test_dcnm_inter_links_dst_fab_rw_dst_sw_non_mgbl" in self._testMethodName:
+
+            merge_links_resp = self.payloads_data.get(
+                "merge_links_fabric_response"
+            )
+            deploy_resp = self.payloads_data.get("deploy_resp")
+            config_preview_resp = self.payloads_data.get("config_preview_resp")
+
+            self.run_dcnm_send.side_effect = [self.mock_monitor_false_resp,
+                                              self.mock_monitor_false_resp,
+                                              [],
+                                              merge_links_resp,
+                                              deploy_resp,
+                                              config_preview_resp]
+
+        if "test_dcnm_inter_links_dst_fab_rw_src_sw_non_mgbl" in self._testMethodName:
+
+            merge_links_resp = self.payloads_data.get(
+                "merge_links_fabric_response"
+            )
+            deploy_resp = self.payloads_data.get("deploy_resp")
+            config_preview_resp = self.payloads_data.get("config_preview_resp")
+
+            self.run_dcnm_send.side_effect = [self.mock_monitor_false_resp,
+                                              self.mock_monitor_false_resp,
+                                              [],
+                                              merge_links_resp,
+                                              deploy_resp,
+                                              config_preview_resp]
+
+        if "test_dcnm_inter_links_dst_fab_rw_src_dst_sw_non_mgbl" in self._testMethodName:
+
+            merge_links_resp = self.payloads_data.get(
+                "merge_links_fabric_response"
+            )
+            deploy_resp = self.payloads_data.get("deploy_resp")
+            config_preview_resp = self.payloads_data.get("config_preview_resp")
+
+            self.run_dcnm_send.side_effect = [self.mock_monitor_false_resp,
+                                              self.mock_monitor_false_resp,
+                                              [],
+                                              merge_links_resp,
+                                              deploy_resp,
+                                              config_preview_resp]
+
+        if "test_dcnm_inter_links_dst_fab_rw_src_dst_sw_mgbl" in self._testMethodName:
+
+            merge_links_resp = self.payloads_data.get(
+                "merge_links_fabric_response"
+            )
+            deploy_resp = self.payloads_data.get("deploy_resp")
+            config_preview_resp = self.payloads_data.get("config_preview_resp")
+
+            self.run_dcnm_send.side_effect = [self.mock_monitor_false_resp,
+                                              self.mock_monitor_false_resp,
+                                              [],
+                                              merge_links_resp,
+                                              deploy_resp,
+                                              deploy_resp,
+                                              config_preview_resp,
+                                              config_preview_resp,
+                                              config_preview_resp]
+
         # -------------------------- INTRA-FABRIC-UNNUMBERED --------------------------
 
         if (
@@ -125,6 +253,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 [],
                 [],
                 merge_links_resp,
@@ -145,6 +274,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 [],
                 [],
                 merge_links_resp,
@@ -163,6 +293,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             )
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 [],
                 [],
                 merge_links_resp,
@@ -187,6 +318,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 have_links_resp1,
                 have_links_resp2,
                 deploy_resp,
@@ -205,6 +337,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 [],
                 [],
                 merge_links_resp,
@@ -235,6 +368,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 have_links_resp1,
                 have_links_resp2,
                 merge_links_resp,
@@ -260,6 +394,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 have_links_resp1,
                 have_links_resp2,
                 merge_links_resp,
@@ -285,6 +420,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 have_links_resp1,
                 have_links_resp2,
                 merge_links_resp,
@@ -310,6 +446,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 have_links_resp1,
                 have_links_resp2,
                 [],
@@ -336,6 +473,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 have_links_resp1,
                 [],
                 [],
@@ -351,7 +489,9 @@ class TestDcnmLinksModule(TestDcnmModule):
             == self._testMethodName
         ):
 
-            self.run_dcnm_send.side_effect = [[], [], [], [], []]
+            self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
+                [], [], [], [], []]
 
         if (
             "test_dcnm_intra_links_unnumbered_template_change"
@@ -368,6 +508,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 have_links_resp1,
                 merge_links_resp,
                 deploy_resp,
@@ -379,7 +520,9 @@ class TestDcnmLinksModule(TestDcnmModule):
             query_links_resp = self.payloads_data.get(
                 "intra_query_links_unnum_fabric_response"
             )
-            self.run_dcnm_send.side_effect = [query_links_resp]
+            self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
+                query_links_resp]
 
         # -------------------------- INTRA-FABRIC-IPV6 ----------------------------------
 
@@ -395,6 +538,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 [],
                 [],
                 [],
@@ -414,6 +558,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 [],
                 [],
                 [],
@@ -445,6 +590,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 have_links_resp1,
                 have_links_resp2,
                 have_links_resp3,
@@ -464,6 +610,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 [],
                 [],
                 [],
@@ -494,6 +641,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 have_links_resp1,
                 have_links_resp2,
                 have_links_resp3,
@@ -523,6 +671,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 have_links_resp1,
                 have_links_resp2,
                 have_links_resp3,
@@ -553,6 +702,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 have_links_resp1,
                 have_links_resp2,
                 have_links_resp3,
@@ -583,6 +733,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 have_links_resp1,
                 have_links_resp2,
                 have_links_resp3,
@@ -614,6 +765,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 have_links_resp1,
                 have_links_resp2,
                 have_links_resp3,
@@ -630,14 +782,18 @@ class TestDcnmLinksModule(TestDcnmModule):
             == self._testMethodName
         ):
 
-            self.run_dcnm_send.side_effect = [[], [], [], [], []]
+            self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
+                [], [], [], [], []]
 
         if "test_dcnm_intra_links_ipv6_query" in self._testMethodName:
 
             query_links_resp = self.payloads_data.get(
                 "intra_query_links_ipv6_fabric_response"
             )
-            self.run_dcnm_send.side_effect = [query_links_resp]
+            self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
+                query_links_resp]
 
         # -------------------------- INTRA-FABRIC-NUMBERED --------------------------
 
@@ -653,6 +809,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 [],
                 [],
                 [],
@@ -672,6 +829,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 [],
                 [],
                 [],
@@ -703,6 +861,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 have_links_resp1,
                 have_links_resp2,
                 have_links_resp3,
@@ -722,6 +881,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 [],
                 [],
                 [],
@@ -751,6 +911,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 have_links_resp1,
                 have_links_resp2,
                 have_links_resp3,
@@ -780,6 +941,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 have_links_resp1,
                 have_links_resp2,
                 have_links_resp3,
@@ -810,6 +972,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 have_links_resp1,
                 have_links_resp2,
                 have_links_resp3,
@@ -840,6 +1003,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 have_links_resp1,
                 have_links_resp2,
                 have_links_resp3,
@@ -871,6 +1035,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 have_links_resp1,
                 have_links_resp2,
                 have_links_resp3,
@@ -887,7 +1052,9 @@ class TestDcnmLinksModule(TestDcnmModule):
             == self._testMethodName
         ):
 
-            self.run_dcnm_send.side_effect = [[], [], [], [], []]
+            self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
+                [], [], [], [], []]
 
         if (
             "test_dcnm_intra_links_numbered_template_change"
@@ -904,6 +1071,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 have_links_resp1,
                 merge_links_resp,
                 deploy_resp,
@@ -915,7 +1083,9 @@ class TestDcnmLinksModule(TestDcnmModule):
             query_links_resp = self.payloads_data.get(
                 "intra_query_links_num_fabric_response"
             )
-            self.run_dcnm_send.side_effect = [query_links_resp]
+            self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
+                query_links_resp]
 
         # ------------------------------ INTRA-FABRIC-VPC ---------------------------
 
@@ -931,6 +1101,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 [],
                 merge_links_resp,
                 deploy_resp,
@@ -946,6 +1117,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 [],
                 merge_links_resp,
                 deploy_resp,
@@ -964,6 +1136,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 have_links_resp1,
                 deploy_resp,
                 config_preview_resp,
@@ -981,6 +1154,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 [],
                 merge_links_resp,
                 deploy_resp,
@@ -1001,6 +1175,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 have_links_resp1,
                 merge_links_resp,
                 deploy_resp,
@@ -1019,6 +1194,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 have_links_resp1,
                 merge_links_resp,
                 deploy_resp,
@@ -1040,6 +1216,7 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
                 have_links_resp1,
                 merge_links_resp,
                 deploy_resp,
@@ -1058,10 +1235,11 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
+                [],
+                [],
+                [],
                 have_links_resp1,
-                [],
-                [],
-                [],
                 [],
                 delete_links_resp,
                 deploy_resp,
@@ -1083,10 +1261,11 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
+                [],
+                [],
+                [],
                 have_links_resp1,
-                [],
-                [],
-                [],
                 [],
                 delete_links_resp,
                 deploy_resp,
@@ -1098,14 +1277,18 @@ class TestDcnmLinksModule(TestDcnmModule):
             == self._testMethodName
         ):
 
-            self.run_dcnm_send.side_effect = [[], [], [], [], []]
+            self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
+                [], [], [], [], []]
 
         if "test_dcnm_intra_links_vpc_query" in self._testMethodName:
 
             query_links_resp = self.payloads_data.get(
                 "intra_query_links_vpc_response"
             )
-            self.run_dcnm_send.side_effect = [query_links_resp]
+            self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
+                query_links_resp]
 
         # -------------------------- INTER-FABRIC-NUMBERED --------------------------
 
@@ -1121,6 +1304,9 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
+                self.mock_monitor_false_resp,
+                self.mock_monitor_false_resp,
                 [],
                 [],
                 [],
@@ -1150,6 +1336,9 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
+                self.mock_monitor_false_resp,
+                self.mock_monitor_false_resp,
                 [],
                 [],
                 [],
@@ -1200,6 +1389,9 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
+                self.mock_monitor_false_resp,
+                self.mock_monitor_false_resp,
                 have_links_resp1,
                 have_links_resp2,
                 have_links_resp3,
@@ -1226,6 +1418,9 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
+                self.mock_monitor_false_resp,
+                self.mock_monitor_false_resp,
                 [],
                 [],
                 [],
@@ -1271,6 +1466,9 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
+                self.mock_monitor_false_resp,
+                self.mock_monitor_false_resp,
                 have_links_resp1,
                 have_links_resp2,
                 have_links_resp3,
@@ -1318,6 +1516,9 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
+                self.mock_monitor_false_resp,
+                self.mock_monitor_false_resp,
                 have_links_resp1,
                 have_links_resp2,
                 have_links_resp3,
@@ -1368,6 +1569,9 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
+                self.mock_monitor_false_resp,
+                self.mock_monitor_false_resp,
                 have_links_resp1,
                 have_links_resp2,
                 have_links_resp3,
@@ -1418,6 +1622,9 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
+                self.mock_monitor_false_resp,
+                self.mock_monitor_false_resp,
                 have_links_resp1,
                 have_links_resp2,
                 have_links_resp3,
@@ -1464,6 +1671,9 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
+                self.mock_monitor_false_resp,
+                self.mock_monitor_false_resp,
                 have_links_resp1,
                 have_links_resp2,
                 have_links_resp3,
@@ -1487,7 +1697,11 @@ class TestDcnmLinksModule(TestDcnmModule):
             == self._testMethodName
         ):
 
-            self.run_dcnm_send.side_effect = [[], [], [], [], [], []]
+            self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
+                self.mock_monitor_false_resp,
+                self.mock_monitor_false_resp,
+                [], [], [], [], [], []]
 
         if (
             "test_dcnm_inter_links_numbered_template_change"
@@ -1504,6 +1718,8 @@ class TestDcnmLinksModule(TestDcnmModule):
             config_preview_resp = self.payloads_data.get("config_preview_resp")
 
             self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
+                self.mock_monitor_false_resp,
                 have_links_resp1,
                 merge_links_resp,
                 deploy_resp,
@@ -1512,12 +1728,23 @@ class TestDcnmLinksModule(TestDcnmModule):
                 config_preview_resp,
             ]
 
-        if "test_dcnm_inter_links_numbered_query" in self._testMethodName:
+        if "test_dcnm_inter_links_numbered_query_no_config" in self._testMethodName:
 
             query_links_resp = self.payloads_data.get(
                 "inter_query_links_num_fabric_response"
             )
-            self.run_dcnm_send.side_effect = [query_links_resp]
+            self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
+                query_links_resp]
+        elif "test_dcnm_inter_links_numbered_query" in self._testMethodName:
+
+            query_links_resp = self.payloads_data.get(
+                "inter_query_links_num_fabric_response"
+            )
+            self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
+                self.mock_monitor_false_resp,
+                query_links_resp]
 
     def load_fixtures(self, response=None, device=""):
 
@@ -1549,6 +1776,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -1583,6 +1812,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -1617,6 +1848,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -1651,6 +1884,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -1685,6 +1920,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -1722,6 +1959,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -1757,6 +1996,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -1792,6 +2033,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -1827,6 +2070,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -1862,6 +2107,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -1897,6 +2144,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -1932,6 +2181,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -1967,6 +2218,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -1998,6 +2251,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -2029,6 +2284,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -2060,6 +2317,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -2091,6 +2350,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -2122,6 +2383,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -2151,6 +2414,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -2186,6 +2451,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_umnum_fab_data"
         )
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -2222,6 +2489,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -2258,6 +2527,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -2293,6 +2564,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -2329,6 +2602,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -2365,6 +2640,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -2404,6 +2681,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -2443,6 +2722,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -2482,6 +2763,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -2521,6 +2804,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -2562,6 +2847,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -2601,6 +2888,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -2638,6 +2927,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -2677,6 +2968,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -2708,6 +3001,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -2741,6 +3036,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -2774,6 +3071,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -2807,6 +3106,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -2840,6 +3141,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -2873,6 +3176,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -2904,6 +3209,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -2937,6 +3244,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_ipv6_fab_info = self.payloads_data.get("mock_ipv6_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -2971,6 +3280,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_ipv6_fab_info = self.payloads_data.get("mock_ipv6_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -3005,6 +3316,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_ipv6_fab_info = self.payloads_data.get("mock_ipv6_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -3039,6 +3352,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_ipv6_fab_info = self.payloads_data.get("mock_ipv6_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -3073,6 +3388,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_ipv6_fab_info = self.payloads_data.get("mock_ipv6_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -3108,6 +3425,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_ipv6_fab_info = self.payloads_data.get("mock_ipv6_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -3143,6 +3462,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_ipv6_fab_info = self.payloads_data.get("mock_ipv6_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -3180,6 +3501,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_ipv6_fab_info = self.payloads_data.get("mock_ipv6_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -3215,6 +3538,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_ipv6_fab_info = self.payloads_data.get("mock_ipv6_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -3250,6 +3575,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_ipv6_fab_info = self.payloads_data.get("mock_ipv6_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -3285,6 +3612,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_ipv6_fab_info = self.payloads_data.get("mock_ipv6_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -3318,6 +3647,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_ipv6_fab_info = self.payloads_data.get("mock_ipv6_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -3349,6 +3680,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_ipv6_fab_info = self.payloads_data.get("mock_ipv6_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -3380,6 +3713,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_ipv6_fab_info = self.payloads_data.get("mock_ipv6_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -3411,6 +3746,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_ipv6_fab_info = self.payloads_data.get("mock_ipv6_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -3442,6 +3779,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_ipv6_fab_info = self.payloads_data.get("mock_ipv6_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -3473,6 +3812,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_ipv6_fab_info = self.payloads_data.get("mock_ipv6_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -3502,6 +3843,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_ipv6_fab_info = self.payloads_data.get("mock_ipv6_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -3533,6 +3876,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_ipv6_fab_info = self.payloads_data.get("mock_ipv6_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -3566,6 +3911,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -3598,6 +3945,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -3630,6 +3979,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -3662,6 +4013,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -3694,6 +4047,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -3727,6 +4082,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -3760,6 +4117,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -3793,6 +4152,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -3826,6 +4187,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -3859,6 +4222,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -3892,6 +4257,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -3925,6 +4292,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -3956,6 +4325,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -3987,6 +4358,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -4018,6 +4391,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -4049,6 +4424,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -4080,6 +4457,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -4109,6 +4488,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -4146,6 +4527,8 @@ class TestDcnmLinksModule(TestDcnmModule):
             "mock_unnum_fab_data"
         )
         self.mock_ipv6_fab_info = self.payloads_data.get("mock_ipv6_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -4182,6 +4565,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
@@ -4222,6 +4607,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
@@ -4262,6 +4649,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
@@ -4302,6 +4691,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
@@ -4345,6 +4736,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
@@ -4386,6 +4779,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
@@ -4427,6 +4822,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
@@ -4468,6 +4865,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
@@ -4509,6 +4908,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
@@ -4550,6 +4951,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
@@ -4589,6 +4992,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
@@ -4629,6 +5034,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
@@ -4664,6 +5071,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
@@ -4699,6 +5108,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
@@ -4734,6 +5145,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
@@ -4769,6 +5182,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
@@ -4804,6 +5219,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
@@ -4837,6 +5254,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
@@ -4872,6 +5291,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
         self.mock_unnum_fab_info = self.payloads_data.get(
             "mock_unnum_fab_data"
         )
@@ -4909,6 +5330,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -4940,6 +5363,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(dict(state="merged", config=self.playbook_config))
 
@@ -4967,6 +5392,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -5000,6 +5427,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -5034,6 +5463,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -5068,6 +5499,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -5101,6 +5534,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -5134,6 +5569,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -5167,6 +5604,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
         self.mock_ipv6_fab_info = self.payloads_data.get("mock_ipv6_fab_data")
 
         set_module_args(
@@ -5202,6 +5641,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
         self.mock_ipv6_fab_info = self.payloads_data.get("mock_ipv6_fab_data")
 
         set_module_args(
@@ -5237,6 +5678,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -5271,6 +5714,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -5303,6 +5748,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -5336,6 +5783,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -5371,6 +5820,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -5402,6 +5853,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(dict(state="merged", config=self.playbook_config))
 
@@ -5429,6 +5882,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -5462,6 +5917,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -5496,6 +5953,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -5530,6 +5989,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -5563,6 +6024,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -5596,6 +6059,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -5629,6 +6094,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
         self.mock_ipv6_fab_info = self.payloads_data.get("mock_ipv6_fab_data")
 
         set_module_args(
@@ -5663,6 +6130,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
         self.mock_ipv6_fab_info = self.payloads_data.get("mock_ipv6_fab_data")
 
         set_module_args(
@@ -5697,6 +6166,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -5730,6 +6201,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -5763,6 +6236,8 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
 
         set_module_args(
             dict(
@@ -5781,3 +6256,307 @@ class TestDcnmLinksModule(TestDcnmModule):
             self.assertEqual(
                 ("ipv4_addr : Required parameter not found" in str(e)), True
             )
+
+    # ---------------------- INTER-FABRIC MISC ----------------------------
+
+    def test_dcnm_inter_links_src_fab_ro(self):
+
+        # load the json from playbooks
+        self.config_data = loadPlaybookData("dcnm_links_configs")
+        self.payloads_data = loadPlaybookData("dcnm_links_payloads")
+
+        # load required config data
+        self.playbook_config = self.config_data.get(
+            "inter_src_fab_ro_config"
+        )
+        self.mock_ip_sn = self.payloads_data.get("mock_ip_sn")
+        self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
+        self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
+        self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
+
+        set_module_args(
+            dict(
+                state="merged",
+                src_fabric="mmudigon-src-fab-ro",
+                config=self.playbook_config,
+            )
+        )
+
+        result = None
+
+        try:
+            result = self.execute_module(changed=False, failed=False)
+        except Exception as e:
+            self.assertEqual(result, None)
+            self.assertEqual(
+                ("is in Monitoring mode" in str(e)), True
+            )
+            self.assertEqual(
+                ("No changes are allowed on the fabric" in str(e)), True
+            )
+
+    def test_dcnm_inter_links_dst_fab_ro_dst_sw_non_mgbl(self):
+
+        # load the json from playbooks
+        self.config_data = loadPlaybookData("dcnm_links_configs")
+        self.payloads_data = loadPlaybookData("dcnm_links_payloads")
+
+        # load required config data
+        self.playbook_config = self.config_data.get(
+            "inter_dst_fab_ro_dst_sw_non_mgbl_config"
+        )
+        self.mock_ip_sn = self.payloads_data.get("mock_ip_sn")
+        self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
+        self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
+        self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
+
+        set_module_args(
+            dict(
+                state="merged",
+                src_fabric="mmudigon-numbered",
+                config=self.playbook_config,
+            )
+        )
+
+        result = self.execute_module(changed=True, failed=False)
+
+        self.assertEqual(len(result["diff"][0]["merged"]), 1)
+        self.assertEqual(len(result["diff"][0]["modified"]), 0)
+        self.assertEqual(len(result["diff"][0]["deleted"]), 0)
+        self.assertEqual(len(result["diff"][0]["deploy"][0]["mmudigon-numbered"]), 1)
+        self.assertEqual(len(result["diff"][0]["deploy"][0]["mmudigon-dst-fab-ro"]), 0)
+
+    def test_dcnm_inter_links_dst_fab_ro_src_sw_non_mgbl(self):
+
+        # load the json from playbooks
+        self.config_data = loadPlaybookData("dcnm_links_configs")
+        self.payloads_data = loadPlaybookData("dcnm_links_payloads")
+
+        # load required config data
+        self.playbook_config = self.config_data.get(
+            "inter_dst_fab_ro_src_sw_non_mgbl_config"
+        )
+        self.mock_ip_sn = self.payloads_data.get("mock_ip_sn")
+        self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
+        self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
+        self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
+
+        set_module_args(
+            dict(
+                state="merged",
+                src_fabric="mmudigon-numbered",
+                config=self.playbook_config,
+            )
+        )
+
+        result = self.execute_module(changed=True, failed=False)
+
+        self.assertEqual(len(result["diff"][0]["merged"]), 1)
+        self.assertEqual(len(result["diff"][0]["modified"]), 0)
+        self.assertEqual(len(result["diff"][0]["deleted"]), 0)
+        self.assertEqual(len(result["diff"][0]["deploy"][0]["mmudigon-numbered"]), 0)
+        self.assertEqual(len(result["diff"][0]["deploy"][0]["mmudigon-dst-fab-ro"]), 0)
+
+    def test_dcnm_inter_links_dst_fab_ro_src_dst_sw_non_mgbl(self):
+
+        # load the json from playbooks
+        self.config_data = loadPlaybookData("dcnm_links_configs")
+        self.payloads_data = loadPlaybookData("dcnm_links_payloads")
+
+        # load required config data
+        self.playbook_config = self.config_data.get(
+            "inter_dst_fab_ro_src_dst_sw_non_mgbl_config"
+        )
+        self.mock_ip_sn = self.payloads_data.get("mock_ip_sn")
+        self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
+        self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
+        self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
+
+        set_module_args(
+            dict(
+                state="merged",
+                src_fabric="mmudigon-numbered",
+                config=self.playbook_config,
+            )
+        )
+
+        result = self.execute_module(changed=True, failed=False)
+
+        self.assertEqual(len(result["diff"][0]["merged"]), 1)
+        self.assertEqual(len(result["diff"][0]["modified"]), 0)
+        self.assertEqual(len(result["diff"][0]["deleted"]), 0)
+        self.assertEqual(len(result["diff"][0]["deploy"][0]["mmudigon-numbered"]), 0)
+        self.assertEqual(len(result["diff"][0]["deploy"][0]["mmudigon-dst-fab-ro"]), 0)
+
+    def test_dcnm_inter_links_dst_fab_ro_src_dst_sw_mgbl(self):
+
+        # load the json from playbooks
+        self.config_data = loadPlaybookData("dcnm_links_configs")
+        self.payloads_data = loadPlaybookData("dcnm_links_payloads")
+
+        # load required config data
+        self.playbook_config = self.config_data.get(
+            "inter_dst_fab_ro_src_dst_sw_mgbl_config"
+        )
+        self.mock_ip_sn = self.payloads_data.get("mock_ip_sn")
+        self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
+        self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
+        self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
+
+        set_module_args(
+            dict(
+                state="merged",
+                src_fabric="mmudigon-numbered",
+                config=self.playbook_config,
+            )
+        )
+
+        result = self.execute_module(changed=True, failed=False)
+
+        self.assertEqual(len(result["diff"][0]["merged"]), 1)
+        self.assertEqual(len(result["diff"][0]["modified"]), 0)
+        self.assertEqual(len(result["diff"][0]["deleted"]), 0)
+        self.assertEqual(len(result["diff"][0]["deploy"][0]["mmudigon-numbered"]), 1)
+        self.assertEqual(len(result["diff"][0]["deploy"][0]["mmudigon-dst-fab-ro"]), 0)
+
+    def test_dcnm_inter_links_dst_fab_rw_dst_sw_non_mgbl(self):
+
+        # load the json from playbooks
+        self.config_data = loadPlaybookData("dcnm_links_configs")
+        self.payloads_data = loadPlaybookData("dcnm_links_payloads")
+
+        # load required config data
+        self.playbook_config = self.config_data.get(
+            "inter_dst_fab_rw_dst_sw_non_mgbl_config"
+        )
+        self.mock_ip_sn = self.payloads_data.get("mock_ip_sn")
+        self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
+        self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
+        self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
+
+        set_module_args(
+            dict(
+                state="merged",
+                src_fabric="mmudigon-numbered",
+                config=self.playbook_config,
+            )
+        )
+
+        result = self.execute_module(changed=True, failed=False)
+
+        self.assertEqual(len(result["diff"][0]["merged"]), 1)
+        self.assertEqual(len(result["diff"][0]["modified"]), 0)
+        self.assertEqual(len(result["diff"][0]["deleted"]), 0)
+        self.assertEqual(len(result["diff"][0]["deploy"][0]["mmudigon-numbered"]), 1)
+        self.assertEqual(len(result["diff"][0]["deploy"][0]["mmudigon-dst-fab-rw"]), 0)
+
+    def test_dcnm_inter_links_dst_fab_rw_src_sw_non_mgbl(self):
+
+        # load the json from playbooks
+        self.config_data = loadPlaybookData("dcnm_links_configs")
+        self.payloads_data = loadPlaybookData("dcnm_links_payloads")
+
+        # load required config data
+        self.playbook_config = self.config_data.get(
+            "inter_dst_fab_rw_src_sw_non_mgbl_config"
+        )
+        self.mock_ip_sn = self.payloads_data.get("mock_ip_sn")
+        self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
+        self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
+        self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
+
+        set_module_args(
+            dict(
+                state="merged",
+                src_fabric="mmudigon-numbered",
+                config=self.playbook_config,
+            )
+        )
+
+        result = self.execute_module(changed=True, failed=False)
+
+        self.assertEqual(len(result["diff"][0]["merged"]), 1)
+        self.assertEqual(len(result["diff"][0]["modified"]), 0)
+        self.assertEqual(len(result["diff"][0]["deleted"]), 0)
+        self.assertEqual(len(result["diff"][0]["deploy"][0]["mmudigon-numbered"]), 0)
+        self.assertEqual(len(result["diff"][0]["deploy"][0]["mmudigon-dst-fab-rw"]), 0)
+
+    def test_dcnm_inter_links_dst_fab_rw_src_dst_sw_non_mgbl(self):
+
+        # load the json from playbooks
+        self.config_data = loadPlaybookData("dcnm_links_configs")
+        self.payloads_data = loadPlaybookData("dcnm_links_payloads")
+
+        # load required config data
+        self.playbook_config = self.config_data.get(
+            "inter_dst_fab_rw_src_dst_sw_non_mgbl_config"
+        )
+        self.mock_ip_sn = self.payloads_data.get("mock_ip_sn")
+        self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
+        self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
+        self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
+
+        set_module_args(
+            dict(
+                state="merged",
+                src_fabric="mmudigon-numbered",
+                config=self.playbook_config,
+            )
+        )
+
+        result = self.execute_module(changed=True, failed=False)
+
+        self.assertEqual(len(result["diff"][0]["merged"]), 1)
+        self.assertEqual(len(result["diff"][0]["modified"]), 0)
+        self.assertEqual(len(result["diff"][0]["deleted"]), 0)
+        self.assertEqual(len(result["diff"][0]["deploy"][0]["mmudigon-numbered"]), 0)
+        self.assertEqual(len(result["diff"][0]["deploy"][0]["mmudigon-dst-fab-rw"]), 0)
+
+    def test_dcnm_inter_links_dst_fab_rw_src_dst_sw_mgbl(self):
+
+        # load the json from playbooks
+        self.config_data = loadPlaybookData("dcnm_links_configs")
+        self.payloads_data = loadPlaybookData("dcnm_links_payloads")
+
+        # load required config data
+        self.playbook_config = self.config_data.get(
+            "inter_dst_fab_rw_src_dst_sw_mgbl_config"
+        )
+        self.mock_ip_sn = self.payloads_data.get("mock_ip_sn")
+        self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
+        self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
+        self.mock_num_fab_info = self.payloads_data.get("mock_num_fab_data")
+        self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
+        self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")
+
+        set_module_args(
+            dict(
+                state="merged",
+                src_fabric="mmudigon-numbered",
+                config=self.playbook_config,
+            )
+        )
+
+        result = self.execute_module(changed=True, failed=False)
+
+        self.assertEqual(len(result["diff"][0]["merged"]), 1)
+        self.assertEqual(len(result["diff"][0]["modified"]), 0)
+        self.assertEqual(len(result["diff"][0]["deleted"]), 0)
+        self.assertEqual(len(result["diff"][0]["deploy"][0]["mmudigon-numbered"]), 1)
+        self.assertEqual(len(result["diff"][0]["deploy"][0]["mmudigon-dst-fab-rw"]), 1)


### PR DESCRIPTION
This commit includes changes to dcnm_links module to:
     - identify all switches which are in monitoring state
     - identify all switches which are managable
     - check for monitoring and managable attributes before deploy
     - avoid deploying on fabrics which are in monitoring state
     - avoid deploy to switches which have managable set to false

Added IT and UT cases to verify the above scenarios.
Updated the dcnm.py module to add logicalName to Serial Number mappings to inventory_data in case ipAddress is "". This will be the case for META switches.