### PR TITLE
dcnm_inventory: Add discovery username and password parameters

### DIFF
--- a/docs/cisco.dcnm.dcnm_inventory_module.rst
+++ b/docs/cisco.dcnm.dcnm_inventory_module.rst
@@ -154,6 +154,40 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>discovery_password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Password for device discovery during POAP and RMA discovery</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>discovery_username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Username for device discovery during POAP and RMA discovery</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>hostname</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -315,6 +349,40 @@ Parameters
                         <div><code>modulesModel</code> is list of model of modules in switch to Bootstrap for RMA.</div>
                         <div><code>gateway</code> is the gateway IP with mask for the switch to Bootstrap for RMA.</div>
                         <div>For other supported config data please refer to NDFC/DCNM configuration guide.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>discovery_password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Password for device discovery during POAP and RMA discovery</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>discovery_username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Username for device discovery during POAP and RMA discovery</div>
                 </td>
             </tr>
             <tr>

--- a/plugins/modules/dcnm_inventory.py
+++ b/plugins/modules/dcnm_inventory.py
@@ -605,7 +605,7 @@ class DcnmInventory:
 
             if poap_upd.get("serialNumber"):
                 self.switch_snos.append(poap_upd["serialNumber"])
-            
+
 
         return poap_upd
 

--- a/plugins/modules/dcnm_inventory.py
+++ b/plugins/modules/dcnm_inventory.py
@@ -486,6 +486,7 @@ from ansible_collections.cisco.dcnm.plugins.module_utils.network.dcnm.dcnm impor
     get_ip_sn_dict,
 )
 
+
 class DcnmInventory:
     def __init__(self, module):
         self.switches = {}
@@ -605,7 +606,6 @@ class DcnmInventory:
 
             if poap_upd.get("serialNumber"):
                 self.switch_snos.append(poap_upd["serialNumber"])
-
 
         return poap_upd
 
@@ -739,7 +739,6 @@ class DcnmInventory:
             resp = self.update_discover_params(inv_upd)
 
             inv_upd["switches"] = resp
-
 
         return inv_upd
 

--- a/plugins/modules/dcnm_inventory.py
+++ b/plugins/modules/dcnm_inventory.py
@@ -1054,6 +1054,12 @@ class DcnmInventory:
                             msg = "user_name must be 'admin' for RMA"
                         if inv["rma"][0].get("serial_number") is None or inv["rma"][0].get("old_serial") is None:
                             msg = "Please provide 'serial_number' and 'old_serial' for RMA"
+                        if inv["rma"][0].get("discovery_username"):
+                            if inv["rma"][0].get("discovery_password") is None:
+                                msg = "discovery_password must be set when discovery_username is specified"
+                        if inv["rma"][0].get("discovery_password"):
+                            if inv["rma"][0].get("discovery_username") is None:
+                                msg = "discovery_username must be set when discovery_password is specified"
                     if msg:
                         self.module.fail_json(msg=msg)
             else:

--- a/plugins/modules/dcnm_inventory.py
+++ b/plugins/modules/dcnm_inventory.py
@@ -106,6 +106,16 @@ options:
         type: list
         elements: dict
         suboptions:
+          discovery_username:
+            description:
+            - Username for device discovery during POAP and RMA discovery
+            type: str
+            required: false
+          discovery_password:
+            description:
+            - Password for device discovery during POAP and RMA discovery
+            type: str
+            required: false
           serial_number:
             description:
             - Serial number of switch to Bootstrap.
@@ -161,6 +171,16 @@ options:
         type: list
         elements: dict
         suboptions:
+          discovery_username:
+            description:
+            - Username for device discovery during POAP and RMA discovery
+            type: str
+            required: false
+          discovery_password:
+            description:
+            - Password for device discovery during POAP and RMA discovery
+            type: str
+            required: false
           serial_number:
             description:
             - Serial number of switch to Bootstrap for RMA.

--- a/plugins/modules/dcnm_inventory.py
+++ b/plugins/modules/dcnm_inventory.py
@@ -466,13 +466,6 @@ from ansible_collections.cisco.dcnm.plugins.module_utils.network.dcnm.dcnm impor
     get_ip_sn_dict,
 )
 
-import datetime
-def logit(msg):
-    with open('/tmp/alog.txt', 'a') as of:
-        d = datetime.datetime.now().replace(microsecond=0).isoformat()
-        of.write("---- %s ----\n%s\n" % (d,msg))
-
-
 class DcnmInventory:
     def __init__(self, module):
         self.switches = {}
@@ -570,7 +563,6 @@ class DcnmInventory:
         state = self.params["state"]
 
         if state == "merged":
