### PR TITLE
Add support for fabric loopback interfaces

### DIFF
--- a/docs/cisco.dcnm.dcnm_interface_module.rst
+++ b/docs/cisco.dcnm.dcnm_interface_module.rst
@@ -804,7 +804,7 @@ Parameters
                         <b>Default:</b><br/><div style="color: blue">""</div>
                 </td>
                 <td>
-                        <div>IPV4 address of the interface.</div>
+                        <div>IPv4 address of the interface.</div>
                 </td>
             </tr>
             <tr>
@@ -822,7 +822,7 @@ Parameters
                         <b>Default:</b><br/><div style="color: blue">""</div>
                 </td>
                 <td>
-                        <div>IPV6 address of the interface.</div>
+                        <div>IPv6 address of the interface.</div>
                 </td>
             </tr>
             <tr>
@@ -840,6 +840,7 @@ Parameters
                 <td>
                         <ul style="margin: 0; padding: 0"><b>Choices:</b>
                                     <li>lo</li>
+                                    <li>fabric</li>
                         </ul>
                 </td>
                 <td>
@@ -862,6 +863,24 @@ Parameters
                 </td>
                 <td>
                         <div>Route tag associated with the interface IP.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>secondary_ipv4_addr</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">""</div>
+                </td>
+                <td>
+                        <div>Secondary IP address of the nve interface loopback</div>
                 </td>
             </tr>
 

--- a/docs/cisco.dcnm.dcnm_interface_module.rst
+++ b/docs/cisco.dcnm.dcnm_interface_module.rst
@@ -841,10 +841,15 @@ Parameters
                         <ul style="margin: 0; padding: 0"><b>Choices:</b>
                                     <li>lo</li>
                                     <li>fabric</li>
+                                    <li>mpls</li>
                         </ul>
                 </td>
                 <td>
-                        <div>Interface mode</div>
+                        <div>There are several modes for loopback interfaces.</div>
+                        <div>Mode &#x27;lo&#x27; is used to create, modify and delete non fabric loopback interfaces using policy &#x27;int_loopback&#x27;.</div>
+                        <div>Mode &#x27;fabric&#x27; is used to modify loopbacks created when the fabric is first created using policy &#x27;int_fabric_loopback_11_1&#x27;</div>
+                        <div>Mode &#x27;mpls&#x27; is used to modify loopbacks created when the fabric is first created using policy &#x27;int_mpls_loopback&#x27;</div>
+                        <div>Mode &#x27;fabric&#x27; and &#x27;mpls&#x27; interfaces can be modified but not created or deleted.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/cisco.dcnm.dcnm_interface_module.rst
+++ b/docs/cisco.dcnm.dcnm_interface_module.rst
@@ -2608,6 +2608,26 @@ Examples
                 - no shutdown
               description: "loopback interface 100 configuration - replaced"
 
+    ## Loopback Interfaces Created During Fabric Creation
+    - name: Mange Fabric loopback interfaces
+      cisco.dcnm.dcnm_interface:
+        fabric: mmudigon-fabric
+        state: merged
+        config:
+          - name: lo1                           # This is usually lo0 or lo1 created during fabric creation
+            type: lo
+            switch:
+              - "192.172.1.1"                   # provide the switch where to deploy the config
+            deploy: true                        # choose from [true, false]
+            profile:
+              admin_state: false                # choose from [true, false]
+              mode: fabric                      # This must be set to 'fabric' for fabric loopback interfaces
+              secondary_ipv4_addr: 172.16.5.1   # secondary ipv4 address for loopback interface
+              route_tag: "100"                  # Routing Tag for the interface
+              cmds:                             # Freeform config
+                - no shutdown
+              description: "Fabric interface managed by Ansible"
+
     # To delete or reset all interfaces on all switches in the fabric
     - name: Delete loopback interfaces
       cisco.dcnm.dcnm_interface:

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -345,6 +345,7 @@ options:
         - Object profile which must be included for loopback interface configurations.
         suboptions:
           mode:
+            choices: ['lo', 'fabric', 'mpls']
             description:
             - There are several modes for loopback interfaces.
             - Mode 'lo' is used to create, modify and delete non fabric loopback
