### PR TITLE
Fix default mcast group address in network module

### DIFF
--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -2453,7 +2453,12 @@ class DcnmNetwork:
 
         if state == "query":
 
-            if self.dcnm_version > 11:
+            # If ingress replication is enabled multicast group address should be set to "" as default.
+            # If ingress replication is not enabled, the default value for multicast group address
+            # is different for DCNM and NDFC.
+            if self.fabric_det.get("replicationMode") == "Ingress":
+                mcast_group_addr = ""
+            elif self.dcnm_version > 11:
                 mcast_group_addr = "239.1.1.1"
             else:
                 mcast_group_addr = "239.1.1.0"
@@ -2533,8 +2538,12 @@ class DcnmNetwork:
 
         else:
 
-            # The default value for multicast group address is different for DCNM and NDFC.
-            if self.dcnm_version > 11:
+            # If ingress replication is enabled multicast group address should be set to "" as default.
+            # If ingress replication is not enabled, the default value for multicast group address
+            # is different for DCNM and NDFC.
+            if self.fabric_det.get("replicationMode") == "Ingress":
+                mcast_group_addr = ""
+            elif self.dcnm_version > 11:
                 mcast_group_addr = "239.1.1.1"
             else:
                 mcast_group_addr = "239.1.1.0"

--- a/tests/integration/targets/dcnm_network/tests/dcnm/self-contained-tests/ingress_replication_networks.yaml
+++ b/tests/integration/targets/dcnm_network/tests/dcnm/self-contained-tests/ingress_replication_networks.yaml
@@ -1,133 +1,134 @@
 ##############################################
 ##                 SETUP                    ##
 ##############################################
+- block:
+  - set_fact:
+      rest_path: "/rest/control/fabrics/{{ test_ing_fabric }}"
+    when: controller_version == "11"
 
-- set_fact:
-    rest_path: "/rest/control/fabrics/{{ test_ing_fabric }}"
-  when: controller_version == "11"
+  - set_fact:
+      rest_path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ test_ing_fabric }}"
+    when: controller_version >= "12"
 
-- set_fact:
-    rest_path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ test_ing_fabric }}"
-  when: controller_version >= "12"
+  - name: ING_REP - Verify if fabric - Fabric1 is deployed.
+    cisco.dcnm.dcnm_rest:
+      method: GET
+      path: "{{ rest_path }}"
+    register: result
 
-- name: ING_REP - Verify if fabric - Fabric1 is deployed.
-  cisco.dcnm.dcnm_rest:
-    method: GET
-    path: "{{ rest_path }}"
-  register: result
+  - assert:
+      that:
+      - 'result.response.DATA != None'
 
-- assert:
-    that:
-    - 'result.response.DATA != None'
+  - name: ING_REP - Remove all existing networks to start with a clean state
+    cisco.dcnm.dcnm_network:
+      fabric: "{{ test_ing_fabric }}"
+      state: deleted
 
-- name: ING_REP - Remove all existing networks to start with a clean state
-  cisco.dcnm.dcnm_network:
-    fabric: "{{ test_ing_fabric }}"
-    state: deleted
-
-- name: ING_REP - Create vrfs required for this test and remove all other vrfs
-  cisco.dcnm.dcnm_vrf:
-    fabric: "{{ test_ing_fabric }}"
-    state: overridden
-    config:
-    - vrf_name: Tenant-1
-      vrf_id: 9008012
-      vlan_id: 501
-      attach:
-      - ip_address: "{{ ansible_ing_switch1 }}"
-      deploy: true
+  - name: ING_REP - Create vrfs required for this test and remove all other vrfs
+    cisco.dcnm.dcnm_vrf:
+      fabric: "{{ test_ing_fabric }}"
+      state: overridden
+      config:
+      - vrf_name: Tenant-1
+        vrf_id: 9008012
+        vlan_id: 501
+        attach:
+        - ip_address: "{{ ansible_ing_switch1 }}"
+        deploy: true
 
 ##############################################
 ##                MERGED                    ##
 ##############################################
 