-            logit('update_poap_params')
             poap_upd = {
                 "ipAddress": s_ip,
                 "discoveryAuthProtocol": "0",
@@ -588,8 +580,6 @@ class DcnmInventory:
             if poap.get("discovery_username"):
                 poap_upd['discoveryUsername'] = poap["discovery_username"]
                 poap_upd['discoveryPassword'] = poap["discovery_password"]
-
-            logit(poap_upd)
 
             poap_upd = self.discover_poap_params(poap_upd, poap)
 
@@ -640,7 +630,6 @@ class DcnmInventory:
         state = self.params["state"]
 
         if state == "merged":
-            logit('update_rma_params')
             rma_upd = {
                 "ipAddress": s_ip,
                 "discoveryAuthProtocol": "0",
@@ -716,7 +705,6 @@ class DcnmInventory:
             else:
                 pro = 0
 
-            logit('update_create_params')
             inv_upd = {
                 "seedIP": s_ip,
                 "snmpV3AuthProtocol": pro,
@@ -731,7 +719,6 @@ class DcnmInventory:
             resp = self.update_discover_params(inv_upd)
 
             inv_upd["switches"] = resp
-            logit(inv_upd)
 
 
         return inv_upd
@@ -1010,7 +997,6 @@ class DcnmInventory:
 
             msg = None
             if self.config:
-                logit('validate input')
                 for inv in self.config:
                     if (
                         "seed_ip" not in inv
@@ -1390,7 +1376,6 @@ class DcnmInventory:
                     )
                     self.module.fail_json(msg=msg)
                 if lan["ipAddress"] == create["switches"][0]["ipaddr"]:
-                    logit('lancred all switches')
                     set_lan = {
                         "switchIds": lan["switchDbID"],
                         "userName": create["username"],
@@ -1667,7 +1652,6 @@ class DcnmInventory:
 
         if "DATA" in response:
             for resp in response["DATA"]:
-                logit('swap serial')
                 if (resp["serialNumber"] == poap["serialNumber"]):
                     resp.update({"password": poap["password"]})
                     resp.update({"discoveryAuthProtocol": "0"})
@@ -1763,8 +1747,6 @@ class DcnmInventory:
 
 def main():
     """main entry point for module execution"""
-
-    logit('Calling dcnm_inventory module')
 
     element_spec = dict(
         fabric=dict(required=True, type="str"),

--- a/tests/unit/modules/dcnm/fixtures/dcnm_inventory.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_inventory.json
@@ -190,7 +190,9 @@
             "hostname": "test_poap_test",
             "model": "N9K-C9300v",
             "serial_number": "9D2DAUJJFQQ",
-            "version": "9.3(7)"
+            "version": "9.3(7)",
+            "discovery_username": "aaa_username",
+            "discovery_password": "aaa_password"
           }
         ]
       }
@@ -342,6 +344,40 @@
       }
     ],
 
