### PR TITLE
Code update to handle ethernet interface delete/default based on switch role

### DIFF
--- a/tests/unit/modules/dcnm/fixtures/dcnm_intf_aa_fex_configs.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_intf_aa_fex_configs.json
@@ -5,7 +5,7 @@
         "serialNumber": "SAL1819SAN8",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "Leaf",
+        "switchRole": "Leaf",
         "managable": "True"
     },
       "192.168.1.109": {
@@ -13,7 +13,7 @@
         "serialNumber": "FOX1821H035",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "Leaf",
+        "switchRole": "Leaf",
         "managable": "True"
       },
       "10.69.69.1": {
@@ -21,7 +21,7 @@
         "serialNumber": "TEST-SNO-1",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "None",
+        "switchRole": "None",
         "managable": "False"
       }
   },

--- a/tests/unit/modules/dcnm/fixtures/dcnm_intf_bunched_configs.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_intf_bunched_configs.json
@@ -6,7 +6,7 @@
         "serialNumber": "SAL1819SAN8",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "Leaf",
+        "switchRole": "Leaf",
         "managable": "True"
     },
       "192.168.1.109": {
@@ -14,7 +14,7 @@
         "serialNumber": "FOX1821H035",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "Leaf",
+        "switchRole": "Leaf",
         "managable": "True"
       },
       "10.69.69.1": {
@@ -22,7 +22,7 @@
         "serialNumber": "TEST-SNO-1",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "None",
+        "switchRole": "None",
         "managable": "False"
       }
   },

--- a/tests/unit/modules/dcnm/fixtures/dcnm_intf_eth_configs.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_intf_eth_configs.json
@@ -5,7 +5,7 @@
         "serialNumber": "SAL1819SAN8",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "Leaf",
+        "switchRole": "Leaf",
         "managable": "True"
     },
       "192.168.1.109": {
@@ -13,7 +13,7 @@
         "serialNumber": "FOX1821H035",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "Leaf",
+        "switchRole": "Leaf",
         "managable": "True"
       },
       "10.69.69.1": {
@@ -21,7 +21,7 @@
         "serialNumber": "TEST-SNO-1",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "None",
+        "switchRole": "None",
         "managable": "False"
       }
   },

--- a/tests/unit/modules/dcnm/fixtures/dcnm_intf_lo_configs.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_intf_lo_configs.json
@@ -5,7 +5,7 @@
         "serialNumber": "SAL1819SAN8",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "Leaf",
+        "switchRole": "Leaf",
         "managable": "True"
     },
       "192.168.1.109": {
@@ -13,7 +13,7 @@
         "serialNumber": "FOX1821H035",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "Leaf",
+        "switchRole": "Leaf",
         "managable": "True"
       },
       "10.69.69.1": {
@@ -21,7 +21,7 @@
         "serialNumber": "TEST-SNO-1",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "None",
+        "switchRole": "None",
         "managable": "False"
       }
   },

--- a/tests/unit/modules/dcnm/fixtures/dcnm_intf_mixed_configs.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_intf_mixed_configs.json
@@ -5,7 +5,7 @@
         "serialNumber": "SAL1819SAN8",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "Leaf",
+        "switchRole": "Leaf",
         "managable": "True"
     },
       "192.168.1.109": {
@@ -13,7 +13,7 @@
         "serialNumber": "FOX1821H035",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "Leaf",
+        "switchRole": "Leaf",
         "managable": "True"
       },
       "10.69.69.1": {
@@ -21,7 +21,7 @@
         "serialNumber": "TEST-SNO-1",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "None",
+        "switchRole": "None",
         "managable": "False"
       }
   },

--- a/tests/unit/modules/dcnm/fixtures/dcnm_intf_multi_configs.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_intf_multi_configs.json
@@ -5,7 +5,7 @@
         "serialNumber": "SAL1819SAN8",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "Leaf",
+        "switchRole": "Leaf",
         "managable": "True"
     },
       "192.168.1.109": {
@@ -13,7 +13,7 @@
         "serialNumber": "FOX1821H035",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "Leaf",
+        "switchRole": "Leaf",
         "managable": "True"
       },
       "10.69.69.1": {
@@ -21,7 +21,7 @@
         "serialNumber": "TEST-SNO-1",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "None",
+        "switchRole": "None",
         "managable": "False"
       }
   },

--- a/tests/unit/modules/dcnm/fixtures/dcnm_intf_multi_intf_configs.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_intf_multi_intf_configs.json
@@ -5,7 +5,7 @@
         "serialNumber": "SAL1819SAN8",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "Leaf",
