### PR TITLE
dcnm_link issues

### DIFF
--- a/docs/cisco.dcnm.dcnm_links_module.rst
+++ b/docs/cisco.dcnm.dcnm_links_module.rst
@@ -835,7 +835,7 @@ Parameters
                 </td>
                 <td>
                         <div>BGP ASN number on the source fabric.</div>
-                        <div>{&#x27;Required for below templates&#x27;: None}</div>
+                        <div>Required for below templates</div>
                         <div>ext_fabric_setup</div>
                         <div>ext_multisite_underlay_setup</div>
                         <div>ext_evpn_multisite_overlay_setup</div>

--- a/docs/cisco.dcnm.dcnm_links_module.rst
+++ b/docs/cisco.dcnm.dcnm_links_module.rst
@@ -182,6 +182,47 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>dci_routing_proto</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>is-is</b>&nbsp;&larr;</div></li>
+                                    <li>ospf</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Routing protocol used on the DCI MPLS link</div>
+                        <div>This parameter is applicable only if template is `ext_vxlan_mpls_underlay_setup` and `mpls_fabric` is `SR`</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>dci_routing_tag</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">"MPLS_UNDERLAY"</div>
+                </td>
+                <td>
+                        <div>Routing Process Tag of DCI Underlay</div>
+                        <div>This parameter is applicable only if template is `ext_vxlan_mpls_underlay_setup`</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>deploy_dci_tracking</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -216,7 +257,11 @@ Parameters
                 </td>
                 <td>
                         <div>BGP ASN number on the destination fabric.</div>
-                        <div>This parameter is required only if template is &#x27;ext_fabric_setup&#x27; or &#x27;ext_multisite_underlay_setup&#x27;. or &quot;ext_evpn_multisite_overlay_setup&quot;</div>
+                        <div>Required for below templates</div>
+                        <div>ext_fabric_setup</div>
+                        <div>ext_multisite_underlay_setup</div>
+                        <div>ext_evpn_multisite_overlay_setup</div>
+                        <div>ext_vxlan_mpls_overlay_setup</div>
                 </td>
             </tr>
             <tr>
@@ -314,6 +359,25 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>global_block_range</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">"16000-23999"</div>
+                </td>
+                <td>
+                        <div>For Segment Routing binding</div>
+                        <div>This parameter is applicable only if template is `ext_vxlan_mpls_underlay_setup` and `mpls_fabric` is `SR`</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>inherit_from_msd</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -387,7 +451,9 @@ Parameters
                 </td>
                 <td>
                         <div>IPV4 address of the source interface with mask.</div>
-                        <div>This parameter is required only if template is &#x27;ext_fabric_setup&#x27; or &#x27;ext_multisite_underlay_setup&#x27;.</div>
+                        <div>Required for below templates</div>
+                        <div>ext_fabric_setup</div>
+                        <div>ext_multisite_underlay_setup</div>
                 </td>
             </tr>
             <tr>
@@ -407,6 +473,28 @@ Parameters
                 <td>
                         <div>Maximum number of iBGP/eBGP paths.</div>
                         <div>This parameter is required only if template is &#x27;ext_multisite_underlay_setup&#x27;.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>mpls_fabric</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>SR</b>&nbsp;&larr;</div></li>
+                                    <li>LDP</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>MPLS LDP or Segment-Routing</div>
+                        <div>This parameter is applicable only if template is `ext_vxlan_mpls_underlay_setup`.</div>
                 </td>
             </tr>
             <tr>
@@ -445,7 +533,31 @@ Parameters
                 </td>
                 <td>
                         <div>IPV4 address of the neighbor switch on the destination fabric.</div>
-                        <div>This parameter is required only if template is &#x27;ext_fabric_setup&#x27; or &#x27;ext_multisite_underlay_setup&#x27; or &quot;ext_evpn_multisite_overlay_setup&quot;</div>
+                        <div>Required for below templates</div>
+                        <div>ext_fabric_setup</div>
+                        <div>ext_multisite_underlay_setup</div>
+                        <div>ext_evpn_multisite_overlay_setup</div>
+                        <div>ext_vxlan_mpls_underlay_setup</div>
+                        <div>ext_vxlan_mpls_overlay_setup</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ospf_area_id</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">"0.0.0.0"</div>
+                </td>
+                <td>
+                        <div>OSPF Area ID in IP address format</div>
+                        <div>This parameter is applicable only if template is `ext_vxlan_mpls_underlay_setup` and `dci_routing_proto` is `ospf`</div>
                 </td>
             </tr>
             <tr>
@@ -554,6 +666,25 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>peer1_sr_mpls_index</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">"0"</div>
+                </td>
+                <td>
+                        <div>Unique SR SID index for the source border</div>
+                        <div>This parameter is applicable only if template is `ext_vxlan_mpls_underlay_setup` and `mpls_fabric` is `SR`</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>peer2_bfd_echo_disable</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -655,6 +786,25 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>peer2_sr_mpls_index</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">"0"</div>
+                </td>
+                <td>
+                        <div>Unique SR SID index for the destination border</div>
+                        <div>This parameter is applicable only if template is `ext_vxlan_mpls_underlay_setup` and `mpls_fabric` is `SR`</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>route_tag</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -685,7 +835,11 @@ Parameters
                 </td>
                 <td>
                         <div>BGP ASN number on the source fabric.</div>
-                        <div>This parameter is required only if template is &#x27;ext_fabric_setup&#x27; or &#x27;ext_multisite_underlay_setup&#x27; or &quot;ext_evpn_multisite_overlay_setup&quot;</div>
+                        <div>{&#x27;Required for below templates&#x27;: None}</div>
+                        <div>ext_fabric_setup</div>
+                        <div>ext_multisite_underlay_setup</div>
+                        <div>ext_evpn_multisite_overlay_setup</div>
+                        <div>ext_vxlan_mpls_overlay_setup</div>
                 </td>
             </tr>
             <tr>
@@ -1030,6 +1184,30 @@ Examples
                   ebpg_auth_key_type: 3                              # optional, required only if ebpg_password_enable is true, and inherit_from_msd
                                                                      # is false. Default is 3
                                                                      # choose from [3 - 3DES, 7 - Cisco ]
+              - dst_fabric: "{{ ansible_unnum_fabric }}"             # Destination fabric
+                src_interface: "{{ intf_1_5 }}"                      # Interface on the Source fabric
+                dst_interface: "{{ intf_1_5 }}"                      # Interface on the Destination fabric
+                src_device: "{{ ansible_num_switch1 }}"              # Device on the Source fabric
+                dst_device: "{{ ansible_unnum_switch1 }}"            # Device on the Destination fabric
+                template: ext_vxlan_mpls_underlay_setup              # Template of MPLS handoff underlay link
+                profile:
+                  ipv4_subnet: 193.168.3.1/30                        # IP address of interface in src fabric with the mask
+                  neighbor_ip: 193.168.3.2                           # IP address of the interface in dst fabric
+                  mpls_fabric: LDP                                   # MPLS handoff protocol, choose from [LDP, SR]
+                  dci_routing_proto: isis                            # Routing protocol used on the DCI MPLS link, choose from [is-is, ospf]
+
+              - dst_fabric: "{{ ansible_unnum_fabric }}"             # Destination fabric
+                src_interface:  Loopback101                          # Loopback interface on the Source fabric
+                dst_interface:  Loopback1                            # Loopback interface on the Destination fabric
+                src_device: "{{ ansible_num_switch1 }}"              # Device on the Source fabric
+                dst_device: "{{ ansible_unnum_switch1 }}"            # Device on the Destination fabric
+                template: ext_vxlan_mpls_overlay_setup               #Template of MPLS handoff overlay link
+                profile:
+                  neighbor_ip: 2.2.2.2 .                             # IP address of the loopback interface of destination device
+                  src_asn: 498278384                                 # BGP ASN in source fabric
+                  dst_asn: 498278384                                 # BGP ASN in destination fabric
+
+
 
     # FABRIC WITH VPC PAIRED SWITCHES
 

--- a/plugins/modules/dcnm_links.py
+++ b/plugins/modules/dcnm_links.py
@@ -171,7 +171,7 @@ options:
           src_asn:
             description:
               - BGP ASN number on the source fabric.
-              - Required for below templates:
+              - Required for below templates
               - ext_fabric_setup
               - ext_multisite_underlay_setup
               - ext_evpn_multisite_overlay_setup
@@ -2687,8 +2687,7 @@ class DcnmLinks:
                 "PEER1_SR_MPLS_INDEX",
                 "PEER2_SR_MPLS_INDEX",
                 "GB_BLOCK_RANGE",
-                "OSPF_AREA_ID"
-                ]
+                "OSPF_AREA_ID"]
             for nv_pair in mpls_underlay_spec_nvpairs:
                 if (
                     str(wlink["nvPairs"][nv_pair]).lower()

--- a/plugins/modules/dcnm_links.py
+++ b/plugins/modules/dcnm_links.py
@@ -146,7 +146,9 @@ options:
           ipv4_subnet:
             description:
               - IPV4 address of the source interface with mask.
-              - This parameter is required only if template is 'ext_fabric_setup' or 'ext_multisite_underlay_setup'.
+              - Required for below templates
+              - ext_fabric_setup
+              - ext_multisite_underlay_setup
             type: str
             required: true
           ipv4_address:
@@ -158,22 +160,32 @@ options:
           neighbor_ip:
             description:
               - IPV4 address of the neighbor switch on the destination fabric.
-              - This parameter is required only if template is 'ext_fabric_setup' or 'ext_multisite_underlay_setup'
-                or "ext_evpn_multisite_overlay_setup"
+              - Required for below templates
+              - ext_fabric_setup
+              - ext_multisite_underlay_setup
+              - ext_evpn_multisite_overlay_setup
+              - ext_vxlan_mpls_underlay_setup
+              - ext_vxlan_mpls_overlay_setup
             type: str
             required: true
           src_asn:
             description:
               - BGP ASN number on the source fabric.
-              - This parameter is required only if template is 'ext_fabric_setup' or 'ext_multisite_underlay_setup'
-                or "ext_evpn_multisite_overlay_setup"
+              - Required for below templates:
+              - ext_fabric_setup
+              - ext_multisite_underlay_setup
+              - ext_evpn_multisite_overlay_setup
+              - ext_vxlan_mpls_overlay_setup
             type: str
             required: true
           dst_asn:
             description:
               - BGP ASN number on the destination fabric.
-              - This parameter is required only if template is 'ext_fabric_setup' or 'ext_multisite_underlay_setup'.
-                or "ext_evpn_multisite_overlay_setup"
+              - Required for below templates
+              - ext_fabric_setup
+              - ext_multisite_underlay_setup
+              - ext_evpn_multisite_overlay_setup
+              - ext_vxlan_mpls_overlay_setup
             type: str
             required: true
           auto_deploy:
@@ -326,6 +338,54 @@ options:
             type: str
             required: false
             default: ""
+          mpls_fabric:
+            description:
+              - MPLS LDP or Segment-Routing
+              - This parameter is applicable only if template is `ext_vxlan_mpls_underlay_setup`.
+            type: str
+            default: "SR"
+            choices:
+              - SR
+              - LDP
+          peer1_sr_mpls_index:
+            description:
+              - Unique SR SID index for the source border
+              - This parameter is applicable only if template is `ext_vxlan_mpls_underlay_setup` and `mpls_fabric` is `SR`
+            type: int
+            default: "0"
+          peer2_sr_mpls_index:
+            description:
+              - Unique SR SID index for the destination border
+              - This parameter is applicable only if template is `ext_vxlan_mpls_underlay_setup` and `mpls_fabric` is `SR`
+            type: int
+            default: "0"
+          global_block_range:
+            description:
+              - For Segment Routing binding
+              - This parameter is applicable only if template is `ext_vxlan_mpls_underlay_setup` and `mpls_fabric` is `SR`
+            type: str
+            default: "16000-23999"
+          dci_routing_proto:
+            description:
+              - Routing protocol used on the DCI MPLS link
+              - This parameter is applicable only if template is `ext_vxlan_mpls_underlay_setup` and `mpls_fabric` is `SR`
+            type: str
+            default: "is-is"
+            choices:
+              - is-is
+              - ospf
+          ospf_area_id:
+            description:
+              - OSPF Area ID in IP address format
+              - This parameter is applicable only if template is `ext_vxlan_mpls_underlay_setup` and `dci_routing_proto` is `ospf`
+            type: str
+            default: "0.0.0.0"
+          dci_routing_tag:
+            description:
+              - Routing Process Tag of DCI Underlay
+              - This parameter is applicable only if template is `ext_vxlan_mpls_underlay_setup`
+            type: str
+            default: "MPLS_UNDERLAY"
 """
 
 EXAMPLES = """
@@ -515,6 +575,30 @@ EXAMPLES = """
               ebpg_auth_key_type: 3                              # optional, required only if ebpg_password_enable is true, and inherit_from_msd
                                                                  # is false. Default is 3
                                                                  # choose from [3 - 3DES, 7 - Cisco ]
+          - dst_fabric: "{{ ansible_unnum_fabric }}"             # Destination fabric
+            src_interface: "{{ intf_1_5 }}"                      # Interface on the Source fabric
+            dst_interface: "{{ intf_1_5 }}"                      # Interface on the Destination fabric
+            src_device: "{{ ansible_num_switch1 }}"              # Device on the Source fabric
+            dst_device: "{{ ansible_unnum_switch1 }}"            # Device on the Destination fabric
+            template: ext_vxlan_mpls_underlay_setup              # Template of MPLS handoff underlay link
+            profile:
+              ipv4_subnet: 193.168.3.1/30                        # IP address of interface in src fabric with the mask
+              neighbor_ip: 193.168.3.2                           # IP address of the interface in dst fabric
+              mpls_fabric: LDP                                   # MPLS handoff protocol, choose from [LDP, SR]
+              dci_routing_proto: isis                            # Routing protocol used on the DCI MPLS link, choose from [is-is, ospf]
+
+          - dst_fabric: "{{ ansible_unnum_fabric }}"             # Destination fabric
+            src_interface:  Loopback101                          # Loopback interface on the Source fabric
+            dst_interface:  Loopback1                            # Loopback interface on the Destination fabric
+            src_device: "{{ ansible_num_switch1 }}"              # Device on the Source fabric
+            dst_device: "{{ ansible_unnum_switch1 }}"            # Device on the Destination fabric
+            template: ext_vxlan_mpls_overlay_setup               #Template of MPLS handoff overlay link
+            profile:
+              neighbor_ip: 2.2.2.2 .                             # IP address of the loopback interface of destination device
+              src_asn: 498278384                                 # BGP ASN in source fabric
+              dst_asn: 498278384                                 # BGP ASN in destination fabric
+
+
 
 # FABRIC WITH VPC PAIRED SWITCHES
 
@@ -813,6 +897,9 @@ class DcnmLinks:
             "ext_fabric_setup": "ext_fabric_setup_11_1",
             "ext_multisite_underlay_setup": "ext_multisite_underlay_setup_11_1",
             "ext_evpn_multisite_overlay_setup": "ext_evpn_multisite_overlay_setup",
+            "ext_vxlan_mpls_overlay_setup": "ext_vxlan_mpls_overlay_setup",
+            "ext_vxlan_mpls_underlay_setup": "ext_vxlan_mpls_underlay_setup"
+
         },
         12: {
             "int_intra_fabric_ipv6_link_local": "int_intra_fabric_ipv6_link_local",
@@ -824,6 +911,8 @@ class DcnmLinks:
             "ext_fabric_setup": "ext_fabric_setup",
             "ext_multisite_underlay_setup": "ext_multisite_underlay_setup",
             "ext_evpn_multisite_overlay_setup": "ext_evpn_multisite_overlay_setup",
+            "ext_vxlan_mpls_overlay_setup": "ext_vxlan_mpls_overlay_setup",
+            "ext_vxlan_mpls_underlay_setup": "ext_vxlan_mpls_underlay_setup"
         },
     }
 
@@ -838,6 +927,8 @@ class DcnmLinks:
             "ext_fabric_setup_11_1",
             "ext_multisite_underlay_setup_11_1",
             "ext_evpn_multisite_overlay_setup",
+            "ext_vxlan_mpls_overlay_setup",
+            "ext_vxlan_mpls_underlay_setup"
         ],
         12: [
             "int_intra_fabric_ipv6_link_local",
@@ -849,6 +940,8 @@ class DcnmLinks:
             "ext_fabric_setup",
             "ext_multisite_underlay_setup",
             "ext_evpn_multisite_overlay_setup",
+            "ext_vxlan_mpls_overlay_setup",
+            "ext_vxlan_mpls_underlay_setup"
         ],
     }
 
@@ -1213,7 +1306,7 @@ class DcnmLinks:
 
     def dcnm_links_get_inter_fabric_link_spec(self, cfg):
 
-        inter_fabric_choices = self.template_choices[6:9]
+        inter_fabric_choices = self.template_choices[6:11]
 
         link_spec = dict(
             dst_fabric=dict(required=True, type="str"),
@@ -1235,6 +1328,8 @@ class DcnmLinks:
             == self.templates["ext_multisite_underlay_setup"]
         ) or (
             cfg[0].get("template", "") == self.templates["ext_fabric_setup"]
+        ) or (
+            cfg[0].get("template", "") == self.templates["ext_vxlan_mpls_underlay_setup"]
         ):
             link_spec["profile"]["ipv4_subnet"] = dict(
                 required=True, type="ipv4_subnet"
@@ -1248,14 +1343,23 @@ class DcnmLinks:
             )
             link_spec["profile"]["peer1_cmds"] = dict(type="list", default=[])
             link_spec["profile"]["peer2_cmds"] = dict(type="list", default=[])
-        else:
+        elif cfg[0].get("template") != self.templates["ext_vxlan_mpls_overlay_setup"]:
             link_spec["profile"]["ipv4_addr"] = dict(
                 required=True, type="ipv4"
             )
 
         link_spec["profile"]["neighbor_ip"] = dict(required=True, type="ipv4")
-        link_spec["profile"]["src_asn"] = dict(required=True, type="int")
-        link_spec["profile"]["dst_asn"] = dict(required=True, type="int")
+        # src_asn and dst_asn are not common parameters
+        if (
+            cfg[0].get("template", "")
+            == self.templates["ext_multisite_underlay_setup"]
+        ) or (
+            cfg[0].get("template", "") == self.templates["ext_fabric_setup"]
+        ) or (
+            cfg[0].get("template", "") == self.templates["ext_vxlan_mpls_overlay_setup"]
+        ):
+            link_spec["profile"]["src_asn"] = dict(required=True, type="int")
+            link_spec["profile"]["dst_asn"] = dict(required=True, type="int")
 
         if cfg[0].get("template", "") == self.templates["ext_fabric_setup"]:
             link_spec["profile"]["auto_deploy"] = dict(
@@ -1309,6 +1413,31 @@ class DcnmLinks:
                     link_spec["profile"]["ebgp_auth_key_type"] = dict(
                         type="int", default=3, choices=[3, 7]
                     )
+        if (
+            cfg[0].get("template", "")
+            == self.templates["ext_vxlan_mpls_underlay_setup"]
+        ):
+            link_spec["profile"]["mpls_fabric"] = dict(
+                type="str", default="SR", choice=["SR", "LDP"]
+            )
+            link_spec["profile"]["dci_routing_proto"] = dict(
+                type="str", default="is-is", choice=["is-is", "ospf"]
+            )
+            link_spec["profile"]["dci_routing_tag"] = dict(
+                type="str", default="MPLS_UNDERLAY", choice=["is-is", "ospf"]
+            )
+            link_spec["profile"]["peer1_sr_mpls_index"] = dict(
+                type="int", default=0
+            )
+            link_spec["profile"]["peer2_sr_mpls_index"] = dict(
+                type="int", default=0
+            )
+            link_spec["profile"]["global_block_range"] = dict(
+                type="str", default="16000-23999"
+            )
+            link_spec["profile"]["ospf_area_id"] = dict(
+                type="str", default="0.0.0.0"
+            )
 
         return link_spec
 
@@ -1482,7 +1611,9 @@ class DcnmLinks:
         link_payload["nvPairs"] = {}
         if (
             link["template"] == self.templates["ext_multisite_underlay_setup"]
-        ) or (link["template"] == self.templates["ext_fabric_setup"]):
+        ) or (
+            link["template"] == self.templates["ext_fabric_setup"]
+        ) or (link["template"] == self.templates["ext_vxlan_mpls_underlay_setup"]):
             ip_prefix = link["profile"]["ipv4_subnet"].split("/")
 
             link_payload["nvPairs"]["IP_MASK"] = (
@@ -1509,7 +1640,7 @@ class DcnmLinks:
                 link_payload["nvPairs"]["PEER2_CONF"] = "\n".join(
                     link["profile"].get("peer2_cmds")
                 )
-        else:
+        elif link["template"] != self.templates["ext_vxlan_mpls_overlay_setup"]:
             link_payload["nvPairs"]["SOURCE_IP"] = str(
                 ipaddress.ip_address(link["profile"]["ipv4_addr"])
             )
@@ -1517,8 +1648,13 @@ class DcnmLinks:
         link_payload["nvPairs"]["NEIGHBOR_IP"] = str(
             ipaddress.ip_address(link["profile"]["neighbor_ip"])
         )
-        link_payload["nvPairs"]["asn"] = link["profile"]["src_asn"]
-        link_payload["nvPairs"]["NEIGHBOR_ASN"] = link["profile"]["dst_asn"]
+        if (
+            link["template"] == self.templates["ext_multisite_underlay_setup"]
+        ) or (
+            link["template"] == self.templates["ext_fabric_setup"]
+        ) or (link["template"] == self.templates["ext_vxlan_mpls_overlay_setup"]):
+            link_payload["nvPairs"]["asn"] = link["profile"]["src_asn"]
+            link_payload["nvPairs"]["NEIGHBOR_ASN"] = link["profile"]["dst_asn"]
 
         if link["template"] == self.templates["ext_fabric_setup"]:
             link_payload["nvPairs"]["AUTO_VRF_LITE_FLAG"] = link["profile"][
@@ -1570,6 +1706,14 @@ class DcnmLinks:
                     link_payload["nvPairs"]["BGP_AUTH_KEY_TYPE"] = link[
                         "profile"
                     ]["ebgp_auth_key_type"]
+        if link["template"] == self.templates["ext_vxlan_mpls_underlay_setup"]:
+            link_payload["nvPairs"]["MPLS_FABRIC"] = link["profile"]["mpls_fabric"]
+            link_payload["nvPairs"]["DCI_ROUTING_PROTO"] = link["profile"]["dci_routing_proto"]
+            link_payload["nvPairs"]["DCI_ROUTING_TAG"] = link["profile"]["dci_routing_tag"]
+            link_payload["nvPairs"]["PEER1_SR_MPLS_INDEX"] = link["profile"]["peer1_sr_mpls_index"]
+            link_payload["nvPairs"]["PEER2_SR_MPLS_INDEX"] = link["profile"]["peer2_sr_mpls_index"]
+            link_payload["nvPairs"]["GB_BLOCK_RANGE"] = link["profile"]["global_block_range"]
+            link_payload["nvPairs"]["OSPF_AREA_ID"] = link["profile"]["ospf_area_id"]
 
     def dcnm_links_get_intra_fabric_links_payload(self, link, link_payload):
 
@@ -2078,7 +2222,6 @@ class DcnmLinks:
         else:
             # If devices are not managable, the path should not include them
             path = self.paths["LINKS_GET_BY_SWITCH_PAIR"]
-
         resp = dcnm_send(self.module, "GET", path)
 
         if (
@@ -2201,7 +2344,9 @@ class DcnmLinks:
         if (
             wlink["templateName"]
             == self.templates["ext_multisite_underlay_setup"]
-        ) or (wlink["templateName"] == self.templates["ext_fabric_setup"]):
+        ) or (
+            wlink["templateName"] == self.templates["ext_fabric_setup"]
+        ) or (wlink["templateName"] == self.templates["ext_vxlan_mpls_underlay_setup"]):
             if (
                 self.dcnm_links_compare_ip_addresses(
                     wlink["nvPairs"]["IP_MASK"], hlink["nvPairs"]["IP_MASK"]
@@ -2277,7 +2422,7 @@ class DcnmLinks:
                         ]
                     }
                 )
-        else:
+        elif wlink["templateName"] != self.templates["ext_vxlan_mpls_overlay_setup"]:
             if (
                 self.dcnm_links_compare_ip_addresses(
                     wlink["nvPairs"]["SOURCE_IP"],
@@ -2310,29 +2455,35 @@ class DcnmLinks:
                 }
             )
         if (
-            str(wlink["nvPairs"]["asn"]).lower()
-            != str(hlink["nvPairs"]["asn"]).lower()
-        ):
-            mismatch_reasons.append(
-                {
-                    "ASN_MISMATCH": [
-                        str(wlink["nvPairs"]["asn"]).lower(),
-                        str(hlink["nvPairs"]["asn"]).lower(),
-                    ]
-                }
-            )
-        if (
-            str(wlink["nvPairs"]["NEIGHBOR_ASN"]).lower()
-            != str(hlink["nvPairs"]["NEIGHBOR_ASN"]).lower()
-        ):
-            mismatch_reasons.append(
-                {
-                    "NEIGHBOR_ASN_MISMATCH": [
-                        str(wlink["nvPairs"]["NEIGHBOR_ASN"]).lower(),
-                        str(hlink["nvPairs"]["NEIGHBOR_ASN"]).lower(),
-                    ]
-                }
-            )
+            wlink["templateName"]
+            == self.templates["ext_multisite_underlay_setup"]
+        ) or (
+            wlink["templateName"] == self.templates["ext_fabric_setup"]
+        ) or (wlink["templateName"] == self.templates["ext_vxlan_mpls_overlay_setup"]):
+            if (
+                str(wlink["nvPairs"]["asn"]).lower()
+                != str(hlink["nvPairs"]["asn"]).lower()
+            ):
+                mismatch_reasons.append(
+                    {
+                        "ASN_MISMATCH": [
+                            str(wlink["nvPairs"]["asn"]).lower(),
+                            str(hlink["nvPairs"]["asn"]).lower(),
+                        ]
+                    }
+                )
+            if (
+                str(wlink["nvPairs"]["NEIGHBOR_ASN"]).lower()
+                != str(hlink["nvPairs"]["NEIGHBOR_ASN"]).lower()
+            ):
+                mismatch_reasons.append(
+                    {
+                        "NEIGHBOR_ASN_MISMATCH": [
+                            str(wlink["nvPairs"]["NEIGHBOR_ASN"]).lower(),
+                            str(hlink["nvPairs"]["NEIGHBOR_ASN"]).lower(),
+                        ]
+                    }
+                )
 
         if wlink["templateName"] == self.templates["ext_fabric_setup"]:
 
@@ -2525,6 +2676,36 @@ class DcnmLinks:
                                 ]
                             }
                         )
+        if (
+            wlink["templateName"]
+            == self.templates["ext_vxlan_mpls_underlay_setup"]
+        ):
+            mpls_underlay_spec_nvpairs = [
+                "MPLS_FABRIC",
+                "DCI_ROUTING_PROTO",
+                "DCI_ROUTING_TAG",
+                "PEER1_SR_MPLS_INDEX",
+                "PEER2_SR_MPLS_INDEX",
+                "GB_BLOCK_RANGE",
+                "OSPF_AREA_ID"
+                ]
+            for nv_pair in mpls_underlay_spec_nvpairs:
+                if (
+                    str(wlink["nvPairs"][nv_pair]).lower()
+                    != str(hlink["nvPairs"][nv_pair]).lower()
+                ):
+                    mismatch_reasons.append(
+                        {
+                            f"{nv_pair}_MISMATCH": [
+                                str(
+                                    wlink["nvPairs"][nv_pair]
+                                ).lower(),
+                                str(
+                                    hlink["nvPairs"][nv_pair]
+                                ).lower(),
+                            ]
+                        }
+                    )
 
         if mismatch_reasons != []:
             return "DCNM_LINK_MERGE", mismatch_reasons, hlink
@@ -2849,7 +3030,8 @@ class DcnmLinks:
             have
             for have in self.have
             if (
-                (have["sw1-info"]["fabric-name"] == want["sourceFabric"])
+                (have.get("templateName") is not None)  # if templateName is empty, link is autodicovered, consider link is new
+                and (have["sw1-info"]["fabric-name"] == want["sourceFabric"])
                 and (
                     have["sw2-info"]["fabric-name"]
                     == want["destinationFabric"]
@@ -2872,7 +3054,6 @@ class DcnmLinks:
         ]
 
         for mlink in match_have:
-
             if want["sourceFabric"] == want["destinationFabric"]:
                 return self.dcnm_links_compare_intra_fabric_link_params(
                     want, mlink
@@ -2953,7 +3134,6 @@ class DcnmLinks:
 
         if not self.want:
             return
-
         for link in self.want:
 
             rc, reasons, have = self.dcnm_links_compare_Links(link)
@@ -2975,7 +3155,7 @@ class DcnmLinks:
                     # ones in have. For replace, no need to merge them. They must be replaced with what is given.
                     if self.module.params["state"] == "merged":
                         # Check if the templates are same. If not dont try to merge want and have, because
-                        # the parameters in want anf have will be different. Since template has changed, go ahead
+                        # the parameters in want and have will be different. Since template has changed, go ahead
                         # and push MODIFY request with the new payload
 
                         if link["templateName"] == have["templateName"]:

--- a/plugins/modules/dcnm_vrf.py
+++ b/plugins/modules/dcnm_vrf.py
@@ -566,6 +566,7 @@ from ansible_collections.cisco.dcnm.plugins.module_utils.network.dcnm.dcnm impor
     dcnm_get_url,
 )
 from ansible.module_utils.basic import AnsibleModule
+import q
 
 
 class DcnmVrf:
@@ -656,6 +657,7 @@ class DcnmVrf:
                         ):
                             want_ext_values = want["extensionValues"]
                             want_ext_values = ast.literal_eval(want_ext_values)
+                            q(want_ext_values)
                             have_ext_values = have["extensionValues"]
                             have_ext_values = ast.literal_eval(have_ext_values)
 
@@ -2538,6 +2540,11 @@ class DcnmVrf:
                 dot1q=dict(type="int"),
             )
 
+            mpls_spec = dict(
+                rt_import_evpn=dict(type="str"),
+                rt_export_evpn=dict(type="str"),
+            )
+
             msg = None
             if self.config:
                 for vrf in self.config:
@@ -2642,6 +2649,9 @@ class DcnmVrf:
             )
             att_spec = dict(
                 ip_address=dict(required=True, type="str"),
+                lo_id=dict(type="int"),
+                lo_ipv4=dict(type="ipv4"),
+                lo_ipv6=dict(type="ipv6"),
                 deploy=dict(type="bool", default=True),
                 vrf_lite=dict(type="list", default=[]),
             )
@@ -2655,6 +2665,11 @@ class DcnmVrf:
                 dot1q=dict(type="int"),
             )
 
+            mpls_spec = dict(
+                rt_import_evpn=dict(type="str"),
+                rt_export_evpn=dict(type="str"),
+            )
+
             if self.config:
                 valid_vrf, invalid_params = validate_list_of_dicts(
                     self.config, vrf_spec
@@ -2666,6 +2681,12 @@ class DcnmVrf:
                         )
                         vrf["attach"] = valid_att
                         invalid_params.extend(invalid_att)
+
+                        valid_mpls, invalid_mpls = validate_list_of_dicts(
+                            vrf["attatch"].get("mpls"), mpls_spec
+                        )
+                        invalid_params.extend(invalid_mpls)
+
                         for lite in vrf.get("attach"):
                             if lite.get("vrf_lite"):
                                 valid_lite, invalid_lite = validate_list_of_dicts(


### PR DESCRIPTION
- fix an issue when the link is already discovered by NDFC #236
- with the fix above, issue #244 should be eased as the source and destination fabric/device/interface should be determined. A more bulletproof fix should switch the source and destination and then compare what is configured already and what is defined in the playbook but will need more effort, will revisit it later.
- Adding two types of links. ext_vxlan_mpls_overlay_setup and ext_vxlan_mpls_underlay_setup #248 