### PR TITLE
Fix for non zero max hop config

### DIFF
--- a/plugins/modules/dcnm_inventory.py
+++ b/plugins/modules/dcnm_inventory.py
@@ -702,8 +702,12 @@ class DcnmInventory:
             self.module.fail_json(msg=response)
 
         if "DATA" in response:
-            return response["DATA"]
-
+            switch = []
+            for sw in response["DATA"]:
+                if inv["seedIP"] == sw["ipaddr"]:
+                    switch.append(sw)
+                    return switch
+            return 0
         else:
             return 0
 

--- a/plugins/modules/dcnm_inventory.py
+++ b/plugins/modules/dcnm_inventory.py
@@ -89,7 +89,9 @@ options:
         required: true
       max_hops:
         description:
-        - Maximum Hops to reach the switch
+        - Maximum Hops to reach the switch.
+        - This parameter is deprecated(as on 2024-03-06)
+        - Defaults to 0 irrespective of configured value.
         type: int
         required: false
         default: 0
@@ -746,7 +748,7 @@ class DcnmInventory:
                 "snmpV3AuthProtocol": pro,
                 "username": inv["user_name"],
                 "password": inv["password"],
-                "maxHops": inv["max_hops"],
+                "maxHops": 0,
                 "cdpSecondTimeout": "5",
                 "role": inv["role"].replace(" ", "_"),
                 "preserveConfig": inv["preserve_config"],

--- a/tests/integration/targets/dcnm_inventory/tests/dcnm/merged.yaml
+++ b/tests/integration/targets/dcnm_inventory/tests/dcnm/merged.yaml
@@ -188,6 +188,43 @@
     fabric: "{{ ansible_it_fabric }}"
     state: deleted
 
+- name: MERGED - Merge a Switch using GreenField Deployment with non zero max hop
+  cisco.dcnm.dcnm_inventory: &conf_hop
+    fabric: "{{ ansible_it_fabric }}"
+    state: merged
+    config:
+    - seed_ip: "{{ ansible_switch1 }}"
+      auth_proto: MD5
+      user_name: "{{ switch_username }}"
+      password: "{{ switch_password }}"
+      max_hops: 2
+      role: leaf
+      preserve_config: False
+  register: result
+
+- assert:
+    that:
+    - 'result.changed == true'
+
+- assert:
+    that:
+      - 'item["RETURN_CODE"] == 200'
+  loop: '{{ result.response }}'
+
+- name: MERGED - conf_hope - MH - Idempotence
+  cisco.dcnm.dcnm_inventory: *conf_hop
+  register: result
+
+- assert:
+    that:
+    - 'result.changed == false'
+    - 'result.response == "The switch provided is already part of the fabric and cannot be created again"'
+
+- name: MERGED - setup - Clean up any existing devices
+  cisco.dcnm.dcnm_inventory:
+    fabric: "{{ ansible_it_fabric }}"
+    state: deleted
+
 - name: MERGED - Merge a Switch without seed_ip
   cisco.dcnm.dcnm_inventory:
     fabric: "{{ ansible_it_fabric }}"


### PR DESCRIPTION
When max is set to and non zero value, and if there are other switches in the network within that hops, the discovery api returns all the switches available with that hop. In such cases inventory module tries to configure all available switches apart from the configured one. The fix now restricts the configuration only to the configured switch.