### PR TITLE
Update dcnm_image_upgrade action plugin timeout to 1800 seconds.

### DIFF
--- a/plugins/action/dcnm_image_upgrade.py
+++ b/plugins/action/dcnm_image_upgrade.py
@@ -31,7 +31,7 @@ class ActionModule(ActionNetworkModule):
         persistent_connect_timeout = connection.get_option("persistent_connect_timeout")
         persistent_command_timeout = connection.get_option("persistent_command_timeout")
 
-        timeout = 1000
+        timeout = 1800
 
         if (persistent_command_timeout < timeout or persistent_connect_timeout < timeout):
             display.warning(


### PR DESCRIPTION
This is to update the timeout value in the ActionModule for dcnm_image_upgrade to 1800 seconds.