### PR TITLE
Added VPC switch pairing tasks using dcnm_rest in preparatory and cleanup portions of IT

### DIFF
--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -1639,6 +1639,8 @@ class DcnmIntf:
                 "query": [],
                 "debugs": [],
                 "delete_deploy": [],
+                "skipped": [],
+                "deferred": [],
             }
         ]
 
@@ -3823,12 +3825,27 @@ class DcnmIntf:
                 (str(have["isPhysical"]).lower() != "none")
                 and (str(have["isPhysical"]).lower() == "true")
             ):
+
                 if have["alias"] != "" and have["deleteReason"] is not None:
+                    self.changed_dict[0]["skipped"].append(
+                        {
+                            "Name": name,
+                            "Alias": have["alias"],
+                            "Delete Reason": have["deleteReason"],
+                        }
+                    )
                     continue
 
                 if str(have["deletable"]).lower() == "false":
                     # Add this 'have to a deferred list. We will process this list once we have processed all the 'haves'
                     defer_list.append(have)
+                    self.changed_dict[0]["deferred"].append(
+                        {
+                            "Name": name,
+                            "Deletable": have["deletable"],
+                            "Underlay Policies": have["underlayPolicies"],
+                        }
+                    )
                     continue
 
                 uelem = self.dcnm_intf_get_default_eth_payload(
@@ -3903,12 +3920,25 @@ class DcnmIntf:
                             have["alias"] is not None
                             and "vpc-peer-link" in have["alias"]
                         ):
+                            self.changed_dict[0]["skipped"].append(
+                                {"Name": name, "Alias": have["alias"]}
+                            )
                             continue
+                        else:
+                            self.changed_dict[0]["debugs"].append(
+                                {"Name": name, "Alias": have["alias"]}
+                            )
 
                     # Interfaces sometimes take time to get deleted from DCNM. Such interfaces will have
                     # underlayPolicies set to "None". Such interfaces need not be deleted again
 
                     if have["underlayPolicies"] is None:
+                        self.changed_dict[0]["skipped"].append(
+                            {
+                                "Name": name,
+                                "Underlay Policies": have["underlayPolicies"],
+                            }
+                        )
                         continue
 
                     # For interfaces that are matching, leave them alone. We will overwrite the config anyway

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -3907,7 +3907,6 @@ class DcnmIntf:
                     )
                 )
             ):
-
                 # Certain interfaces cannot be deleted, so check before deleting. But if the interface has been marked for delete,
                 # we still go in and check if need to deploy.
                 if (
@@ -3921,12 +3920,24 @@ class DcnmIntf:
                             and "vpc-peer-link" in have["alias"]
                         ):
                             self.changed_dict[0]["skipped"].append(
-                                {"Name": name, "Alias": have["alias"]}
+                                {
+                                    "Name": name,
+                                    "Alias": have["alias"],
+                                    "Underlay Policies": have[
+                                        "underlayPolicies"
+                                    ],
+                                }
                             )
                             continue
                         else:
                             self.changed_dict[0]["debugs"].append(
-                                {"Name": name, "Alias": have["alias"]}
+                                {
+                                    "Name": name,
+                                    "Alias": have["alias"],
+                                    "Underlay Policies": have[
+                                        "underlayPolicies"
+                                    ],
+                                }
                             )
 
                     # Interfaces sometimes take time to get deleted from DCNM. Such interfaces will have
@@ -3936,6 +3947,7 @@ class DcnmIntf:
                         self.changed_dict[0]["skipped"].append(
                             {
                                 "Name": name,
+                                "Alias": have["alias"],
                                 "Underlay Policies": have["underlayPolicies"],
                             }
                         )

--- a/tests/integration/targets/dcnm_interface/tasks/dcnm.yaml
+++ b/tests/integration/targets/dcnm_interface/tasks/dcnm.yaml
@@ -141,4 +141,3 @@
     that:
       - 'item["RETURN_CODE"] == 200'
   loop: '{{ result.response }}'
-

--- a/tests/integration/targets/dcnm_interface/tasks/dcnm.yaml
+++ b/tests/integration/targets/dcnm_interface/tasks/dcnm.yaml
@@ -34,7 +34,7 @@
 ##############################################
 ##          DELETE VXLAN VPC PAIR           ##
 ##############################################