+        "switchRole": "Leaf",
         "managable": "True"
     },
       "192.168.1.109": {
@@ -13,7 +13,7 @@
         "serialNumber": "FOX1821H035",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "Leaf",
+        "switchRole": "Leaf",
         "managable": "True"
       },
       "10.69.69.1": {
@@ -21,7 +21,7 @@
         "serialNumber": "TEST-SNO-1",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "None",
+        "switchRole": "None",
         "managable": "False"
       }
   },

--- a/tests/unit/modules/dcnm/fixtures/dcnm_intf_pc_configs.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_intf_pc_configs.json
@@ -5,7 +5,7 @@
         "serialNumber": "SAL1819SAN8",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "Leaf",
+        "switchRole": "Leaf",
         "managable": "True"
     },
       "192.168.1.109": {
@@ -13,7 +13,7 @@
         "serialNumber": "FOX1821H035",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "Leaf",
+        "switchRole": "Leaf",
         "managable": "True"
       },
       "10.69.69.1": {
@@ -21,7 +21,7 @@
         "serialNumber": "TEST-SNO-1",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "None",
+        "switchRole": "None",
         "managable": "False"
       }
   },

--- a/tests/unit/modules/dcnm/fixtures/dcnm_intf_query_configs.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_intf_query_configs.json
@@ -5,7 +5,7 @@
         "serialNumber": "SAL1819SAN8",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "Leaf",
+        "switchRole": "Leaf",
         "managable": "True"
     },
       "192.168.1.109": {
@@ -13,7 +13,7 @@
         "serialNumber": "FOX1821H035",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "Leaf",
+        "switchRole": "Leaf",
         "managable": "True"
       },
       "10.69.69.1": {
@@ -21,7 +21,7 @@
         "serialNumber": "TEST-SNO-1",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "None",
+        "switchRole": "None",
         "managable": "False"
       }
   },

--- a/tests/unit/modules/dcnm/fixtures/dcnm_intf_st_fex_configs.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_intf_st_fex_configs.json
@@ -5,7 +5,7 @@
         "serialNumber": "SAL1819SAN8",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "Leaf",
+        "switchRole": "Leaf",
         "managable": "True"
     },
       "192.168.1.109": {
@@ -13,7 +13,7 @@
         "serialNumber": "FOX1821H035",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "Leaf",
+        "switchRole": "Leaf",
         "managable": "True"
       },
       "10.69.69.1": {
@@ -21,7 +21,7 @@
         "serialNumber": "TEST-SNO-1",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "None",
+        "switchRole": "None",
         "managable": "False"
       }
   },

--- a/tests/unit/modules/dcnm/fixtures/dcnm_intf_subint_configs.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_intf_subint_configs.json
@@ -5,7 +5,7 @@
         "serialNumber": "SAL1819SAN8",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "Leaf",
+        "switchRole": "Leaf",
         "managable": "True"
     },
       "192.168.1.109": {
@@ -13,7 +13,7 @@
         "serialNumber": "FOX1821H035",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "Leaf",
+        "switchRole": "Leaf",
         "managable": "True"
       },
       "10.69.69.1": {
@@ -21,7 +21,7 @@
         "serialNumber": "TEST-SNO-1",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "None",
+        "switchRole": "None",
         "managable": "False"
       }
   },

--- a/tests/unit/modules/dcnm/fixtures/dcnm_intf_svi_configs.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_intf_svi_configs.json
@@ -5,7 +5,7 @@
         "serialNumber": "SAL1819SAN8",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "Leaf",
+        "switchRole": "Leaf",
         "managable": "True"
     },
       "192.168.1.109": {
@@ -13,7 +13,7 @@
         "serialNumber": "FOX1821H035",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "Leaf",
+        "switchRole": "Leaf",
         "managable": "True"
       },
       "10.69.69.1": {
@@ -21,7 +21,7 @@
         "serialNumber": "TEST-SNO-1",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "None",
+        "switchRole": "None",
         "managable": "False"
       }
   },

--- a/tests/unit/modules/dcnm/fixtures/dcnm_intf_vpc_configs.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_intf_vpc_configs.json
@@ -5,7 +5,7 @@
         "serialNumber": "SAL1819SAN8",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "Leaf",
+        "switchRole": "Leaf",
         "managable": "True"
     },
       "192.168.1.109": {
@@ -13,7 +13,7 @@
         "serialNumber": "FOX1821H035",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "Leaf",
+        "switchRole": "Leaf",
         "managable": "True"
       },
       "10.69.69.1": {
@@ -21,7 +21,7 @@
         "serialNumber": "TEST-SNO-1",
         "isVpcConfigured": "True",
         "vpcDomain": 1,
-        "switchRoleEnum": "None",
+        "switchRole": "None",
         "managable": "False"
       }
   },


### PR DESCRIPTION
DCNM interface module has been updated to check for switch role and default ethernet interfaces to appropriate policy. for e.g. a switch with role as 'leaf' will be defaulted to policy trunk and switches with other roles will be defaulted to routed policy.