-- name: ING_REP - Create New Network with Deploy
-  cisco.dcnm.dcnm_network:
-    fabric: "{{ test_ing_fabric }}"
-    state: merged
-    config:
-    - net_name: ansible-net15
-      vrf_name: Tenant-1
-      net_id: 7005
-      net_template: Default_Network_Universal
-      net_extension_template: Default_Network_Extension_Universal
-      vlan_id: 1500
-      gw_ip_subnet: '192.168.30.1/24'
-      deploy: True
-  register: result
+  - name: ING_REP - Create New Network with Deploy
+    cisco.dcnm.dcnm_network:
+      fabric: "{{ test_ing_fabric }}"
+      state: merged
+      config:
+      - net_name: ansible-net15
+        vrf_name: Tenant-1
+        net_id: 7005
+        net_template: Default_Network_Universal
+        net_extension_template: Default_Network_Extension_Universal
+        vlan_id: 1500
+        gw_ip_subnet: '192.168.30.1/24'
+        deploy: True
+    register: result
 
-- name: Query fabric for creation of Network Object
-  cisco.dcnm.dcnm_network:
-    fabric: "{{ test_ing_fabric }}"
-    state: query
-  register: query_result
-  until:
-    - "query_result.response[0].parent.displayName is search('ansible-net15')"
-    - "query_result.response[0].parent.networkId is search('7005')"
-    - "query_result.response[0].parent.vrf is search('Tenant-1')"
-  retries: 5
-  delay: 2
+  - name: Query fabric for creation of Network Object
+    cisco.dcnm.dcnm_network:
+      fabric: "{{ test_ing_fabric }}"
+      state: query
+    register: query_result
+    until:
+      - "query_result.response[0].parent.displayName is search('ansible-net15')"
+      - "query_result.response[0].parent.networkId is search('7005')"
+      - "query_result.response[0].parent.vrf is search('Tenant-1')"
+    retries: 5
+    delay: 2
 
-- assert:
-    that:
-    - 'result.changed == true'
-    - 'result.response[0].RETURN_CODE == 200'
-    - 'result.diff[0].attach|length == 0'
-    - 'result.diff[0].net_name == "ansible-net15"'
-    - 'result.diff[0].net_id == 7005'
-    - 'result.diff[0].vrf_name == "Tenant-1"'
+  - assert:
+      that:
+      - 'result.changed == true'
+      - 'result.response[0].RETURN_CODE == 200'
+      - 'result.diff[0].attach|length == 0'
+      - 'result.diff[0].net_name == "ansible-net15"'
+      - 'result.diff[0].net_id == 7005'
+      - 'result.diff[0].vrf_name == "Tenant-1"'
 
-- name: ING_REP - setup - Clean up any existing networks
-  cisco.dcnm.dcnm_network:
-    fabric: "{{ test_ing_fabric }}"
-    state: deleted
+  - name: ING_REP - setup - Clean up any existing networks
+    cisco.dcnm.dcnm_network:
+      fabric: "{{ test_ing_fabric }}"
+      state: deleted
 
-- name: MERGED - Create New Network with Attach and global deploy
-  cisco.dcnm.dcnm_network:
-    fabric: "{{ test_ing_fabric }}"
-    state: merged
-    config:
-    - net_name: ansible-net16
-      vrf_name: Tenant-1
-      net_id: 7005
-      net_template: Default_Network_Universal
-      net_extension_template: Default_Network_Extension_Universal
-      vlan_id: 1500
-      gw_ip_subnet: '192.168.30.1/24'
-      attach:
-      - ip_address: "{{ ansible_ing_switch1 }}"
-        ports: ["{{ ansible_ing_sw1_int1 }}", "{{ ansible_ing_sw1_int2 }}"]
-      deploy: True
-  register: result
+  - name: MERGED - Create New Network with Attach and global deploy
+    cisco.dcnm.dcnm_network:
+      fabric: "{{ test_ing_fabric }}"
+      state: merged
+      config:
+      - net_name: ansible-net16
+        vrf_name: Tenant-1
+        net_id: 7005
+        net_template: Default_Network_Universal
+        net_extension_template: Default_Network_Extension_Universal
+        vlan_id: 1500
+        gw_ip_subnet: '192.168.30.1/24'
+        attach:
+        - ip_address: "{{ ansible_ing_switch1 }}"
+          ports: ["{{ ansible_ing_sw1_int1 }}", "{{ ansible_ing_sw1_int2 }}"]
+        deploy: True
+    register: result
 