-- name: Fianl Cleanup - Delete DCNM VXLAN Fabric VPC switch pair
+- name: Final Cleanup - Delete DCNM VXLAN Fabric VPC switch pair
   cisco.dcnm.dcnm_rest:
     method: DELETE
     path: "{{ [vpc_delete_path[controller_version], ansible_vxlan_fabric_sno1] | join ('') }}"
@@ -48,13 +48,13 @@
   when: (ansible_vxlan_fabric is defined and ansible_vxlan_fabric_sno1 is defined and ansible_vxlan_fabric_sno2 is defined)
 
 ##############################################
-##          CONFIG SAVE AND PREVIEW         ##
+##          CONFIG SAVE                     ##
 ##############################################
 
 - name: Config Save
   cisco.dcnm.dcnm_rest:
     method: POST
-    path: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ ansible_vxlan_fabric }}/config-save
+    path: "{{ vxlan_config_save_path[controller_version] }}"
   register: result
   when: (ansible_vxlan_fabric is defined and ansible_vxlan_fabric_sno1 is defined and ansible_vxlan_fabric_sno2 is defined)
   ignore_errors: yes
@@ -63,7 +63,7 @@
 ##          DEPLOY VXLAN VPC PAIR           ##
 ##############################################
 
-- name: Fianl Cleanup - Deploy DCNM VXLAN Fabric VPC switch pair
+- name: Final Cleanup - Deploy DCNM VXLAN Fabric VPC switch pair
   cisco.dcnm.dcnm_rest:
     method: POST
     path: "{{ vpc_vxlan_deploy_path[controller_version] }}"
@@ -77,7 +77,7 @@
 ##############################################
 ##          DELETE CXT VPC PAIR             ##
 ##############################################
-- name: Fianl Cleanup - Delete DCNM CXT Fabric VPC switch pair
+- name: Final Cleanup - Delete DCNM CXT Fabric VPC switch pair
   cisco.dcnm.dcnm_rest:
     method: DELETE
     path: "{{ [vpc_delete_path[controller_version], ansible_cxt_fabric_sno1] | join ('') }}"
@@ -91,10 +91,22 @@
   when: (ansible_cxt_fabric is defined and ansible_cxt_fabric_sno1 is defined and ansible_cxt_fabric_sno2 is defined)
 
 ##############################################
+##          CONFIG SAVE                     ##
+##############################################
+
+- name: Config Save
+  cisco.dcnm.dcnm_rest:
+    method: POST
+    path: "{{ cxt_config_save_path[controller_version] }}"
+  register: result
+  when: (ansible_cxt_fabric is defined and ansible_cxt_fabric_sno1 is defined and ansible_cxt_fabric_sno2 is defined)
+  ignore_errors: yes
+
+##############################################
 ##          DEPLOY CXT VPC PAIR             ##
 ##############################################
 
-- name: Fianl Cleanup - Deploy DCNM CXT Fabric VPC switch pair
+- name: Final Cleanup - Deploy DCNM CXT Fabric VPC switch pair
   cisco.dcnm.dcnm_rest:
     method: POST
     path: "{{ vpc_cxt_deploy_path[controller_version] }}"

--- a/tests/integration/targets/dcnm_interface/tasks/dcnm.yaml
+++ b/tests/integration/targets/dcnm_interface/tasks/dcnm.yaml
@@ -19,7 +19,93 @@
   loop_control:
     loop_var: test_case_to_run
 