@@ -354,7 +355,6 @@ options:
             - Mode 'mpls' is used to modify loopbacks created when the fabric is first
               created using policy 'int_mpls_loopback'
             - Mode 'fabric' and 'mpls' interfaces can be modified but not created or deleted.
-            choices: ['lo', 'fabric', 'mpls']
             type: str
             required: true
           int_vrf:
@@ -4628,7 +4628,6 @@ class DcnmIntf:
                 payload['interfaces'][0]["nvPairs"]["DCI_ROUTING_PROTO"] = drp
                 payload['interfaces'][0]["nvPairs"]["DCI_ROUTING_TAG"] = drt
 
-            self.log_msg("diff_replace payload: {0}".format(payload))
             json_payload = json.dumps(payload)
             resp = dcnm_send(self.module, "PUT", path, json_payload)
 

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -3432,7 +3432,7 @@ class DcnmIntf:
             if (state == "replaced") or (state == "overridden"):
                 # Special handling is required for mode 'mpls' loopback interfaces.
                 # They will contain either of the following two read_only properties.
-                if k == 'DCI_ROUTING_PROTO' or k == 'DCI_ROUTING_TAG':
+                if k in ['DCI_ROUTING_PROTO', 'DCI_ROUTING_TAG']:
                     return "copy_and_add"
 
                 return "add"

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -853,6 +853,26 @@ EXAMPLES = """
             - no shutdown
           description: "loopback interface 100 configuration - replaced"
 
+## Loopback Interfaces Created During Fabric Creation
+- name: Mange Fabric loopback interfaces
+  cisco.dcnm.dcnm_interface:
+    fabric: mmudigon-fabric
+    state: merged
+    config:
+      - name: lo1                           # This is usually lo0 or lo1 created during fabric creation
+        type: lo
+        switch:
+          - "192.172.1.1"                   # provide the switch where to deploy the config
+        deploy: true                        # choose from [true, false]
+        profile:
+          admin_state: false                # choose from [true, false]
+          mode: fabric                      # This must be set to 'fabric' for fabric loopback interfaces
+          secondary_ipv4_addr: 172.16.5.1   # secondary ipv4 address for loopback interface
+          route_tag: "100"                  # Routing Tag for the interface
+          cmds:                             # Freeform config
+            - no shutdown
+          description: "Fabric interface managed by Ansible"
+
 # To delete or reset all interfaces on all switches in the fabric
 - name: Delete loopback interfaces
   cisco.dcnm.dcnm_interface:

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -3177,8 +3177,6 @@ class DcnmIntf:
         if "aa_fex" == delem["type"]:
             self.dcnm_intf_get_aa_fex_payload(delem, intf, "profile")
 
-        # import epdb ; epdb.serve(port=8888)
-
         return intf
 
     def dcnm_intf_merge_intf_info(self, intf_info, if_head):

--- a/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_lo_fabric.yaml
+++ b/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_lo_fabric.yaml
@@ -67,8 +67,7 @@
             profile:
               admin_state: true
               mode: fabric                        # This mode is needed to manage fabric lpbk interfaces
-              ipv4_addr: 192.168.5.1              # ipv4 address for the loopback interface
-              # secondary_ipv4_addr: 192.168.2.1  # secondary ipv4 address for loopback interface 
+              ipv4_addr: 192.168.2.1              # ipv4 address for the loopback interface
               ipv6_addr: fd08::0201               # ipV6 address for the loopback interface
               route_tag: "55"                     # Routing Tag for the interface
               cmds:                               # Freeform config
@@ -83,8 +82,8 @@
             profile:
               admin_state: true
               mode: fabric                      # This mode is needed to manage fabric lpbk interfaces
-              ipv4_addr: 192.168.7.1            # ipv4 address for the loopback interface
-              # secondary_ipv4_addr: 192.168.4.1  # secondary ipv4 address for loopback interface 
+              ipv4_addr: 192.168.5.1            # ipv4 address for the loopback interface
+              secondary_ipv4_addr: 172.16.5.1   # secondary ipv4 address for loopback interface 
               ipv6_addr: fd08::0301             # ipV6 address for the loopback interface
               route_tag: "77"                   # Routing Tag for the interface
               cmds:                             # Freeform config
@@ -135,9 +134,28 @@
               - "{{ ansible_switch2 }}"
       register: lpk0_data_new
 
+    - name: Query and save new data for loopback1
+      cisco.dcnm.dcnm_interface:
+        check_deploy: True
+        fabric: "{{ ansible_it_fabric }}" 
+        state: query
+        config:
+          - name: lo1
+            switch:
+              - "{{ ansible_switch2 }}"
+      register: lpk1_data_new
+
     - assert:
         that:
-          - 'lpk0_data_new.response[0]["interfaces"][0]["nvPairs"]["IP"] == "192.168.5.1"'
+          - 'lpk0_data_new.response[0]["interfaces"][0]["nvPairs"]["IP"] == "192.168.2.1"'
+          - 'lpk0_data_new.response[0]["interfaces"][0]["nvPairs"]["V6IP"] == "fd08::0201"'
+          - 'lpk0_data_new.response[0]["interfaces"][0]["nvPairs"]["ROUTE_MAP_TAG"] == "55"'
+          - 'lpk0_data_new.response[0]["interfaces"][0]["nvPairs"]["DESC"] == "Fabric Lpk0 Configured By Ansible"'
+          - 'lpk1_data_new.response[0]["interfaces"][0]["nvPairs"]["IP"] == "192.168.5.1"'
+          - 'lpk1_data_new.response[0]["interfaces"][0]["nvPairs"]["SECONDARY_IP"] == "172.16.5.1"'
+          - 'lpk1_data_new.response[0]["interfaces"][0]["nvPairs"]["V6IP"] == "fd08::0301"'
+          - 'lpk1_data_new.response[0]["interfaces"][0]["nvPairs"]["ROUTE_MAP_TAG"] == "77"'
+          - 'lpk1_data_new.response[0]["interfaces"][0]["nvPairs"]["DESC"] == "Fabric Lpk1 Configured By Ansible"'
 
   # Only execute this test if loopback0 and 1 are fabric loopbacks
   when:
@@ -165,7 +183,6 @@
             admin_state: true
             mode: fabric
             ipv4_addr: "{{ lpk0_data.response[0]['interfaces'][0]['nvPairs']['IP'] }}"
-            secondary_ipv4_addr: "{{ lpk0_data.response[0]['interfaces'][0]['nvPairs']['SECONDARY_IP'] }}"
             ipv6_addr: "{{ lpk0_data.response[0]['interfaces'][0]['nvPairs']['V6IP'] }}"
             route_tag: "{{ lpk0_data.response[0]['interfaces'][0]['nvPairs']['ROUTE_MAP_TAG'] }}"
             description: "{{ lpk0_data.response[0]['interfaces'][0]['nvPairs']['DESC'] }}"
@@ -183,6 +200,9 @@
             ipv6_addr: "{{ lpk1_data.response[0]['interfaces'][0]['nvPairs']['V6IP'] }}"
             route_tag: "{{ lpk1_data.response[0]['interfaces'][0]['nvPairs']['ROUTE_MAP_TAG'] }}"
             description: "{{ lpk1_data.response[0]['interfaces'][0]['nvPairs']['DESC'] }}"
+    when:
+      - lpk0_data.response[0]['policy'] == 'int_fabric_loopback_11_1'
+      - lpk1_data.response[0]['policy'] == 'int_fabric_loopback_11_1'
 
   - name: Put fabric to default state
     cisco.dcnm.dcnm_interface:

--- a/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_lo_fabric.yaml
+++ b/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_lo_fabric.yaml
@@ -1,0 +1,199 @@
+##############################################
+##               SETUP                      ##
+##############################################
+
+# This test file specfically validates fabric loopback
+# interfaces that are created at fabric creation time.
+# Typically they are loopback0 or loopback1 and use
+# the ndfc profile 'int_fabric_loopback_11_1'
+
+- name: Remove local log file
+  local_action: command rm -f dcnm_intf.log
+
+- name: Put the fabric to default state
+  cisco.dcnm.dcnm_interface:
+    check_deploy: True
+    fabric: "{{ ansible_it_fabric }}" 
+    state: overridden
+  register: result  
+
+- assert:
+    that:
+      - 'item["RETURN_CODE"] == 200'  
+  loop: '{{ result.response }}'
+
+- name: Save Data For Loopback0
+  cisco.dcnm.dcnm_interface:
+    check_deploy: True
+    fabric: "{{ ansible_it_fabric }}" 
+    state: query
+    config:
+      - name: lo0
+        switch:
+          - "{{ ansible_switch2 }}"
+  register: lpk0_data
+
+- name: Save Data For Loopback1
+  cisco.dcnm.dcnm_interface:
+    check_deploy: True
+    fabric: "{{ ansible_it_fabric }}" 
+    state: query
+    config:
+      - name: lo1
+        switch:
+          - "{{ ansible_switch2 }}"
+  register: lpk1_data
+
+- debug: msg="Loopback 0 Data - {{ lpk0_data.response[0]['interfaces'][0]['nvPairs'] }}"
+- debug: msg="Loopback 1 Data - {{ lpk1_data.response[0]['interfaces'][0]['nvPairs'] }}"
+
+- block:
+
+##############################################
+##                MERGE                     ##
+##############################################
+
+    - name: Modify fabric loopback interfaces
+      cisco.dcnm.dcnm_interface: &lo_merge
+        check_deploy: True
+        fabric: "{{ ansible_it_fabric }}" 
+        state: merged
+        config:
+          - name: lo0
+            type: lo
+            switch:
+              - "{{ ansible_switch2 }}"
+            deploy: true
+            profile:
+              admin_state: true
+              mode: fabric                        # This mode is needed to manage fabric lpbk interfaces
+              ipv4_addr: 192.168.5.1              # ipv4 address for the loopback interface
+              # secondary_ipv4_addr: 192.168.2.1  # secondary ipv4 address for loopback interface 
+              ipv6_addr: fd08::0201               # ipV6 address for the loopback interface
+              route_tag: "55"                     # Routing Tag for the interface
+              cmds:                               # Freeform config
+                - no shutdown
+              description: "Fabric Lpk0 Configured By Ansible"
+
+          - name: lo1
+            type: lo
+            switch:
+              - "{{ ansible_switch2 }}"
+            deploy: true
+            profile:
+              admin_state: true
+              mode: fabric                      # This mode is needed to manage fabric lpbk interfaces
+              ipv4_addr: 192.168.7.1            # ipv4 address for the loopback interface
+              # secondary_ipv4_addr: 192.168.4.1  # secondary ipv4 address for loopback interface 
+              ipv6_addr: fd08::0301             # ipV6 address for the loopback interface
+              route_tag: "77"                   # Routing Tag for the interface
+              cmds:                             # Freeform config
+                - no shutdown
+              description: "Fabric Lpk1 Configured By Ansible"
+      register: result
+
+    - assert:
+        that:
+          - 'result.changed == true'
+          - '(result["diff"][0]["merged"] | length) == 2'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["replaced"] | length) == 0'
+          - '(result["diff"][0]["overridden"] | length) == 0'
+          - '(result["diff"][0]["deploy"] | length) == 2'
+
+    - assert:
+        that:
+          - 'item["RETURN_CODE"] == 200'  
+      loop: '{{ result.response }}'
+
+    - name: Modify fabric loopback interfaces - Idempotence
+      cisco.dcnm.dcnm_interface: *lo_merge
+      register: result
+
+    - assert:
+        that:
+          - 'result.changed == false'
+          - '(result["diff"][0]["merged"] | length) == 0'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["replaced"] | length) == 0'
+          - '(result["diff"][0]["overridden"] | length) == 0'
+          - '(result["diff"][0]["deploy"] | length) == 0'
+
+    - assert:
+        that:
+          - 'item["RETURN_CODE"] == 200'  
+      loop: '{{ result.response }}'
+
+    - name: Query and save new data for loopback0
+      cisco.dcnm.dcnm_interface:
+        check_deploy: True
+        fabric: "{{ ansible_it_fabric }}" 
+        state: query
+        config:
+          - name: lo0
+            switch:
+              - "{{ ansible_switch2 }}"
+      register: lpk0_data_new
+
+    - assert:
+        that:
+          - 'lpk0_data_new.response[0]["interfaces"][0]["nvPairs"]["IP"] == "192.168.5.1"'
+
+  # Only execute this test if loopback0 and 1 are fabric loopbacks
+  when:
+    - lpk0_data.response[0]['policy'] == 'int_fabric_loopback_11_1'
+    - lpk1_data.response[0]['policy'] == 'int_fabric_loopback_11_1'
+
+##############################################
+##             CLEANUP                      ##
+##############################################
+
+  always:
+
+  - name: Set Loopback0 and Loopback1 back to inital state
+    cisco.dcnm.dcnm_interface:
+      check_deploy: True
+      fabric: "{{ ansible_it_fabric }}" 
+      state: merged
+      config:
+        - name: lo0
+          type: lo
+          switch:
+            - "{{ ansible_switch2 }}"
+          deploy: true
+          profile:
+            admin_state: true
+            mode: fabric
+            ipv4_addr: "{{ lpk0_data.response[0]['interfaces'][0]['nvPairs']['IP'] }}"
+            # secondary_ipv4_addr: "{{ lpk0_data.response[0]['interfaces'][0]['nvPairs']['SECONDARY_IP'] }}"
+            ipv6_addr: "{{ lpk0_data.response[0]['interfaces'][0]['nvPairs']['V6IP'] }}"
+            route_tag: "{{ lpk0_data.response[0]['interfaces'][0]['nvPairs']['ROUTE_MAP_TAG'] }}"
+            description: "{{ lpk0_data.response[0]['interfaces'][0]['nvPairs']['DESC'] }}"
+
+        - name: lo1
+          type: lo
+          switch:
+            - "{{ ansible_switch2 }}"
+          deploy: true
+          profile:
+            admin_state: true
+            mode: fabric
+            ipv4_addr: "{{ lpk1_data.response[0]['interfaces'][0]['nvPairs']['IP'] }}"
+            # secondary_ipv4_addr: "{{ lpk1_data.response[0]['interfaces'][0]['nvPairs']['SECONDARY_IP'] }}"
+            ipv6_addr: "{{ lpk1_data.response[0]['interfaces'][0]['nvPairs']['V6IP'] }}"
+            route_tag: "{{ lpk1_data.response[0]['interfaces'][0]['nvPairs']['ROUTE_MAP_TAG'] }}"
+            description: "{{ lpk1_data.response[0]['interfaces'][0]['nvPairs']['DESC'] }}"
+
+  - name: Put fabric to default state
+    cisco.dcnm.dcnm_interface:
+      check_deploy: True
+      fabric: "{{ ansible_it_fabric }}" 
+      state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
+    register: result
+    when: IT_CONTEXT is not defined
+
+  - assert:
+      that:
+        - 'item["RETURN_CODE"] == 200'  
+    loop: '{{ result.response }}'
+    when: IT_CONTEXT is not defined

--- a/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_lo_fabric.yaml
+++ b/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_lo_fabric.yaml
@@ -165,7 +165,7 @@
             admin_state: true
             mode: fabric
             ipv4_addr: "{{ lpk0_data.response[0]['interfaces'][0]['nvPairs']['IP'] }}"
-            # secondary_ipv4_addr: "{{ lpk0_data.response[0]['interfaces'][0]['nvPairs']['SECONDARY_IP'] }}"
+            secondary_ipv4_addr: "{{ lpk0_data.response[0]['interfaces'][0]['nvPairs']['SECONDARY_IP'] }}"
             ipv6_addr: "{{ lpk0_data.response[0]['interfaces'][0]['nvPairs']['V6IP'] }}"
             route_tag: "{{ lpk0_data.response[0]['interfaces'][0]['nvPairs']['ROUTE_MAP_TAG'] }}"
             description: "{{ lpk0_data.response[0]['interfaces'][0]['nvPairs']['DESC'] }}"
@@ -179,7 +179,7 @@
             admin_state: true
             mode: fabric
             ipv4_addr: "{{ lpk1_data.response[0]['interfaces'][0]['nvPairs']['IP'] }}"
-            # secondary_ipv4_addr: "{{ lpk1_data.response[0]['interfaces'][0]['nvPairs']['SECONDARY_IP'] }}"
+            secondary_ipv4_addr: "{{ lpk1_data.response[0]['interfaces'][0]['nvPairs']['SECONDARY_IP'] }}"
             ipv6_addr: "{{ lpk1_data.response[0]['interfaces'][0]['nvPairs']['V6IP'] }}"
             route_tag: "{{ lpk1_data.response[0]['interfaces'][0]['nvPairs']['ROUTE_MAP_TAG'] }}"
             description: "{{ lpk1_data.response[0]['interfaces'][0]['nvPairs']['DESC'] }}"

--- a/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_lo_mpls.yaml
+++ b/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_lo_mpls.yaml
@@ -1,0 +1,151 @@
+##############################################
+##               SETUP                      ##
+##############################################
+
+# This test file specfically validates fabric loopback
+# interfaces that are created at fabric creation time
+# for VXLAN-EVPN to SR-MPLS and MPLS LDP interconnection
+
+# By default they are loopback101 as defined in the fabric
+# settings and use the ndfc profile 'int_mpls_loopback'
+
+- name: Remove local log file
+  local_action: command rm -f dcnm_intf.log
+
+- name: Save Data For Loopback101
+  cisco.dcnm.dcnm_interface:
+    check_deploy: True
+    fabric: "{{ ansible_it_fabric }}"
+    state: query
+    config:
+      - name: lo101
+        switch:
+          - "{{ ansible_switch1 }}"
+  register: lpk101_data
+
+- name: Set Test Control Flag
+  ansible.builtin.set_fact:
+    run_test: True
+
+- name: Test will not be run since Loopback101 does not appear to exist
+  ansible.builtin.set_fact:
+    run_test: False
+  when: lpk101_data.response == []
+
+- name: Access Policy Data If Loopack101 Data Is Available
+  ansible.builtin.set_fact:
+    loopback_policy: "{{ lpk101_data.response[0]['policy'] }}"
+  when: lpk101_data.response != []
+
+- name: Test will not be run since Loopback101 is not an MPLS Fabric Loopback
+  ansible.builtin.set_fact:
+    run_test: False
+  when: (loopback_policy is defined) and (loopback_policy != 'int_mpls_loopback')
+
+- debug: msg="Loopback 101 Data - {{ lpk101_data.response[0]['interfaces'][0]['nvPairs'] }}"
+  when: run_test
+
+- block:
+
+##############################################
+##                MERGE                     ##
+##############################################
+
+    - name: Modify mpls fabric loopback interface
+      cisco.dcnm.dcnm_interface: &lo_merge
+        check_deploy: True
+        fabric: "{{ ansible_it_fabric }}"
+        state: merged
+        config:
+          - name: lo101
+            type: lo
+            switch:
+              - "{{ ansible_switch1 }}"
+            deploy: true
+            profile:
+              admin_state: true
+              mode: mpls                          # This mode is needed to manage mpls fabric lpbk interfaces
+              ipv4_addr: 192.168.55.2              # ipv4 address for the loopback interface
+              cmds:                               # Freeform config
+                - no shutdown
+              description: "Fabric Lpk101 Configured By Ansible"
+      register: result
+
+    - name: Pause for 30 seconds
+      ansible.builtin.pause:
+        seconds: 30
+
+    - assert:
+        that:
+          - 'result.changed == true'
+          - '(result["diff"][0]["merged"] | length) == 1'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["replaced"] | length) == 0'
+          - '(result["diff"][0]["overridden"] | length) == 0'
+          - '(result["diff"][0]["deploy"] | length) == 1'
+
+    - assert:
+        that:
+          - 'item["RETURN_CODE"] == 200'
+      loop: '{{ result.response }}'
+
+    - name: Modify mpls fabric loopback interfaces - Idempotence
+      cisco.dcnm.dcnm_interface: *lo_merge
+      register: result
+
+    - assert:
+        that:
+          - 'result.changed == false'
+          - '(result["diff"][0]["merged"] | length) == 0'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["replaced"] | length) == 0'
+          - '(result["diff"][0]["overridden"] | length) == 0'
+          - '(result["diff"][0]["deploy"] | length) == 0'
+
+    - assert:
+        that:
+          - 'item["RETURN_CODE"] == 200'
+      loop: '{{ result.response }}'
+
+    - name: Query and save new data for loopback101
+      cisco.dcnm.dcnm_interface:
+        check_deploy: True
+        fabric: "{{ ansible_it_fabric }}"
+        state: query
+        config:
+          - name: lo101
+            switch:
+              - "{{ ansible_switch1 }}"
+      register: lpk101_data_new
+
+    - assert:
+        that:
+          - 'lpk101_data_new.response[0]["interfaces"][0]["nvPairs"]["IP"] == "192.168.55.2"'
+          - 'lpk101_data_new.response[0]["interfaces"][0]["nvPairs"]["DESC"] == "Fabric Lpk101 Configured By Ansible"'
+
+  # Only execute this test if loopback101 is a fabric mpls loopback
+  when: run_test
+
+##############################################
+##             CLEANUP                      ##
+##############################################
+
+  always:
+
+  - name: Set Loopback101 back to inital state
+    cisco.dcnm.dcnm_interface:
+      check_deploy: True
+      fabric: "{{ ansible_it_fabric }}"
+      state: merged
+      config:
+        - name: lo101
+          type: lo
+          switch:
+            - "{{ ansible_switch1 }}"
+          deploy: true
+          profile:
+            admin_state: true
+            mode: mpls
+            ipv4_addr: "{{ lpk101_data.response[0]['interfaces'][0]['nvPairs']['IP'] }}"
+            description: "{{ lpk101_data.response[0]['interfaces'][0]['nvPairs']['DESC'] }}"
+    when: run_test

--- a/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_lo_mpls.yaml
+++ b/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_lo_mpls.yaml
@@ -51,7 +51,7 @@
 ##                MERGE                     ##
 ##############################################
 
-    - name: Modify mpls fabric loopback interface
+    - name: Modify mpls fabric loopback interface using merge
       cisco.dcnm.dcnm_interface: &lo_merge
         check_deploy: True
         fabric: "{{ ansible_it_fabric }}"
@@ -71,10 +71,6 @@
               description: "Fabric Lpk101 Configured By Ansible"
       register: result
 
-    - name: Pause for 30 seconds
-      ansible.builtin.pause:
-        seconds: 30
-
     - assert:
         that:
           - 'result.changed == true'
@@ -89,7 +85,23 @@
           - 'item["RETURN_CODE"] == 200'
       loop: '{{ result.response }}'
 
-    - name: Modify mpls fabric loopback interfaces - Idempotence
+    - name: Verify interface properties are modified using merge
+      cisco.dcnm.dcnm_interface:
+        check_deploy: True
+        fabric: "{{ ansible_it_fabric }}"
+        state: query
+        config:
+          - name: lo101
+            switch:
+              - "{{ ansible_switch1 }}"
+      register: lpk101_data_new
+      until:
+        - 'lpk101_data_new.response[0]["interfaces"][0]["nvPairs"]["IP"] == "192.168.55.2"'
+        - 'lpk101_data_new.response[0]["interfaces"][0]["nvPairs"]["DESC"] == "Fabric Lpk101 Configured By Ansible"'
+      retries: 5
+      delay: 2
+
+    - name: Modify mpls fabric loopback interface using merge - Idempotence
       cisco.dcnm.dcnm_interface: *lo_merge
       register: result
 
@@ -107,7 +119,59 @@
           - 'item["RETURN_CODE"] == 200'
       loop: '{{ result.response }}'
 
-    - name: Query and save new data for loopback101
+    - name: Modify mpls fabric loopback interface using replace
+      cisco.dcnm.dcnm_interface: &lo_replace
+        check_deploy: True
+        fabric: "{{ ansible_it_fabric }}"
+        state: replaced
+        config:
+          - name: lo101
+            type: lo
+            switch:
+              - "{{ ansible_switch1 }}"
+            deploy: true
+            profile:
+              admin_state: true
+              mode: mpls                          # This mode is needed to manage mpls fabric lpbk interfaces
+              ipv4_addr: 192.168.88.55            # ipv4 address for the loopback interface
+              cmds:                               # Freeform config
+                - no shutdown
+              description: "Fabric Lpk101 Replaced By Ansible"
+      register: result
+
+    - assert:
+        that:
+          - 'result.changed == true'
+          - '(result["diff"][0]["merged"] | length) == 0'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["replaced"] | length) == 1'
+          - '(result["diff"][0]["overridden"] | length) == 0'
+          - '(result["diff"][0]["deploy"] | length) == 1'
+
+    - assert:
+        that:
+          - 'item["RETURN_CODE"] == 200'
+      loop: '{{ result.response }}'
+
+    - name: Modify mpls fabric loopback interface using replace - Idempotence
+      cisco.dcnm.dcnm_interface: *lo_replace
+      register: result
+
+    - assert:
+        that:
+          - 'result.changed == false'
+          - '(result["diff"][0]["merged"] | length) == 0'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["replaced"] | length) == 0'
+          - '(result["diff"][0]["overridden"] | length) == 0'
+          - '(result["diff"][0]["deploy"] | length) == 0'
+
+    - assert:
+        that:
+          - 'item["RETURN_CODE"] == 200'
+      loop: '{{ result.response }}'
+
+    - name: Verify interface properties are modified using replace
       cisco.dcnm.dcnm_interface:
         check_deploy: True
         fabric: "{{ ansible_it_fabric }}"
@@ -117,11 +181,11 @@
             switch:
               - "{{ ansible_switch1 }}"
       register: lpk101_data_new
-
-    - assert:
-        that:
-          - 'lpk101_data_new.response[0]["interfaces"][0]["nvPairs"]["IP"] == "192.168.55.2"'
-          - 'lpk101_data_new.response[0]["interfaces"][0]["nvPairs"]["DESC"] == "Fabric Lpk101 Configured By Ansible"'
+      until:
+        - 'lpk101_data_new.response[0]["interfaces"][0]["nvPairs"]["IP"] == "192.168.88.55"'
+        - 'lpk101_data_new.response[0]["interfaces"][0]["nvPairs"]["DESC"] == "Fabric Lpk101 Replaced By Ansible"'
+      retries: 5
+      delay: 2
 
   # Only execute this test if loopback101 is a fabric mpls loopback
   when: run_test
@@ -136,7 +200,7 @@
     cisco.dcnm.dcnm_interface:
       check_deploy: True
       fabric: "{{ ansible_it_fabric }}"
-      state: merged
+      state: overridden
       config:
         - name: lo101
           type: lo
@@ -148,4 +212,21 @@
             mode: mpls
             ipv4_addr: "{{ lpk101_data.response[0]['interfaces'][0]['nvPairs']['IP'] }}"
             description: "{{ lpk101_data.response[0]['interfaces'][0]['nvPairs']['DESC'] }}"
+    when: run_test
+
+  - name: Verify interface properties are restored to original values using overridden
+    cisco.dcnm.dcnm_interface:
+      check_deploy: True
+      fabric: "{{ ansible_it_fabric }}"
+      state: query
+      config:
+        - name: lo101
+          switch:
+            - "{{ ansible_switch1 }}"
+    register: lpk101_data_new
+    until:
+      - 'lpk101_data_new.response[0]["interfaces"][0]["nvPairs"]["IP"] == lpk101_data.response[0]["interfaces"][0]["nvPairs"]["IP"]'
+      - 'lpk101_data_new.response[0]["interfaces"][0]["nvPairs"]["DESC"] == lpk101_data.response[0]["interfaces"][0]["nvPairs"]["DESC"]'
+    retries: 5
+    delay: 2
     when: run_test


### PR DESCRIPTION
Addresses the following issues:
  * https://github.com/CiscoDevNet/ansible-dcnm/issues/245
  * https://github.com/CiscoDevNet/ansible-dcnm/issues/246
  * Add support for mpls based fabric loopback interfaces