-- name: Query fabric state until networkStatus transitions to DEPLOYED state
-  cisco.dcnm.dcnm_network:
-    fabric: "{{ test_ing_fabric }}"
-    state: query
-  register: query_result
-  until:
-    - "query_result.response[0].parent.networkStatus is search('DEPLOYED|PENDING')"
-  retries: 30
-  delay: 2
+  - name: Query fabric state until networkStatus transitions to DEPLOYED state
+    cisco.dcnm.dcnm_network:
+      fabric: "{{ test_ing_fabric }}"
+      state: query
+    register: query_result
+    until:
+      - "query_result.response[0].parent.networkStatus is search('DEPLOYED|PENDING')"
+    retries: 30
+    delay: 2
 
-- assert:
-    that:
-    - 'result.changed == true'
-    - 'result.response[0].RETURN_CODE == 200'
-    - 'result.response[1].RETURN_CODE == 200'
-    - 'result.response[2].RETURN_CODE == 200'
-    - '(result.response[1].DATA|dict2items)[0].value == "SUCCESS"'
-    - 'result.diff[0].attach[0].deploy == true'
-    - '"{{ ansible_switch1 }}" in result.diff[0].attach[0].ip_address'
-    - 'result.diff[0].net_name == "ansible-net16"'
-    - 'result.diff[0].net_id == 7005'
-    - 'result.diff[0].vrf_name == "Tenant-1"'
+  - assert:
+      that:
+      - 'result.changed == true'
+      - 'result.response[0].RETURN_CODE == 200'
+      - 'result.response[1].RETURN_CODE == 200'
+      - 'result.response[2].RETURN_CODE == 200'
+      - '(result.response[1].DATA|dict2items)[0].value == "SUCCESS"'
+      - 'result.diff[0].attach[0].deploy == true'
+      - '"{{ ansible_switch1 }}" in result.diff[0].attach[0].ip_address'
+      - 'result.diff[0].net_name == "ansible-net16"'
+      - 'result.diff[0].net_id == 7005'
+      - 'result.diff[0].vrf_name == "Tenant-1"'
 
 ##############################################
 ##                 CLEAN-UP                 ##
 ##############################################
 
-- name: MERGED - setup - remove any networks
-  cisco.dcnm.dcnm_network:
-    fabric: "{{ test_fabric }}"
-    state: deleted
+  - name: MERGED - setup - remove any networks
+    cisco.dcnm.dcnm_network:
+      fabric: "{{ test_fabric }}"
+      state: deleted
+  when: test_ing_fabric is defined