-- name: Final Cleanup - delete my_lacp my_interface_vlan and my_hsrp policies that we created during init
+###############################################
+##                FACTS                      ##
+###############################################
+- set_fact:
+    vpc_delete_path: {}
+
+- set_fact:
+    vpc_delete_path: "{{ vpc_delete_path | combine (item) }}"
+  with_items:
+    - {'12': '/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/vpcpair?serialNumber='}
+    - {'11': '/rest/vpcpair?serialNumber='}
+
+##############################################
+##          DELETE VXLAN VPC PAIR           ##
+##############################################
+- name: Fianl Cleanup - Delete DCNM VXLAN Fabric VPC switch pair
+  cisco.dcnm.dcnm_rest:
+    method: DELETE
+    path: "{{ [vpc_delete_path[controller_version], ansible_vxlan_fabric_sno1] | join ('') }}"
+  register: result
+  ignore_errors: yes
+  when: (ansible_vxlan_fabric is defined and ansible_vxlan_fabric_sno1 is defined and ansible_vxlan_fabric_sno2 is defined)
+
+- name: Wait for 10 secs
+  wait_for:
+    timeout: 10
+  when: (ansible_vxlan_fabric is defined and ansible_vxlan_fabric_sno1 is defined and ansible_vxlan_fabric_sno2 is defined)
+
+##############################################
+##          CONFIG SAVE AND PREVIEW         ##
+##############################################
+
+- name: Config Save
+  cisco.dcnm.dcnm_rest:
+    method: POST
+    path: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ ansible_vxlan_fabric }}/config-save
+  register: result
+  when: (ansible_vxlan_fabric is defined and ansible_vxlan_fabric_sno1 is defined and ansible_vxlan_fabric_sno2 is defined)
+  ignore_errors: yes
+
+##############################################
+##          DEPLOY VXLAN VPC PAIR           ##
+##############################################
+
+- name: Fianl Cleanup - Deploy DCNM VXLAN Fabric VPC switch pair
+  cisco.dcnm.dcnm_rest:
+    method: POST
+    path: "{{ vpc_vxlan_deploy_path[controller_version] }}"
+  register: result
+  with_sequence: count=1
+  loop_control:
+    pause: 5
+  ignore_errors: yes
+  when: (ansible_vxlan_fabric is defined and ansible_vxlan_fabric_sno1 is defined and ansible_vxlan_fabric_sno2 is defined)
+
+##############################################
+##          DELETE CXT VPC PAIR             ##
+##############################################
+- name: Fianl Cleanup - Delete DCNM CXT Fabric VPC switch pair
+  cisco.dcnm.dcnm_rest:
+    method: DELETE
+    path: "{{ [vpc_delete_path[controller_version], ansible_cxt_fabric_sno1] | join ('') }}"
+  register: result
+  ignore_errors: yes
+  when: (ansible_cxt_fabric is defined and ansible_cxt_fabric_sno1 is defined and ansible_cxt_fabric_sno2 is defined)
+
+- name: Wait for 10 secs
+  wait_for:
+    timeout: 10
+  when: (ansible_cxt_fabric is defined and ansible_cxt_fabric_sno1 is defined and ansible_cxt_fabric_sno2 is defined)
+
+##############################################
+##          DEPLOY CXT VPC PAIR             ##
+##############################################
+
+- name: Fianl Cleanup - Deploy DCNM CXT Fabric VPC switch pair
+  cisco.dcnm.dcnm_rest:
+    method: POST
+    path: "{{ vpc_cxt_deploy_path[controller_version] }}"
+  register: result
+  with_sequence: count=1
+  loop_control:
+    pause: 5
+  ignore_errors: yes
+  when: (ansible_cxt_fabric is defined and ansible_cxt_fabric_sno1 is defined and ansible_cxt_fabric_sno2 is defined)
+
+- name: Final Cleanup - delete my_vpc my_lacp my_interface_vlan and my_hsrp policies that we created during init
   cisco.dcnm.dcnm_policy:
     fabric: "{{ ansible_it_fabric }}"
     state: deleted                     # only choose form [merged, deleted, query]
@@ -27,6 +113,7 @@
       - name: my_interface_vlan
       - name: my_hsrp
       - name: my_lacp
+      - name: my_vpc
       - switch:
           - ip: "{{ ansible_switch1 }}"
           - ip: "{{ ansible_switch2 }}"
@@ -37,6 +124,9 @@
       - 'item["RETURN_CODE"] == 200'
   loop: '{{ result.response }}'
 
+##############################################
+##          DELETE ALL TEMPLATES            ##
+##############################################
 - name: Final Cleanup - delete all templates created during init
   cisco.dcnm.dcnm_template:
     state: deleted       # only choose form [merged, deleted, query]