+    "playbook_poap_missing_credentials_password" : [
+      {
+        "password": "password",
+        "seed_ip": "192.168.1.223",
+        "user_name": "admin",
+        "poap": [
+          {
+            "config_data": "{\"modulesModel\": [\"N9K-C9300v\"], \"gateway\": \"192.168.1.1/24\"}",
+            "hostname": "test_poap_test",
+            "model": "N9K-C9300v",
+            "version": "9.3(7)",
+            "discovery_username": "aaa_username"
+          }
+        ]
+      }
+    ],
+
+    "playbook_poap_missing_credentials_username" : [
+      {
+        "password": "password",
+        "seed_ip": "192.168.1.223",
+        "user_name": "admin",
+        "poap": [
+          {
+            "config_data": "{\"modulesModel\": [\"N9K-C9300v\"], \"gateway\": \"192.168.1.1/24\"}",
+            "hostname": "test_poap_test",
+            "model": "N9K-C9300v",
+            "version": "9.3(7)",
+            "discovery_password": "aaa_password"
+          }
+        ]
+      }
+    ],
+
     "playbook_poap_no_model_switch_config" : [
       {
         "password": "password",
@@ -388,7 +424,45 @@
             "model": "N9K-C9300v",
             "serial_number": "9D2DAUJJFQQ",
             "old_serial": "9D2DAUJJFRR",
-            "version": "9.3(7)"
+            "version": "9.3(7)",
+            "discovery_username": "aaa_username",
+            "discovery_password": "aaa_password"
+          }
+        ]
+      }
+    ],
+
+    "playbook_rma_missing_credentials_password" : [
+      {
+        "password": "password",
+        "seed_ip": "192.168.1.223",
+        "user_name": "admin",
+        "rma": [
+          {
+            "config_data": "{\"modulesModel\": [\"N9K-C9300v\"], \"gateway\": \"192.168.1.1/24\"}",
+            "hostname": "test_poap_test",
+            "model": "N9K-C9300v",
+            "version": "9.3(7)",
+            "old_serial": "9D2DAUJJFRR",
+            "discovery_username": "aaa_username"
+          }
+        ]
+      }
+    ],
+
+    "playbook_rma_missing_credentials_username" : [
+      {
+        "password": "password",
+        "seed_ip": "192.168.1.223",
+        "user_name": "admin",
+        "rma": [
+          {
+            "config_data": "{\"modulesModel\": [\"N9K-C9300v\"], \"gateway\": \"192.168.1.1/24\"}",
+            "hostname": "test_poap_test",
+            "model": "N9K-C9300v",
+            "version": "9.3(7)",
+            "old_serial": "9D2DAUJJFRR",
+            "discovery_password": "aaa_password"
           }
         ]
       }

--- a/tests/unit/modules/dcnm/test_dcnm_inventory.py
+++ b/tests/unit/modules/dcnm/test_dcnm_inventory.py
@@ -84,6 +84,10 @@ class TestDcnmInvModule(TestDcnmModule):
     playbook_rma_switch_noserial_config = test_data.get("playbook_rma_switch_noserial_config")
     playbook_rma_switch_nooldserial_config = test_data.get("playbook_rma_switch_nooldserial_config")
     playbook_rma_switch_config = test_data.get("playbook_rma_switch_config")
+    playbook_poap_missing_credentials_password = test_data.get("playbook_poap_missing_credentials_password")
+    playbook_poap_missing_credentials_username = test_data.get("playbook_poap_missing_credentials_username")
+    playbook_rma_missing_credentials_password = test_data.get("playbook_rma_missing_credentials_password")
+    playbook_rma_missing_credentials_username = test_data.get("playbook_rma_missing_credentials_username")
     rma_inv_data = test_data.get("rma_inv_data")
 
     # initial merge switch success
@@ -806,6 +810,9 @@ class TestDcnmInvModule(TestDcnmModule):
         elif "poap_overridden_switch" in self._testMethodName:
             self.init_data()
 
+        elif "poap_missing_credentials" in self._testMethodName:
+            self.init_data()
+
         elif "poap_idempotent_switch" in self._testMethodName:
             self.init_data()
             self.run_dcnm_send.side_effect = [
@@ -1298,7 +1305,6 @@ class TestDcnmInvModule(TestDcnmModule):
                 config=self.playbook_poap_switch_config,
             )
         )
-
         result = self.execute_module(changed=True, failed=False)
 
         for resp in result["response"]:
@@ -1660,3 +1666,67 @@ class TestDcnmInvModule(TestDcnmModule):
         for resp in result["response"]:
             self.assertEqual(resp["RETURN_CODE"], 200)
             self.assertEqual(resp["MESSAGE"], "OK")
+
+    def test_dcnm_inv_poap_missing_credentials_password(self):
+        set_module_args(
+            dict(
+                state="merged",
+                fabric="kharicha-fabric",
+                config=self.playbook_poap_missing_credentials_password,
+            )
+        )
+
+        result = self.execute_module(changed=False, failed=True)
+
+        self.assertEqual(
+            result.get("msg"),
+            "discovery_password must be set when discovery_username is specified",
+        )
+
+    def test_dcnm_inv_poap_missing_credentials_username(self):
+        set_module_args(
+            dict(
+                state="merged",
+                fabric="kharicha-fabric",
+                config=self.playbook_poap_missing_credentials_username,
+            )
+        )
+
+        result = self.execute_module(changed=False, failed=True)
+
+        self.assertEqual(
+            result.get("msg"),
+            "discovery_username must be set when discovery_password is specified",
+        )
+
+    def test_dcnm_inv_rma_missing_credentials_password(self):
+        set_module_args(
+            dict(
+                state="merged",
+                fabric="kharicha-fabric",
+                config=self.playbook_rma_missing_credentials_password,
+            )
+        )
+
+        result = self.execute_module(changed=False, failed=True)
+
+        self.assertEqual(
+            result.get("msg"),
+            "discovery_password must be set when discovery_username is specified",
+        )
+
+    def test_dcnm_inv_rma_missing_credentials_username(self):
+        set_module_args(
+            dict(
+                state="merged",
+                fabric="kharicha-fabric",
+                config=self.playbook_rma_missing_credentials_username,
+            )
+        )
+
+        result = self.execute_module(changed=False, failed=True)
+
+        self.assertEqual(
+            result.get("msg"),
+            "discovery_username must be set when discovery_password is specified",
+        )


### PR DESCRIPTION
This update adds two new parameters called `discovery_username` and `discovery_password` to the `dcnm_inventory` module that are option but used during POAP and RMA workflows.

There are certain usecases like using AAA for authentication where a separate set of credentials may be needed during the discovery phase