--- a/tests/integration/targets/dcnm_network/tests/dcnm/self-contained-tests/ingress_replication_networks.yaml
+++ b/tests/integration/targets/dcnm_network/tests/dcnm/self-contained-tests/ingress_replication_networks.yaml
@@ -1,0 +1,133 @@
+##############################################
+##                 SETUP                    ##
+##############################################
+
+- set_fact:
+    rest_path: "/rest/control/fabrics/{{ test_ing_fabric }}"
+  when: controller_version == "11"
+
+- set_fact:
+    rest_path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ test_ing_fabric }}"
+  when: controller_version >= "12"
+
+- name: ING_REP - Verify if fabric - Fabric1 is deployed.
+  cisco.dcnm.dcnm_rest:
+    method: GET
+    path: "{{ rest_path }}"
+  register: result
+
+- assert:
+    that:
+    - 'result.response.DATA != None'
+
+- name: ING_REP - Remove all existing networks to start with a clean state
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ test_ing_fabric }}"
+    state: deleted
+
+- name: ING_REP - Create vrfs required for this test and remove all other vrfs
+  cisco.dcnm.dcnm_vrf:
+    fabric: "{{ test_ing_fabric }}"
+    state: overridden
+    config:
+    - vrf_name: Tenant-1
+      vrf_id: 9008012
+      vlan_id: 501
+      attach:
+      - ip_address: "{{ ansible_ing_switch1 }}"
+      deploy: true
+
+##############################################
+##                MERGED                    ##
+##############################################
+
+- name: ING_REP - Create New Network with Deploy
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ test_ing_fabric }}"
+    state: merged
+    config:
+    - net_name: ansible-net15
+      vrf_name: Tenant-1
+      net_id: 7005
+      net_template: Default_Network_Universal
+      net_extension_template: Default_Network_Extension_Universal
+      vlan_id: 1500
+      gw_ip_subnet: '192.168.30.1/24'
+      deploy: True
+  register: result
+
+- name: Query fabric for creation of Network Object
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ test_ing_fabric }}"
+    state: query
+  register: query_result
+  until:
+    - "query_result.response[0].parent.displayName is search('ansible-net15')"
+    - "query_result.response[0].parent.networkId is search('7005')"
+    - "query_result.response[0].parent.vrf is search('Tenant-1')"
+  retries: 5
+  delay: 2
+
+- assert:
+    that:
+    - 'result.changed == true'
+    - 'result.response[0].RETURN_CODE == 200'
+    - 'result.diff[0].attach|length == 0'
+    - 'result.diff[0].net_name == "ansible-net15"'
+    - 'result.diff[0].net_id == 7005'
+    - 'result.diff[0].vrf_name == "Tenant-1"'
+
+- name: ING_REP - setup - Clean up any existing networks
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ test_ing_fabric }}"
+    state: deleted
+
+- name: MERGED - Create New Network with Attach and global deploy
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ test_ing_fabric }}"
+    state: merged
+    config:
+    - net_name: ansible-net16
+      vrf_name: Tenant-1
+      net_id: 7005
+      net_template: Default_Network_Universal
+      net_extension_template: Default_Network_Extension_Universal
+      vlan_id: 1500
+      gw_ip_subnet: '192.168.30.1/24'
+      attach:
+      - ip_address: "{{ ansible_ing_switch1 }}"
+        ports: ["{{ ansible_ing_sw1_int1 }}", "{{ ansible_ing_sw1_int2 }}"]
+      deploy: True
+  register: result
+
+- name: Query fabric state until networkStatus transitions to DEPLOYED state
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ test_ing_fabric }}"
+    state: query
+  register: query_result
+  until:
+    - "query_result.response[0].parent.networkStatus is search('DEPLOYED|PENDING')"
+  retries: 30
+  delay: 2
+
+- assert:
+    that:
+    - 'result.changed == true'
+    - 'result.response[0].RETURN_CODE == 200'
+    - 'result.response[1].RETURN_CODE == 200'
+    - 'result.response[2].RETURN_CODE == 200'
+    - '(result.response[1].DATA|dict2items)[0].value == "SUCCESS"'
+    - 'result.diff[0].attach[0].deploy == true'
+    - '"{{ ansible_switch1 }}" in result.diff[0].attach[0].ip_address'
+    - 'result.diff[0].net_name == "ansible-net16"'
+    - 'result.diff[0].net_id == 7005'
+    - 'result.diff[0].vrf_name == "Tenant-1"'
+
+##############################################
+##                 CLEAN-UP                 ##
+##############################################
+
+- name: MERGED - setup - remove any networks
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ test_fabric }}"
+    state: deleted


### PR DESCRIPTION
The default multicast group address should be "" in case of networks creates in fabrics with ingress replication enabled.