@@ -44,9 +134,11 @@
       - name: my_interface_vlan
       - name: my_hsrp
       - name: my_lacp
+      - name: my_vpc
   register: result
 
 - assert:
     that:
       - 'item["RETURN_CODE"] == 200'
   loop: '{{ result.response }}'
+

--- a/tests/integration/targets/prepare_dcnm_intf/tasks/main.yaml
+++ b/tests/integration/targets/prepare_dcnm_intf/tasks/main.yaml
@@ -115,6 +115,22 @@
     vpc_vxlan_deploy_path: {}
     cxt_create_path: {}
     vpc_cxt_deploy_path: {}
+    vxlan_config_save_path: {}
+    cxt_config_save_path: {}
+
+- set_fact:
+    vxlan_config_save_path: "{{ vxlan_config_save_path | combine (item) }}"
+  with_items:
+    - {'12': '/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ ansible_vxlan_fabric }}/config-save'}
+    - {'11': '/rest/control/fabrics/{{ ansible_vxlan_fabric }}/config-save'}
+  when: (ansible_vxlan_fabric is defined)
+
+- set_fact:
+    cxt_config_save_path: "{{ cxt_config_save_path | combine (item) }}"
+  with_items:
+    - {'12': '/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ ansible_cxt_fabric }}/config-save'}
+    - {'11': '/rest/control/fabrics/{{ ansible_cxt_fabric }}/config-save'}
+  when: (ansible_cxt_fabric is defined)
 
 - set_fact:
     vpc_create_path: "{{ vpc_create_path | combine (item) }}"
@@ -132,8 +148,8 @@
 - set_fact:
     vpc_cxt_deploy_path: "{{ vpc_cxt_deploy_path | combine (item) }}"
   with_items:
-    - {'12': '/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ ansible_cxt_fabric }}/config-deploy/{{ ansible_vxlan_fabric_sno1 }},{{ ansible_vxlan_fabric_sno2 }}'}
-    - {'11': '/rest/control/fabrics/{{ ansible_cxt_fabric }}/config-deploy/{{ ansible_vxlan_fabric_sno1 }},{{ ansible_vxlan_fabric_sno2 }}'}
+    - {'12': '/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ ansible_cxt_fabric }}/config-deploy/{{ ansible_cxt_fabric_sno1 }},{{ ansible_cxt_fabric_sno2 }}'}
+    - {'11': '/rest/control/fabrics/{{ ansible_cxt_fabric }}/config-deploy/{{ ansible_cxt_fabric_sno1 }},{{ ansible_cxt_fabric_sno2 }}'}
   when: (ansible_cxt_fabric is defined)
 
 - set_fact:
@@ -218,7 +234,7 @@
 - name: Config Save
   cisco.dcnm.dcnm_rest:
     method: POST
-    path: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ ansible_vxlan_fabric }}/config-save
+    path: "{{ vxlan_config_save_path[controller_version] }}"
   register: result
   when: (vxlan_vpc_create == True)
   ignore_errors: yes
@@ -269,7 +285,7 @@
 - name: Config Save
   cisco.dcnm.dcnm_rest:
     method: POST
-    path: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ ansible_cxt_fabric }}/config-save
+    path: "{{ cxt_config_save_path[controller_version] }}"
   register: result
   when: (cxt_vpc_create == True)
   ignore_errors: yes

--- a/tests/integration/targets/prepare_dcnm_intf/tasks/main.yaml
+++ b/tests/integration/targets/prepare_dcnm_intf/tasks/main.yaml
@@ -1,59 +1,295 @@
-    # SVI interfaces require interface-vlan and hsrp features to be enabled
-    
-    - name: Create templates for lacp, interface-vlan and hsrp features
-      cisco.dcnm.dcnm_template:
-        state: merged        # only choose form [merged, deleted, query]
-        config:
-          - name: my_lacp
-            tags: "lacp"
-            description: "internal template for enabling LACP feature"
-            content: |
-              ##
-              ##template content
+# SVI interfaces require interface-vlan and hsrp features to be enabled
+- name: Create templates for vpc, lacp, interface-vlan and hsrp features
+  cisco.dcnm.dcnm_template:
+    state: merged        # only choose form [merged, deleted, query]
+    config:
+      - name: my_vpc
+        tags: "vpc"
+        description: "internal template for enabling VPC feature"
+        content: |
+          ##
+          ##template content
 
-              feature lacp
+          feature vpc
 
-              ##
-          - name: my_interface_vlan
-            tags: "interface_vlan"
-            description: "internal template for enabling interface-vlan feature"
-            content: |
-              ##
-              ##template content
+          ##
+      - name: my_lacp
+        tags: "lacp"
+        description: "internal template for enabling LACP feature"
+        content: |
+          ##
+          ##template content
 
-              feature interface-vlan
+          feature lacp
 
-              ##
-          - name: my_hsrp
-            tags: "hsrp"
-            description: "internal template for enabling hsrp feature"
-            content: |
-              ##
-              ##template content
+          ##
+      - name: my_interface_vlan
+        tags: "interface_vlan"
+        description: "internal template for enabling interface-vlan feature"
+        content: |
+          ##
+          ##template content
 
-              feature hsrp
+          feature interface-vlan
 
-              ##
-      register: result
+          ##
+      - name: my_hsrp
+        tags: "hsrp"
+        description: "internal template for enabling hsrp feature"
+        content: |
+          ##
+          ##template content
+
+          feature hsrp
+
+          ##
+  register: result
 
 # Create the policy to deploy lacp, interface-vlan and hsrp features on the switches
-    - name: Create lacp, interface-vlan and hsrp policies
-      cisco.dcnm.dcnm_policy:
-        fabric: "{{ ansible_it_fabric }}"
-        config:
-          - name: my_interface_vlan  # This must be a valid template name
-            create_additional_policy: false  # Do not create a policy if it already exists
-            priority: 101
-          - name: my_hsrp  # This must be a valid template name
-            create_additional_policy: false  # Do not create a policy if it already exists
-            priority: 101
-          - name: my_lacp  # This must be a valid template name
-            create_additional_policy: false  # Do not create a policy if it already exists
-            priority: 101
+- name: Create vpc, lacp, interface-vlan and hsrp policies
+  cisco.dcnm.dcnm_policy:
+    fabric: "{{ ansible_it_fabric }}"
+    config:
+      - name: my_interface_vlan  # This must be a valid template name
+        create_additional_policy: false  # Do not create a policy if it already exists
+        priority: 101
+      - name: my_hsrp  # This must be a valid template name
+        create_additional_policy: false  # Do not create a policy if it already exists
+        priority: 101
+      - name: my_lacp  # This must be a valid template name
+        create_additional_policy: false  # Do not create a policy if it already exists
+        priority: 101
+      - name: my_vpc   # This must be a valid template name
+        create_additional_policy: false  # Do not create a policy if it already exists
+        priority: 101
 
-          - switch:
-              - ip: "{{ ansible_switch1 }}"
-              - ip: "{{ ansible_switch2 }}"
-        deploy: true
-        state: merged
-      register: result
+      - switch:
+          - ip: "{{ ansible_switch1 }}"
+          - ip: "{{ ansible_switch2 }}"
+    deploy: true
+    state: merged
+  register: result
+
+# Determine the version of Controller
+- name: Determine version of DCNM or NDFC
+  cisco.dcnm.dcnm_rest:
+    method: GET
+    path: /appcenter/cisco/ndfc/api/about/version
+  register: result
+  ignore_errors: yes
+
+- set_fact:
+    controller_version: "{{ result.response['DATA']['version'][0:2] | int }}"
+  when: ( result.response['DATA']['version'] is search("\d\d.\d+") )
+  ignore_errors: yes
+
+- name: Determine version of DCNM or NDFC
+  cisco.dcnm.dcnm_rest:
+    method: GET
+    path: /fm/fmrest/about/version
+  register: result
+  ignore_errors: yes
+
+- set_fact:
+    controller_version: "{{ result.response['DATA']['version'][0:2] | int }}"
+  when: ( result.response['DATA']['version'] is search("\d\d.\d+") )
+  ignore_errors: yes
+
+- name: Determine version of DCNM or NDFC
+  cisco.dcnm.dcnm_rest:
+    method: GET
+    path: /fm/fmrest/about/version
+  register: result
+  ignore_errors: yes
+
+- set_fact:
+    controller_version: '11'
+  when: ( result.response['DATA']['version'] == 'DEVEL' )
+  ignore_errors: yes
+
+###############################################
+##                FACTS                      ##
+###############################################
+- set_fact:
+    vpc_create_path: {}
+    vpc_vxlan_deploy_path: {}
+    cxt_create_path: {}
+    vpc_cxt_deploy_path: {}
+
+- set_fact:
+    vpc_create_path: "{{ vpc_create_path | combine (item) }}"
+  with_items:
+    - {'12': '/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/vpcpair'}
+    - {'11': '/rest/vpcpair'}
+
+- set_fact:
+    vpc_vxlan_deploy_path: "{{ vpc_vxlan_deploy_path | combine (item) }}"
+  with_items:
+    - {'12': '/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ ansible_vxlan_fabric }}/config-deploy/{{ ansible_vxlan_fabric_sno1 }},{{ ansible_vxlan_fabric_sno2 }}'}
+    - {'11': '/rest/control/fabrics/{{ ansible_vxlan_fabric }}/config-deploy/{{ ansible_vxlan_fabric_sno1 }},{{ ansible_vxlan_fabric_sno2 }}'}
+  when: (ansible_vxlan_fabric is defined)
+
+- set_fact:
+    vpc_cxt_deploy_path: "{{ vpc_cxt_deploy_path | combine (item) }}"
+  with_items:
+    - {'12': '/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ ansible_cxt_fabric }}/config-deploy/{{ ansible_vxlan_fabric_sno1 }},{{ ansible_vxlan_fabric_sno2 }}'}
+    - {'11': '/rest/control/fabrics/{{ ansible_cxt_fabric }}/config-deploy/{{ ansible_vxlan_fabric_sno1 }},{{ ansible_vxlan_fabric_sno2 }}'}
+  when: (ansible_cxt_fabric is defined)
+
+- set_fact:
+    vxlan_vpc_create: False
+    vxlan_vpc_deploy: False
+    cxt_vpc_create: False
+    cxt_vpc_deploy: False
+
+- set_fact:
+    vpc_vxlan_data: {
+      "peerOneId": "{{ ansible_vxlan_fabric_sno1 }}",
+      "peerTwoId": "{{ ansible_vxlan_fabric_sno2 }}",
+      "useVirtualPeerlink": false
+    }
+    vxlan_vpc_create: True
+    vxlan_vpc_deploy: True
+  when: (ansible_vxlan_fabric is defined and ansible_vxlan_fabric_sno1 is defined and ansible_vxlan_fabric_sno2 is defined)
+
+- set_fact:
+    vpc_cxt_data: {
+      "peerOneId": "{{ ansible_cxt_fabric_sno1 }}",
+      "peerTwoId": "{{ ansible_cxt_fabric_sno2 }}",
+      "useVirtualPeerlink": false,
+      "nvPairs": {
+        "DOMAIN_ID": "{{ ansible_cxt_vpc_domain_id }}",
+        "PEER1_KEEP_ALIVE_LOCAL_IP": "{{ ansible_cxt_fabric_sw1 }}",
+        "PEER2_KEEP_ALIVE_LOCAL_IP": "{{ ansible_cxt_fabric_sw2 }}",
+        "KEEP_ALIVE_VRF": "management",
+        "isVpcPlus": "false",
+        "fabricPath_switch_id": "",
+        "isVTEPS": "false",
+        "NVE_INTERFACE": "",
+        "PEER1_SOURCE_LOOPBACK": "",
+        "PEER2_SOURCE_LOOPBACK": "",
+        "PEER1_PRIMARY_IP": "",
+        "PEER2_PRIMARY_IP": "",
+        "LOOPBACK_SECONDARY_IP": "",
+        "PEER1_DOMAIN_CONF": "",
+        "PEER2_DOMAIN_CONF": "",
+        "clear_policy": "false",
+        "FABRIC_NAME": "",
+        "PEER1_PCID": "{{ ansible_cxt_vpc_peer1_pcid }}",
+        "PEER2_PCID": "{{ ansible_cxt_vpc_peer2_pcid }}",
+        "PEER1_MEMBER_INTERFACES": "{{ ansible_cxt_vpc_peer1_member }}",
+        "PEER2_MEMBER_INTERFACES": "{{ ansible_cxt_vpc_peer2_member }}",
+        "PC_MODE": "active",
+        "PEER1_PO_DESC": "",
+        "PEER2_PO_DESC": "",
+        "ADMIN_STATE": "true",
+        "ALLOWED_VLANS": "all",
+        "PEER1_PO_CONF": "",
+        "PEER2_PO_CONF": ""
+      }
+    }
+    cxt_vpc_create: True
+    cxt_vpc_deploy: True
+  when: (ansible_cxt_fabric is defined and ansible_cxt_fabric_sno1 is defined and ansible_cxt_fabric_sno2 is defined)
+
+##############################################
+##          CREATE VXLAN VPC PAIR           ##
+##############################################
+
+- name: Create DCNM VPC switch pair
+  cisco.dcnm.dcnm_rest:
+    method: POST
+    path: "{{ vpc_create_path[controller_version] }}"
+    json_data:
+      "{{ vpc_vxlan_data | to_json}}"
+  register: result
+  when: (vxlan_vpc_create == True)
+  ignore_errors: yes
+
+- name: Wait for 10 secs
+  wait_for:
+    timeout: 10
+  when: (vxlan_vpc_create == True)
+
+##############################################
+##          CONFIG SAVE                     ##
+##############################################
+
+- name: Config Save
+  cisco.dcnm.dcnm_rest:
+    method: POST
+    path: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ ansible_vxlan_fabric }}/config-save
+  register: result
+  when: (vxlan_vpc_create == True)
+  ignore_errors: yes
+
+##############################################
+##          DEPLOY VXLAN VPC PAIR           ##
+##############################################
+
+- name: Deploy VPC switch pair
+  cisco.dcnm.dcnm_rest:
+    method: POST
+    path:  "{{ vpc_vxlan_deploy_path[controller_version] }}"
+  register: result
+  with_sequence: count=1
+  loop_control:
+    pause: 5
+  when: (vxlan_vpc_deploy == True)
+  ignore_errors: yes
+
+- name: Wait for 30 secs
+  wait_for:
+    timeout: 30
+  when: (vxlan_vpc_deploy == True)
+
+##############################################
+##          CREATE CXT VPC PAIR             ##
+##############################################
+
+- name: Create DCNM VPC switch pair
+  cisco.dcnm.dcnm_rest:
+    method: POST
+    path: "{{ vpc_create_path[controller_version] }}"
+    json_data:
+      "{{ vpc_cxt_data | to_json}}"
+  register: result
+  when: (cxt_vpc_create == True)
+  ignore_errors: yes
+
+- name: Wait for 20 secs
+  wait_for:
+    timeout: 10
+  when: (cxt_vpc_create == True)
+
+##############################################
+##          CONFIG SAVE                     ##
+##############################################
+
+- name: Config Save
+  cisco.dcnm.dcnm_rest:
+    method: POST
+    path: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ ansible_cxt_fabric }}/config-save
+  register: result
+  when: (cxt_vpc_create == True)
+  ignore_errors: yes
+
+##############################################
+##          DEPLOY CXT VPC PAIR             ##
+##############################################
+
+- name: Deploy VPC switch pair
+  cisco.dcnm.dcnm_rest:
+    method: POST
+    path:  "{{ vpc_cxt_deploy_path[controller_version] }}"
+  register: result
+  with_sequence: count=1
+  loop_control:
+    pause: 5
+  when: (cxt_vpc_deploy == True)
+  ignore_errors: yes
+
+- name: Wait for 30 secs
+  wait_for:
+    timeout: 30
+  when: (cxt_vpc_deploy == True)


### PR DESCRIPTION
This PR includes the following changes:
  - Add tasks to create VPC switch pairing in prepare_dcnm_intf 
  - Create a template and policy to enable VPC feature
  - Cleanup the VPC pairing related information in the Final cleanup tasks

Without these changes, VPC pairing  must be manually created using the GUI since some IT cases involving VPC interfaces are dependent on this. With these changes the pairing task has been automated,