### PR TITLE
Fix to override only specified interface types instead of all types of interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ This collection is intended for use with the following release versions:
 
 This collection has been tested against following Ansible versions: **>=2.9.10**.
 
-For collections that support Ansible 2.9, please ensure you update your `network_os` to use the
-fully qualified collection name (for example, `cisco.ios.ios`).
 Plugins and modules within a collection may be tested with only specific Ansible versions.
 A collection may contain metadata that identifies these versions.
 PEP440 is the schema used to describe the versions of Ansible.

--- a/docs/cisco.dcnm.dcnm_interface_module.rst
+++ b/docs/cisco.dcnm.dcnm_interface_module.rst
@@ -2488,6 +2488,33 @@ Parameters
             <tr>
                 <td colspan="3">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>override_intf_types</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=string</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>pc</li>
+                                    <li>vpc</li>
+                                    <li>sub_int</li>
+                                    <li>lo</li>
+                                    <li>eth</li>
+                                    <li>svi</li>
+                                    <li>st_fex</li>
+                                    <li>aa_fex</li>
+                        </ul>
+                        <b>Default:</b><br/><div style="color: blue">[]</div>
+                </td>
+                <td>
+                        <div>A list of interface types which will be deleted/defaulted in overridden/deleted state. If this list is empty, then during overridden/deleted state, all interface types will be defaulted/deleted. If this list includes specific interface types, then only those interface types that are included in the list will be deleted/defaulted.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>state</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">

--- a/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_intf_override_specific_types.yaml
+++ b/tests/integration/targets/dcnm_interface/tests/dcnm/dcnm_intf_override_specific_types.yaml
@@ -1,0 +1,236 @@
+##############################################
+##               SETUP                      ##
+##############################################
+
+- name: Remove local log file
+  local_action: command rm -f dcnm_intf.log
+
+- name: Put the fabric to default state
+  cisco.dcnm.dcnm_interface:
+    check_deploy: True
+    fabric: "{{ ansible_it_fabric }}"
+    state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
+    deploy: false
+    override_intf_types:                  # choose from [pc, vpc, sub_int, lo, eth, svi]
+      - sub_int
+      - lo
+      - pc
+  register: result
+
+- assert:
+    that:
+      - 'item["RETURN_CODE"] == 200'
+  loop: '{{ result.response }}'
+
+- block:
+
+##############################################
+##              MERGE                       ##
+##############################################
+
+    - name: Create pc/sub/lo interfaces
+      cisco.dcnm.dcnm_interface:
+        check_deploy: True
+        fabric: "{{ ansible_it_fabric }}"
+        state: merged                         # only choose form [merged, replaced, deleted, overridden, query]
+        config:
+          - name: po300                       # should be of the form po<port-id>
+            type: pc                          # choose from this list [pc, vpc, sub_int, lo, eth, svi]
+            switch:
+              - "{{ ansible_switch1 }}"       # provide the switch information where the config is to be deployed
+            deploy: false                     # choose from [true, false]
+            profile:
+              admin_state: true               # choose from [true, false]
+              mode: trunk                     # choose from [trunk, access, l3, monitor]
+              members:                        # member interfaces
+                - "{{ ansible_eth_intf13 }}"
+              pc_mode: 'on'                   # choose from ['on', 'active', 'passive']
+              bpdu_guard: true                # choose from [true, false, no]
+              port_type_fast: true            # choose from [true, false]
+              mtu: jumbo                      # choose from [default, jumbo]
+              allowed_vlans: none             # choose from [none, all, vlan range]
+              cmds:                           # Freeform config
+                - no shutdown
+              description: "port channel acting as trunk"
+
+          - name: po310                       # should be of the form po<port-id>
+            type: pc                          # choose from this list [pc, vpc, sub_int, lo, eth, svi]
+            switch:
+              - "{{ ansible_switch1 }}"       # provide the switch information where the config is to be deployed
+            deploy: false                     # choose from [true, false]
+            profile:
+              admin_state: true               # choose from [true, false]
+              mode: trunk                     # choose from [trunk, access, l3, monitor]
+              pc_mode: 'on'                   # choose from ['on', 'active', 'passive']
+              bpdu_guard: true                # choose from [true, false, no]
+              port_type_fast: true            # choose from [true, false]
+              mtu: jumbo                      # choose from [default, jumbo]
+              allowed_vlans: none             # choose from [none, all, vlan range]
+              description: "port channel acting as trunk"
+
+          - name: lo100                       # should be of the form lo<port-id>
+            type: lo                          # choose from this list [pc, vpc, sub_int, lo, eth, svi]
+            switch:
+              - "{{ ansible_switch1 }}"       # provide the switch where to deploy the config
+            deploy: false                     # choose from [true, false]
+            profile:
+              admin_state: true               # choose from [true, false]
+              mode: lo                        # choose from [lo]
+              int_vrf: ""                     # VRF name
+              ipv4_addr: 192.168.1.1          # ipv4 address for the loopback interface
+              route_tag: ""                   # Routing Tag for the interface
+              cmds:                           # Freeform config
+                - no shutdown
+              description: "loopback interface 100 configuration"
+
+          - name: "{{ ansible_sub_intf1 }}"   # should be of the form eth<port-num>.<port-id>
+            type: sub_int                     # choose from this list [pc, vpc, sub_int, lo, eth, svi]
+            switch:
+              - "{{ ansible_switch1 }}"       # provide the switch information where the config is to be deployed
+            deploy: false                     # choose from [true, false]
+            profile:
+              admin_state: true               # choose from [true, false]
+              mode: subint                    # choose from [subint]
+              vlan: 100                       # vlan ID [min:2, max:3967]
+              int_vrf: ""                     # VRF name
+              ipv4_addr: 192.168.30.1         # ipv4 address for the sub-interface
+              ipv4_mask_len: 24               # choose between [min:8, max:31]
+              mtu: 9216                       # choose between [min:576, max:9216]
+              cmds:                           # Freeform config
+                - no shutdown
+              description: "sub interface eth1/1.1 configuration"
+
+      register: result
+
+    - assert:
+        that:
+          - '(result["diff"][0]["merged"] | length) == 4'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["replaced"] | length) == 0'
+          - '(result["diff"][0]["overridden"] | length) == 0'
+          - '(result["diff"][0]["deploy"] | length) == 0'
+
+    - assert:
+        that:
+          - 'item["RETURN_CODE"] == 200'
+      loop: '{{ result.response }}'
+
+##############################################
+##           OVERRIDE                       ##
+##############################################
+
+    - name: Override vpc interface types alone
+      cisco.dcnm.dcnm_interface:
+        fabric: "{{ ansible_it_fabric }}"
+        state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
+        deploy: false
+        override_intf_types:                  # choose from [pc, vpc, sub_int, lo, eth, svi]
+          - vpc
+      register: result
+
+    - assert:
+        that:
+          - '(result["diff"][0]["merged"] | length) == 0'
+          - '(result["diff"][0]["deleted"] | length) == 0'
+          - '(result["diff"][0]["replaced"] | length) == 0'
+          - '(result["diff"][0]["overridden"] | length) == 0'
+          - '(result["diff"][0]["deploy"] | length) == 0'
+
+    - assert:
+        that:
+          - 'item["RETURN_CODE"] == 200'
+      loop: '{{ result.response }}'
+
+##############################################
+##           OVERRIDE                       ##
+##############################################
+
+    - name: Override pc interface types alone with a new pc config
+      cisco.dcnm.dcnm_interface:
+        fabric: "{{ ansible_it_fabric }}"
+        state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
+        deploy: false
+        override_intf_types:                  # choose from [pc, vpc, sub_int, lo, eth, svi]
+          - pc
+        config:
+          - name: po900                       # should be of the form po<port-id>
+            type: pc                          # choose from this list [pc, vpc, sub_int, lo, eth, svi]
+            switch:
+              - "{{ ansible_switch1 }}"       # provide the switch information where the config is to be deployed
+            deploy: false                     # choose from [true, false]
+            profile:
+              admin_state: true               # choose from [true, false]
+              mode: trunk                     # choose from [trunk, access, l3, monitor]
+              pc_mode: 'on'                   # choose from ['on', 'active', 'passive']
+              bpdu_guard: true                # choose from [true, false, no]
+              port_type_fast: true            # choose from [true, false]
+              mtu: jumbo                      # choose from [default, jumbo]
+              allowed_vlans: none             # choose from [none, all, vlan range]
+              cmds:                           # Freeform config
+                - no shutdown
+              description: "port channel 900 acting as trunk"
+      register: result
+
+    - assert:
+        that:
+          - '(result["diff"][0]["merged"] | length) == 0'
+          - '(result["diff"][0]["deleted"] | length) == 2'
+          - '(result["diff"][0]["replaced"] | length) == 0'
+          - '(result["diff"][0]["overridden"] | length) == 1'
+          - '(result["diff"][0]["deploy"] | length) == 0'
+
+    - assert:
+        that:
+          - 'item["RETURN_CODE"] == 200'
+      loop: '{{ result.response }}'
+
+##############################################
+##           OVERRIDE                       ##
+##############################################
+
+    - name: Override sub_int/lo interface types alone
+      cisco.dcnm.dcnm_interface:
+        fabric: "{{ ansible_it_fabric }}"
+        state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
+        deploy: false
+        override_intf_types:                  # choose from [pc, vpc, sub_int, lo, eth, svi]
+          - lo
+          - sub_int
+      register: result
+
+    - assert:
+        that:
+          - '(result["diff"][0]["merged"] | length) == 0'
+          - '(result["diff"][0]["deleted"] | length) == 2'
+          - '(result["diff"][0]["replaced"] | length) == 0'
+          - '(result["diff"][0]["overridden"] | length) == 0'
+          - '(result["diff"][0]["deploy"] | length) == 0'
+
+    - assert:
+        that:
+          - 'item["RETURN_CODE"] == 200'
+      loop: '{{ result.response }}'
+
+##############################################
+##             CLEANUP                      ##
+##############################################
+
+  always:
+
+    - name: Put fabric to default state
+      cisco.dcnm.dcnm_interface:
+        fabric: "{{ ansible_it_fabric }}"
+        state: overridden                     # only choose form [merged, replaced, deleted, overridden, query]
+        override_intf_types:                  # choose from [pc, vpc, sub_int, lo, eth, svi]
+          - lo
+          - sub_int
+          - pc
+        deploy: false
+      register: result
+      when: IT_CONTEXT is not defined
+
+    - assert:
+        that:
+          - 'item["RETURN_CODE"] == 200'
+      loop: '{{ result.response }}'
+      when: IT_CONTEXT is not defined

--- a/tests/unit/modules/dcnm/fixtures/dcnm_intf_common_configs.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_intf_common_configs.json
@@ -1,0 +1,107 @@
+{
+  "mock_fab_inv_data": {
+    "192.168.1.108": {
+      "logicalName": "n9kv-108",
+        "serialNumber": "SAL1819SAN8",
+        "isVpcConfigured": "True",
+        "vpcDomain": 1,
+        "switchRole": "Leaf",
+        "managable": "True"
+    },
+      "192.168.1.109": {
+        "logicalName": "n9kv-109",
+        "serialNumber": "FOX1821H035",
+        "isVpcConfigured": "True",
+        "vpcDomain": 1,
+        "switchRole": "Leaf",
+        "managable": "True"
+      },
+      "10.69.69.1": {
+        "logicalName": "n9kv-1",
+        "serialNumber": "TEST-SNO-1",
+        "isVpcConfigured": "True",
+        "vpcDomain": 1,
+        "switchRole": "None",
+        "managable": "False"
+      }
+  },
+    "mock_monitor_true_resp": {
+      "RETURN_CODE": 200,
+      "DATA":{
+        "readonly": "True"
+      }
+    },
+
+    "mock_monitor_false_resp": {
+      "RETURN_CODE": 200,
+      "DATA":{
+        "readonly": "False"
+      }
+    },
+
+    "mock_ip_sn" : {
+     "192.168.1.109": "FOX1821H035",
+     "192.168.1.108": "SAL1819SAN8"
+    },
+
+    "mock_vpc_sno" : {
+      "192.168.1.108" : "FOX1821H035~SAL1819SAN8",
+      "192.168.1.109" : "FOX1821H035~SAL1819SAN8"
+    },
+
+		"mock_vpc_resp" : {
+			"MESSAGE": "OK",
+			"REQUEST_PATH": "https://10.122.197.6:443/rest/interface/vpcpair_serial_number?serial_number=FOX1821H035",
+			"DATA": {
+				"vpc_pair_sn": "FOX1821H035~SAL1819SAN8"
+			},
+			"RETURN_CODE": 200,
+			"METHOD": "GET"
+		},
+
+    "mock_succ_resp" : {
+      "DATA": {},
+      "MESSAGE": "OK",
+      "METHOD": "POST",
+      "REQUEST_PATH": "https://10.122.197.6:443/rest/globalInterface",
+      "RETURN_CODE": 200
+    },
+
+    "mock_deploy_resp" : {
+      "DATA": {},
+      "MESSAGE": "OK",
+      "METHOD": "POST",
+      "REQUEST_PATH": "https://10.122.197.6:443/rest/globalInterface/deploy",
+      "RETURN_CODE": 200
+    },
+
+    "pc_config" : [
+    {
+      "switch": [
+        "192.168.1.108"
+      ],
+      "profile": {
+        "description": "port channel trunk changed to access",
+        "bpdu_guard": "True",
+        "sno": "SAL1819SAN8",
+        "mtu": "jumbo",
+        "pc_mode": "on",
+        "mode": "access",
+        "members": [
+          "e2/29"
+        ],
+        "port_type_fast": "True",
+        "policy": "int_port_channel_access_host_11_1",
+        "admin_state": "True",
+        "access_vlan": 900,
+        "cmds": [
+          "no shutdown"
+        ],
+        "ifname": "Port-channel900",
+        "fabric": "test_fabric"
+      },
+      "type": "pc",
+      "name": "po900",
+      "deploy": "False"
+    }]
+}

--- a/tests/unit/modules/dcnm/fixtures/dcnm_intf_have_all_payloads.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_intf_have_all_payloads.json
@@ -1,5 +1,5 @@
 {
-  "eth_payloads" :  
+  "eth_payloads" :
   {
     "MESSAGE": "OK",
       "REQUEST_PATH": "https://10.122.197.6:443/rest/interface?serialNumber=SAL1819SAN8",
@@ -1085,7 +1085,7 @@
         "fabricName": "test_fabric",
         "ifType": "INTERFACE_ETHERNET",
         "isPhysical": "True",
-        "deletable": "False",
+        "deletable": "True",
         "markDeleted": "False",
         "alias": "",
         "deleteReason": null,
@@ -1109,7 +1109,7 @@
         "fabricName": "test_fabric",
         "ifType": "INTERFACE_ETHERNET",
         "isPhysical": "True",
-        "deletable": "False",
+        "deletable": "True",
         "markDeleted": "False",
         "alias": "",
         "deleteReason": null,
@@ -1181,7 +1181,7 @@
         "fabricName": "test_fabric",
         "ifType": "INTERFACE_ETHERNET",
         "isPhysical": "True",
-        "deletable": "False",
+        "deletable": "True",
         "markDeleted": "False",
         "alias": "",
         "deleteReason": null,
@@ -1201,6 +1201,99 @@
       ],
       "RETURN_CODE": 200,
       "METHOD": "GET"
-    }
+    },
 
+
+		"eth_1_1_access_payload" :
+		{
+			"MESSAGE": "OK",
+			"REQUEST_PATH": "https://10.122.197.6:443/rest/interface?serialNumber=SAL1819SAN8&ifName=Ethernet1/1",
+			"DATA": [
+			{
+				"policy": "int_access_host_11_1",
+				"interfaces": [
+				{
+					"interfaceType": "INTERFACE_ETHERNET",
+					"nvPairs": {
+						"ACCESS_VLAN": "31",
+						"CONF": "no shutdown",
+						"MTU": "default",
+						"PORTTYPE_FAST_ENABLED": "True",
+						"ADMIN_STATE": "False",
+						"INTF_NAME": "Ethernet1/1",
+						"BPDUGUARD_ENABLED": "True",
+						"SPEED": "auto",
+						"DESC": "eth interface acting as access"
+					},
+					"ifName": "Ethernet1/1",
+					"serialNumber": "SAL1819SAN8",
+					"fabricName": "test_fabric"
+				}],
+        "skipResourceCheck": "True"
+			}],
+			"RETURN_CODE": 200,
+				"METHOD": "GET"
+		},
+
+		"eth_1_2_access_payload" :
+		{
+			"MESSAGE": "OK",
+			"REQUEST_PATH": "https://10.122.197.6:443/rest/interface?serialNumber=SAL1819SAN8&ifName=Ethernet1/2",
+			"DATA": [
+			{
+				"policy": "int_access_host_11_1",
+				"interfaces": [
+				{
+					"interfaceType": "INTERFACE_ETHERNET",
+					"nvPairs": {
+						"ACCESS_VLAN": "31",
+						"CONF": "no shutdown",
+						"MTU": "default",
+						"PORTTYPE_FAST_ENABLED": "True",
+						"ADMIN_STATE": "False",
+						"INTF_NAME": "Ethernet1/2",
+						"BPDUGUARD_ENABLED": "True",
+						"SPEED": "auto",
+						"DESC": "eth interface acting as access"
+					},
+					"ifName": "Ethernet1/2",
+					"serialNumber": "SAL1819SAN8",
+					"fabricName": "test_fabric"
+				}],
+        "skipResourceCheck": "True"
+			}],
+			"RETURN_CODE": 200,
+				"METHOD": "GET"
+		},
+
+		"eth_3_2_access_payload" :
+		{
+			"MESSAGE": "OK",
+			"REQUEST_PATH": "https://10.122.197.6:443/rest/interface?serialNumber=SAL1819SAN8&ifName=Ethernet3/2",
+			"DATA": [
+			{
+				"policy": "int_access_host_11_1",
+				"interfaces": [
+				{
+					"interfaceType": "INTERFACE_ETHERNET",
+					"nvPairs": {
+						"ACCESS_VLAN": "31",
+						"CONF": "no shutdown",
+						"MTU": "default",
+						"PORTTYPE_FAST_ENABLED": "True",
+						"ADMIN_STATE": "False",
+						"INTF_NAME": "Ethernet3/2",
+						"BPDUGUARD_ENABLED": "True",
+						"SPEED": "auto",
+						"DESC": "eth interface acting as access"
+					},
+					"ifName": "Ethernet3/2",
+					"serialNumber": "SAL1819SAN8",
+					"fabricName": "test_fabric"
+				}],
+        "skipResourceCheck": "True"
+			}],
+			"RETURN_CODE": 200,
+				"METHOD": "GET"
+		}
 }

--- a/tests/unit/modules/dcnm/fixtures/dcnm_intf_pc_payloads.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_intf_pc_payloads.json
@@ -1,5 +1,5 @@
 {
-	"pc_merged_trunk_payloads" : 
+	"pc_merged_trunk_payloads" :
 	{
 		"MESSAGE": "OK",
 			"REQUEST_PATH": "https://10.122.197.6:443/rest/interface?serialNumber=SAL1819SAN8&ifName=Port-channel300",
@@ -34,7 +34,7 @@
 		"RETURN_CODE": 200,
 		"METHOD": "GET"
 	},
-	"pc_merged_access_payloads" : 
+	"pc_merged_access_payloads" :
 	{
 		"MESSAGE": "OK",
 			"REQUEST_PATH": "https://10.122.197.6:443/rest/interface?serialNumber=SAL1819SAN8&ifName=Port-channel301",
@@ -69,7 +69,7 @@
 		"RETURN_CODE": 200,
 		"METHOD": "GET"
 	},
-	"pc_merged_l3_payloads" : 
+	"pc_merged_l3_payloads" :
 	{
 		"MESSAGE": "OK",
 			"REQUEST_PATH": "https://10.122.197.6:443/rest/interface?serialNumber=SAL1819SAN8&ifName=Port-channel302",
@@ -105,7 +105,7 @@
 		"RETURN_CODE": 200,
 		"METHOD": "GET"
 	},
-	"pc_merged_monitor_payloads" : 
+	"pc_merged_monitor_payloads" :
 	{
 		"MESSAGE": "OK",
 			"REQUEST_PATH": "https://10.122.197.6:443/rest/interface?serialNumber=SAL1819SAN8&ifName=Port-channel303",

--- a/tests/unit/modules/dcnm/test_dcnm_intf.py
+++ b/tests/unit/modules/dcnm/test_dcnm_intf.py
@@ -79,6 +79,148 @@ class TestDcnmIntfModule(TestDcnmModule):
 
     # -------------------------- GEN-FIXTURES --------------------------
 
+    def load_general_intf_fixtures(self):
+
+        if (
+            "test_dcnm_intf_override_pc_intf_types_only"
+            in self._testMethodName
+        ):
+
+            playbook_have_all_data = self.have_all_payloads_data.get(
+                "payloads"
+            )
+
+            self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
+                playbook_have_all_data,
+                self.playbook_mock_succ_resp,
+            ]
+
+        if (
+            "test_dcnm_intf_override_pc_intf_types_with_new_config"
+            in self._testMethodName
+        ):
+
+            playbook_have_all_data = self.have_all_payloads_data.get(
+                "payloads"
+            )
+
+            self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
+                self.playbook_mock_vpc_resp,
+                [],
+                playbook_have_all_data,
+                self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+            ]
+
+        if (
+            "test_dcnm_intf_override_all_but_eth_intf_types_only"
+            in self._testMethodName
+        ):
+
+            playbook_have_all_data = self.have_all_payloads_data.get(
+                "payloads"
+            )
+
+            self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
+                playbook_have_all_data,
+                self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+            ]
+
+        if (
+            "test_dcnm_intf_override_svi_intf_types_only"
+            in self._testMethodName
+        ):
+
+            playbook_have_all_data = self.have_all_payloads_data.get(
+                "payloads"
+            )
+
+            self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
+                playbook_have_all_data,
+                self.playbook_mock_succ_resp,
+            ]
+
+        if (
+            "test_dcnm_intf_override_vpc_intf_types_only"
+            in self._testMethodName
+        ):
+
+            playbook_have_all_data = self.have_all_payloads_data.get(
+                "payloads"
+            )
+
+            self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
+                playbook_have_all_data,
+                self.playbook_mock_succ_resp,
+            ]
+
+        if (
+            "test_dcnm_intf_override_eth_intf_types_only"
+            in self._testMethodName
+        ):
+
+            playbook_have_all_data = self.have_all_payloads_data.get(
+                "payloads"
+            )
+            eth_1_1_access_intf = self.have_all_payloads_data.get(
+                "eth_1_1_access_payload"
+            )
+            eth_1_2_access_intf = self.have_all_payloads_data.get(
+                "eth_1_2_access_payload"
+            )
+            eth_3_2_access_intf = self.have_all_payloads_data.get(
+                "eth_3_2_access_payload"
+            )
+
+            self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
+                playbook_have_all_data,
+                eth_1_1_access_intf,
+                eth_1_2_access_intf,
+                eth_3_2_access_intf,
+                self.playbook_mock_succ_resp,
+            ]
+
+        if (
+            "test_dcnm_intf_override_sub_int_intf_types_only"
+            in self._testMethodName
+        ):
+
+            playbook_have_all_data = self.have_all_payloads_data.get(
+                "payloads"
+            )
+            self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
+                playbook_have_all_data,
+                self.playbook_mock_succ_resp,
+            ]
+
+        if (
+            "test_dcnm_intf_override_lo_intf_types_only"
+            in self._testMethodName
+        ):
+
+            playbook_have_all_data = self.have_all_payloads_data.get(
+                "payloads"
+            )
+            self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
+                playbook_have_all_data,
+                self.playbook_mock_succ_resp,
+            ]
+
     def load_multi_intf_fixtures(self):
 
         if "_multi_intf_merged_new" in self._testMethodName:
@@ -537,12 +679,24 @@ class TestDcnmIntfModule(TestDcnmModule):
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
             )
+            eth_1_1_access_intf = self.have_all_payloads_data.get(
+                "eth_1_1_access_payload"
+            )
+            eth_1_2_access_intf = self.have_all_payloads_data.get(
+                "eth_1_2_access_payload"
+            )
+            eth_3_2_access_intf = self.have_all_payloads_data.get(
+                "eth_3_2_access_payload"
+            )
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
                 self.playbook_mock_vpc_resp,
                 playbook_svi_intf1,
                 playbook_have_all_data,
+                eth_1_1_access_intf,
+                eth_1_2_access_intf,
+                eth_3_2_access_intf,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -584,7 +738,9 @@ class TestDcnmIntfModule(TestDcnmModule):
             ]
 
         if "_aa_fex_merged_idempotent" in self._testMethodName:
-            playbook_aa_fex_intf1 = self.payloads_data.get("aa_fex_merged_payloads_150")
+            playbook_aa_fex_intf1 = self.payloads_data.get(
+                "aa_fex_merged_payloads_150"
+            )
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
             )
@@ -600,7 +756,9 @@ class TestDcnmIntfModule(TestDcnmModule):
             ]
 
         if "_aa_fex_merged_existing" in self._testMethodName:
-            playbook_aa_fex_intf1 = self.payloads_data.get("aa_fex_merged_payloads_150")
+            playbook_aa_fex_intf1 = self.payloads_data.get(
+                "aa_fex_merged_payloads_150"
+            )
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
             )
@@ -640,7 +798,9 @@ class TestDcnmIntfModule(TestDcnmModule):
 
         # Use the same payloads that we use for creating new.
         if "_aa_fex_deleted_existing" in self._testMethodName:
-            playbook_aa_fex_intf1 = self.payloads_data.get("aa_fex_merged_payloads_150")
+            playbook_aa_fex_intf1 = self.payloads_data.get(
+                "aa_fex_merged_payloads_150"
+            )
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
             )
@@ -668,7 +828,9 @@ class TestDcnmIntfModule(TestDcnmModule):
             ]
 
         if "_aa_fex_replaced_existing" in self._testMethodName:
-            playbook_aa_fex_intf1 = self.payloads_data.get("aa_fex_merged_payloads_150")
+            playbook_aa_fex_intf1 = self.payloads_data.get(
+                "aa_fex_merged_payloads_150"
+            )
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
             )
@@ -685,9 +847,20 @@ class TestDcnmIntfModule(TestDcnmModule):
 
         if "_aa_fex_overridden_existing" in self._testMethodName:
 
-            playbook_aa_fex_intf1 = self.payloads_data.get("aa_fex_merged_payloads_150")
+            playbook_aa_fex_intf1 = self.payloads_data.get(
+                "aa_fex_merged_payloads_150"
+            )
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
+            )
+            eth_1_1_access_intf = self.have_all_payloads_data.get(
+                "eth_1_1_access_payload"
+            )
+            eth_1_2_access_intf = self.have_all_payloads_data.get(
+                "eth_1_2_access_payload"
+            )
+            eth_3_2_access_intf = self.have_all_payloads_data.get(
+                "eth_3_2_access_payload"
             )
 
             self.run_dcnm_send.side_effect = [
@@ -695,6 +868,9 @@ class TestDcnmIntfModule(TestDcnmModule):
                 self.playbook_mock_vpc_resp,
                 playbook_aa_fex_intf1,
                 playbook_have_all_data,
+                eth_1_1_access_intf,
+                eth_1_2_access_intf,
+                eth_3_2_access_intf,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -716,9 +892,20 @@ class TestDcnmIntfModule(TestDcnmModule):
 
         if "_aa_fex_overridden_modify_existing" in self._testMethodName:
 
-            playbook_aa_fex_intf1 = self.payloads_data.get("aa_fex_merged_payloads_150")
+            playbook_aa_fex_intf1 = self.payloads_data.get(
+                "aa_fex_merged_payloads_150"
+            )
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
+            )
+            eth_1_1_access_intf = self.have_all_payloads_data.get(
+                "eth_1_1_access_payload"
+            )
+            eth_1_2_access_intf = self.have_all_payloads_data.get(
+                "eth_1_2_access_payload"
+            )
+            eth_3_2_access_intf = self.have_all_payloads_data.get(
+                "eth_3_2_access_payload"
             )
 
             self.run_dcnm_send.side_effect = [
@@ -726,6 +913,9 @@ class TestDcnmIntfModule(TestDcnmModule):
                 self.playbook_mock_vpc_resp,
                 playbook_aa_fex_intf1,
                 playbook_have_all_data,
+                eth_1_1_access_intf,
+                eth_1_2_access_intf,
+                eth_3_2_access_intf,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -767,7 +957,9 @@ class TestDcnmIntfModule(TestDcnmModule):
             ]
 
         if "_st_fex_merged_idempotent" in self._testMethodName:
-            playbook_st_fex_intf1 = self.payloads_data.get("st_fex_merged_payloads_150")
+            playbook_st_fex_intf1 = self.payloads_data.get(
+                "st_fex_merged_payloads_150"
+            )
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
             )
@@ -783,7 +975,9 @@ class TestDcnmIntfModule(TestDcnmModule):
             ]
 
         if "_st_fex_merged_existing" in self._testMethodName:
-            playbook_st_fex_intf1 = self.payloads_data.get("st_fex_merged_payloads_150")
+            playbook_st_fex_intf1 = self.payloads_data.get(
+                "st_fex_merged_payloads_150"
+            )
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
             )
@@ -823,7 +1017,9 @@ class TestDcnmIntfModule(TestDcnmModule):
 
         # Use the same payloads that we use for creating new.
         if "_st_fex_deleted_existing" in self._testMethodName:
-            playbook_st_fex_intf1 = self.payloads_data.get("st_fex_merged_payloads_150")
+            playbook_st_fex_intf1 = self.payloads_data.get(
+                "st_fex_merged_payloads_150"
+            )
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
             )
@@ -850,7 +1046,9 @@ class TestDcnmIntfModule(TestDcnmModule):
                 playbook_st_fex_intf1,
             ]
         if "_st_fex_replaced_existing" in self._testMethodName:
-            playbook_st_fex_intf1 = self.payloads_data.get("st_fex_merged_payloads_150")
+            playbook_st_fex_intf1 = self.payloads_data.get(
+                "st_fex_merged_payloads_150"
+            )
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
             )
@@ -867,9 +1065,20 @@ class TestDcnmIntfModule(TestDcnmModule):
 
         if "_st_fex_overridden_existing" in self._testMethodName:
 
-            playbook_st_fex_intf1 = self.payloads_data.get("st_fex_merged_payloads_150")
+            playbook_st_fex_intf1 = self.payloads_data.get(
+                "st_fex_merged_payloads_150"
+            )
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
+            )
+            eth_1_1_access_intf = self.have_all_payloads_data.get(
+                "eth_1_1_access_payload"
+            )
+            eth_1_2_access_intf = self.have_all_payloads_data.get(
+                "eth_1_2_access_payload"
+            )
+            eth_3_2_access_intf = self.have_all_payloads_data.get(
+                "eth_3_2_access_payload"
             )
 
             self.run_dcnm_send.side_effect = [
@@ -877,6 +1086,9 @@ class TestDcnmIntfModule(TestDcnmModule):
                 self.playbook_mock_vpc_resp,
                 playbook_st_fex_intf1,
                 playbook_have_all_data,
+                eth_1_1_access_intf,
+                eth_1_2_access_intf,
+                eth_3_2_access_intf,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -898,9 +1110,20 @@ class TestDcnmIntfModule(TestDcnmModule):
 
         if "_st_fex_overridden_modify_existing" in self._testMethodName:
 
-            playbook_st_fex_intf1 = self.payloads_data.get("st_fex_merged_payloads_150")
+            playbook_st_fex_intf1 = self.payloads_data.get(
+                "st_fex_merged_payloads_150"
+            )
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
+            )
+            eth_1_1_access_intf = self.have_all_payloads_data.get(
+                "eth_1_1_access_payload"
+            )
+            eth_1_2_access_intf = self.have_all_payloads_data.get(
+                "eth_1_2_access_payload"
+            )
+            eth_3_2_access_intf = self.have_all_payloads_data.get(
+                "eth_3_2_access_payload"
             )
 
             self.run_dcnm_send.side_effect = [
@@ -908,6 +1131,9 @@ class TestDcnmIntfModule(TestDcnmModule):
                 self.playbook_mock_vpc_resp,
                 playbook_st_fex_intf1,
                 playbook_have_all_data,
+                eth_1_1_access_intf,
+                eth_1_2_access_intf,
+                eth_3_2_access_intf,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -1180,11 +1406,24 @@ class TestDcnmIntfModule(TestDcnmModule):
                 "payloads"
             )
 
+            eth_1_1_access_intf = self.have_all_payloads_data.get(
+                "eth_1_1_access_payload"
+            )
+            eth_1_2_access_intf = self.have_all_payloads_data.get(
+                "eth_1_2_access_payload"
+            )
+            eth_3_2_access_intf = self.have_all_payloads_data.get(
+                "eth_3_2_access_payload"
+            )
+
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
                 self.playbook_mock_vpc_resp,
                 playbook_pc_intf1,
                 playbook_have_all_data,
+                eth_1_1_access_intf,
+                eth_1_2_access_intf,
+                eth_3_2_access_intf,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -1433,11 +1672,24 @@ class TestDcnmIntfModule(TestDcnmModule):
                 "deployed_payloads"
             )
 
+            eth_1_1_access_intf = self.have_all_payloads_data.get(
+                "eth_1_1_access_payload"
+            )
+            eth_1_2_access_intf = self.have_all_payloads_data.get(
+                "eth_1_2_access_payload"
+            )
+            eth_3_2_access_intf = self.have_all_payloads_data.get(
+                "eth_3_2_access_payload"
+            )
+
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
                 self.playbook_mock_vpc_resp,
                 playbook_eth_intf1,
                 playbook_have_all_data,
+                eth_1_1_access_intf,
+                eth_1_2_access_intf,
+                eth_3_2_access_intf,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -1641,11 +1893,24 @@ class TestDcnmIntfModule(TestDcnmModule):
                 "deployed_payloads"
             )
 
+            eth_1_1_access_intf = self.have_all_payloads_data.get(
+                "eth_1_1_access_payload"
+            )
+            eth_1_2_access_intf = self.have_all_payloads_data.get(
+                "eth_1_2_access_payload"
+            )
+            eth_3_2_access_intf = self.have_all_payloads_data.get(
+                "eth_3_2_access_payload"
+            )
+
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
                 self.playbook_mock_vpc_resp,
                 playbook_subint_intf1,
                 playbook_have_all_data,
+                eth_1_1_access_intf,
+                eth_1_2_access_intf,
+                eth_3_2_access_intf,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -1821,12 +2086,25 @@ class TestDcnmIntfModule(TestDcnmModule):
                 "deployed_payloads"
             )
 
+            eth_1_1_access_intf = self.have_all_payloads_data.get(
+                "eth_1_1_access_payload"
+            )
+            eth_1_2_access_intf = self.have_all_payloads_data.get(
+                "eth_1_2_access_payload"
+            )
+            eth_3_2_access_intf = self.have_all_payloads_data.get(
+                "eth_3_2_access_payload"
+            )
+
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
                 self.playbook_mock_vpc_resp,
                 playbook_lo_intf1,
                 playbook_lo_intf2,
                 playbook_have_all_data,
+                eth_1_1_access_intf,
+                eth_1_2_access_intf,
+                eth_3_2_access_intf,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -1854,11 +2132,24 @@ class TestDcnmIntfModule(TestDcnmModule):
                 "deployed_payloads"
             )
 
+            eth_1_1_access_intf = self.have_all_payloads_data.get(
+                "eth_1_1_access_payload"
+            )
+            eth_1_2_access_intf = self.have_all_payloads_data.get(
+                "eth_1_2_access_payload"
+            )
+            eth_3_2_access_intf = self.have_all_payloads_data.get(
+                "eth_3_2_access_payload"
+            )
+
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
                 self.playbook_mock_vpc_resp,
                 playbook_lo_intf1,
                 playbook_have_all_data,
+                eth_1_1_access_intf,
+                eth_1_2_access_intf,
+                eth_3_2_access_intf,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -1883,11 +2174,24 @@ class TestDcnmIntfModule(TestDcnmModule):
                 "payloads"
             )
 
+            eth_1_1_access_intf = self.have_all_payloads_data.get(
+                "eth_1_1_access_payload"
+            )
+            eth_1_2_access_intf = self.have_all_payloads_data.get(
+                "eth_1_2_access_payload"
+            )
+            eth_3_2_access_intf = self.have_all_payloads_data.get(
+                "eth_3_2_access_payload"
+            )
+
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
                 self.playbook_mock_vpc_resp,
                 playbook_lo_intf1,
                 playbook_have_all_data,
+                eth_1_1_access_intf,
+                eth_1_2_access_intf,
+                eth_3_2_access_intf,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -2052,6 +2356,15 @@ class TestDcnmIntfModule(TestDcnmModule):
             playbook_deployed_data = self.have_all_payloads_data.get(
                 "deployed_payloads"
             )
+            eth_1_1_access_intf = self.have_all_payloads_data.get(
+                "eth_1_1_access_payload"
+            )
+            eth_1_2_access_intf = self.have_all_payloads_data.get(
+                "eth_1_2_access_payload"
+            )
+            eth_3_2_access_intf = self.have_all_payloads_data.get(
+                "eth_3_2_access_payload"
+            )
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
@@ -2059,6 +2372,9 @@ class TestDcnmIntfModule(TestDcnmModule):
                 self.playbook_mock_vpc_resp,
                 playbook_vpc_intf1,
                 playbook_have_all_data,
+                eth_1_1_access_intf,
+                eth_1_2_access_intf,
+                eth_3_2_access_intf,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -2124,6 +2440,9 @@ class TestDcnmIntfModule(TestDcnmModule):
         # Load bunched interface configuration related side-effects
         self.load_bunched_intf_elems_fixtures()
 
+        # Load general side-effects
+        self.load_general_intf_fixtures()
+
         # Load missing elements interface configuration related side-effects
         self.load_type_missing_fixtures()
         self.load_missing_state_fixtures()
@@ -2148,8 +2467,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
 
         set_module_args(
             dict(
@@ -2194,8 +2517,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
 
         set_module_args(
             dict(
@@ -2249,8 +2576,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -2294,8 +2625,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
 
         set_module_args(
             dict(
@@ -2341,8 +2676,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -2386,8 +2725,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -2416,8 +2759,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -2444,8 +2791,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -2482,12 +2833,18 @@ class TestDcnmIntfModule(TestDcnmModule):
         )
 
         # load required config data
-        self.playbook_config = self.config_data.get("pc_deleted_config_no_deploy")
+        self.playbook_config = self.config_data.get(
+            "pc_deleted_config_no_deploy"
+        )
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -2501,15 +2858,7 @@ class TestDcnmIntfModule(TestDcnmModule):
 
         self.assertEqual(len(result["diff"][0]["deleted"]), 1)
         for intf in result["diff"][0]["deleted"]:
-            self.assertEqual(
-                (
-                    intf["ifName"]
-                    in [
-                        "Port-channel300",
-                    ]
-                ),
-                True,
-            )
+            self.assertEqual((intf["ifName"] in ["Port-channel300"]), True)
         self.assertEqual(len(result["diff"][0]["delete_deploy"]), 0)
 
     def test_dcnm_intf_deleted_deploy(self):
@@ -2526,8 +2875,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -2556,8 +2909,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -2611,8 +2968,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -2636,12 +2997,7 @@ class TestDcnmIntfModule(TestDcnmModule):
             "vlan2001",
         ]
 
-        rep_if_names = [
-            "ethernet1/3.2",
-            "ethernet1/1",
-            "ethernet1/2",
-            "ethernet3/2",
-        ]
+        rep_if_names = ["ethernet1/1", "ethernet1/2", "ethernet3/2"]
         ovr_if_names = ["port-channel300"]
 
         for intf in result["diff"][0]["deleted"]:
@@ -2677,8 +3033,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -2708,8 +3068,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -2751,8 +3115,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         for cfg in self.playbook_config:
@@ -2782,8 +3150,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -2839,8 +3211,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -2870,8 +3246,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -2930,8 +3310,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -2964,8 +3348,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         for cfg in self.playbook_config:
@@ -2995,8 +3383,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -3049,8 +3441,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -3079,8 +3475,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -3114,8 +3514,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -3143,8 +3547,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -3203,8 +3611,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -3238,8 +3650,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -3269,8 +3685,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         for cfg in self.playbook_config:
@@ -3300,8 +3720,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -3349,8 +3773,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -3382,8 +3810,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -3442,8 +3874,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -3501,8 +3937,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -3562,8 +4002,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -3596,8 +4040,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         for cfg in self.playbook_config:
@@ -3605,8 +4053,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
 
         set_module_args(
             dict(
@@ -3633,8 +4085,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -3665,8 +4121,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -3726,8 +4186,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -3752,12 +4216,7 @@ class TestDcnmIntfModule(TestDcnmModule):
             "vlan2001",
         ]
 
-        rep_if_names = [
-            "ethernet1/3.2",
-            "ethernet1/1",
-            "ethernet1/2",
-            "ethernet3/2",
-        ]
+        rep_if_names = ["ethernet1/1", "ethernet1/2", "ethernet3/2"]
         ovr_if_names = ["vpc750"]
 
         for intf in result["diff"][0]["deleted"]:
@@ -3791,8 +4250,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -3825,8 +4288,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -3855,8 +4322,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -3888,8 +4359,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -3919,8 +4394,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -3992,8 +4471,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -4018,12 +4501,7 @@ class TestDcnmIntfModule(TestDcnmModule):
             "vlan2001",
         ]
 
-        rep_if_names = [
-            "ethernet1/3.2",
-            "ethernet1/1",
-            "ethernet1/2",
-            "ethernet3/2",
-        ]
+        rep_if_names = ["ethernet1/1", "ethernet1/2", "ethernet3/2"]
         ovr_if_names = ["vlan1010"]
 
         for intf in result["diff"][0]["deleted"]:
@@ -4057,8 +4535,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -4091,8 +4573,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -4115,12 +4601,18 @@ class TestDcnmIntfModule(TestDcnmModule):
         )
 
         # load required config data
-        self.playbook_config = self.config_data.get("aa_fex_merge_existing_config")
+        self.playbook_config = self.config_data.get(
+            "aa_fex_merge_existing_config"
+        )
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -4147,12 +4639,18 @@ class TestDcnmIntfModule(TestDcnmModule):
         )
 
         # load required config data
-        self.playbook_config = self.config_data.get("aa_fex_merge_multi_switches_config")
+        self.playbook_config = self.config_data.get(
+            "aa_fex_merge_multi_switches_config"
+        )
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -4185,8 +4683,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -4218,8 +4720,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -4247,8 +4753,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -4298,12 +4808,18 @@ class TestDcnmIntfModule(TestDcnmModule):
         )
 
         # load required config data
-        self.playbook_config = self.config_data.get("aa_fex_overridden_new_config")
+        self.playbook_config = self.config_data.get(
+            "aa_fex_overridden_new_config"
+        )
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -4328,12 +4844,7 @@ class TestDcnmIntfModule(TestDcnmModule):
             "vlan2001",
         ]
 
-        rep_if_names = [
-            "ethernet1/3.2",
-            "ethernet1/1",
-            "ethernet1/2",
-            "ethernet3/2",
-        ]
+        rep_if_names = ["ethernet1/1", "ethernet1/2", "ethernet3/2"]
 
         ovr_if_names = ["vpc159"]
 
@@ -4362,12 +4873,18 @@ class TestDcnmIntfModule(TestDcnmModule):
         )
 
         # load required config data
-        self.playbook_config = self.config_data.get("aa_fex_overridden_modify_existing_config")
+        self.playbook_config = self.config_data.get(
+            "aa_fex_overridden_modify_existing_config"
+        )
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -4392,12 +4909,7 @@ class TestDcnmIntfModule(TestDcnmModule):
             "vlan2001",
         ]
 
-        rep_if_names = [
-            "ethernet1/3.2",
-            "ethernet1/1",
-            "ethernet1/2",
-            "ethernet3/2",
-        ]
+        rep_if_names = ["ethernet1/1", "ethernet1/2", "ethernet3/2"]
 
         ovr_if_names = ["vpc150"]
 
@@ -4432,8 +4944,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -4466,8 +4982,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -4490,12 +5010,18 @@ class TestDcnmIntfModule(TestDcnmModule):
         )
 
         # load required config data
-        self.playbook_config = self.config_data.get("st_fex_merge_existing_config")
+        self.playbook_config = self.config_data.get(
+            "st_fex_merge_existing_config"
+        )
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -4522,12 +5048,18 @@ class TestDcnmIntfModule(TestDcnmModule):
         )
 
         # load required config data
-        self.playbook_config = self.config_data.get("st_fex_merge_multi_switches_config")
+        self.playbook_config = self.config_data.get(
+            "st_fex_merge_multi_switches_config"
+        )
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -4560,8 +5092,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -4593,8 +5129,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -4622,8 +5162,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -4671,12 +5215,18 @@ class TestDcnmIntfModule(TestDcnmModule):
         )
 
         # load required config data
-        self.playbook_config = self.config_data.get("st_fex_overridden_new_config")
+        self.playbook_config = self.config_data.get(
+            "st_fex_overridden_new_config"
+        )
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -4701,12 +5251,7 @@ class TestDcnmIntfModule(TestDcnmModule):
             "vlan2001",
         ]
 
-        rep_if_names = [
-            "ethernet1/3.2",
-            "ethernet1/1",
-            "ethernet1/2",
-            "ethernet3/2",
-        ]
+        rep_if_names = ["ethernet1/1", "ethernet1/2", "ethernet3/2"]
 
         ovr_if_names = ["port-channel159"]
 
@@ -4735,12 +5280,18 @@ class TestDcnmIntfModule(TestDcnmModule):
         )
 
         # load required config data
-        self.playbook_config = self.config_data.get("st_fex_overridden_modify_existing_config")
+        self.playbook_config = self.config_data.get(
+            "st_fex_overridden_modify_existing_config"
+        )
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -4765,12 +5316,7 @@ class TestDcnmIntfModule(TestDcnmModule):
             "vlan2001",
         ]
 
-        rep_if_names = [
-            "ethernet1/3.2",
-            "ethernet1/1",
-            "ethernet1/2",
-            "ethernet3/2",
-        ]
+        rep_if_names = ["ethernet1/1", "ethernet1/2", "ethernet3/2"]
 
         ovr_if_names = ["port-channel150"]
 
@@ -4791,6 +5337,382 @@ class TestDcnmIntfModule(TestDcnmModule):
 
     # -------------------------- GENERAL --------------------------
 
+    def test_dcnm_intf_override_pc_intf_types_only(self):
+
+        # load the json from playbooks
+        self.config_data = loadPlaybookData("dcnm_intf_common_configs")
+        self.payloads_data = []
+        self.have_all_payloads_data = loadPlaybookData(
+            "dcnm_intf_have_all_payloads"
+        )
+
+        # load required config data
+        self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
+        self.mock_ip_sn = self.config_data.get("mock_ip_sn")
+        self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
+        self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
+
+        set_module_args(
+            dict(
+                state="overridden",
+                fabric="test_fabric",
+                override_intf_types=["pc"],
+                deploy=False,
+                config=[],
+            )
+        )
+        result = self.execute_module(changed=True, failed=False)
+
+        del_if_names = [
+            "port-channel301",
+            "port-channel302",
+            "port-channel303",
+            "port-channel300",
+        ]
+        rep_if_names = []
+        ovr_if_names = []
+
+        for intf in result["diff"][0]["deleted"]:
+            self.assertEqual((intf["ifName"].lower() in del_if_names), True)
+
+        self.assertEqual(len(result["diff"][0]["deleted"]), 4)
+        self.assertEqual(len(result["diff"][0]["replaced"]), 0)
+        self.assertEqual(len(result["diff"][0]["overridden"]), 0)
+
+    def test_dcnm_intf_override_pc_intf_types_with_new_config(self):
+
+        # load the json from playbooks
+        self.config_data = loadPlaybookData("dcnm_intf_common_configs")
+        self.payloads_data = []
+        self.have_all_payloads_data = loadPlaybookData(
+            "dcnm_intf_have_all_payloads"
+        )
+
+        # load required config data
+        self.playbook_config = self.config_data.get("pc_config")
+        self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
+        self.mock_ip_sn = self.config_data.get("mock_ip_sn")
+        self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
+        self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
+
+        set_module_args(
+            dict(
+                state="overridden",
+                fabric="test_fabric",
+                override_intf_types=["pc"],
+                deploy=False,
+                config=self.playbook_config,
+            )
+        )
+        result = self.execute_module(changed=True, failed=False)
+
+        del_if_names = [
+            "port-channel301",
+            "port-channel302",
+            "port-channel303",
+            "port-channel300",
+        ]
+        rep_if_names = []
+        ovr_if_names = ["port-channel900"]
+
+        for intf in result["diff"][0]["deleted"]:
+            self.assertEqual((intf["ifName"].lower() in del_if_names), True)
+
+        for intf in result["diff"][0]["overridden"]:
+            self.assertEqual(
+                (intf["interfaces"][0]["ifName"].lower() in ovr_if_names), True
+            )
+
+        self.assertEqual(len(result["diff"][0]["deleted"]), 4)
+        self.assertEqual(len(result["diff"][0]["replaced"]), 0)
+        self.assertEqual(len(result["diff"][0]["overridden"]), 1)
+        self.assertEqual(len(result["diff"][0]["merged"]), 0)
+
+    def test_dcnm_intf_override_all_but_eth_intf_types_only(self):
+
+        # load the json from playbooks
+        self.config_data = loadPlaybookData("dcnm_intf_common_configs")
+        self.have_all_payloads_data = loadPlaybookData(
+            "dcnm_intf_have_all_payloads"
+        )
+
+        # load required config data
+        self.playbook_config = self.config_data.get(
+            "override_all_but_eth_only_config"
+        )
+        self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
+        self.mock_ip_sn = self.config_data.get("mock_ip_sn")
+        self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
+        self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
+
+        set_module_args(
+            dict(
+                state="overridden",
+                fabric="test_fabric",
+                override_intf_types=["pc", "sub_int", "vpc", "lo", "svi"],
+                deploy=False,
+                config=[],
+            )
+        )
+        result = self.execute_module(changed=True, failed=False)
+
+        del_if_names = [
+            "port-channel301",
+            "port-channel302",
+            "port-channel303",
+            "port-channel300",
+            "ethernet1/3.2",
+            "loopback200",
+            "vpc300",
+            "vlan2001",
+        ]
+        rep_if_names = []
+        ovr_if_names = []
+
+        for intf in result["diff"][0]["deleted"]:
+            self.assertEqual((intf["ifName"].lower() in del_if_names), True)
+
+        self.assertEqual(len(result["diff"][0]["deleted"]), 8)
+        self.assertEqual(len(result["diff"][0]["replaced"]), 0)
+        self.assertEqual(len(result["diff"][0]["overridden"]), 0)
+
+    def test_dcnm_intf_override_svi_intf_types_only(self):
+
+        # load the json from playbooks
+        self.config_data = loadPlaybookData("dcnm_intf_common_configs")
+        self.have_all_payloads_data = loadPlaybookData(
+            "dcnm_intf_have_all_payloads"
+        )
+
+        # load required config data
+        self.playbook_config = self.config_data.get("override_svi_only_config")
+        self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
+        self.mock_ip_sn = self.config_data.get("mock_ip_sn")
+        self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
+        self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
+
+        set_module_args(
+            dict(
+                state="overridden",
+                fabric="test_fabric",
+                override_intf_types=["svi"],
+                deploy=False,
+                config=[],
+            )
+        )
+        result = self.execute_module(changed=True, failed=False)
+
+        del_if_names = ["vlan2001"]
+        ovr_if_names = []
+        rep_if_names = []
+
+        for intf in result["diff"][0]["deleted"]:
+            self.assertEqual((intf["ifName"].lower() in del_if_names), True)
+
+        self.assertEqual(len(result["diff"][0]["deleted"]), 1)
+        self.assertEqual(len(result["diff"][0]["replaced"]), 0)
+        self.assertEqual(len(result["diff"][0]["overridden"]), 0)
+
+    def test_dcnm_intf_override_vpc_intf_types_only(self):
+
+        # load the json from playbooks
+        self.config_data = loadPlaybookData("dcnm_intf_common_configs")
+        self.have_all_payloads_data = loadPlaybookData(
+            "dcnm_intf_have_all_payloads"
+        )
+
+        # load required config data
+        self.playbook_config = self.config_data.get("override_vpc_only_config")
+        self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
+        self.mock_ip_sn = self.config_data.get("mock_ip_sn")
+        self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
+        self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
+
+        set_module_args(
+            dict(
+                state="overridden",
+                fabric="test_fabric",
+                override_intf_types=["vpc"],
+                deploy=False,
+                config=[],
+            )
+        )
+        result = self.execute_module(changed=True, failed=False)
+
+        del_if_names = ["vpc300"]
+        ovr_if_names = []
+        rep_if_names = []
+
+        for intf in result["diff"][0]["deleted"]:
+            self.assertEqual((intf["ifName"].lower() in del_if_names), True)
+
+        self.assertEqual(len(result["diff"][0]["deleted"]), 1)
+        self.assertEqual(len(result["diff"][0]["replaced"]), 0)
+        self.assertEqual(len(result["diff"][0]["overridden"]), 0)
+
+    def test_dcnm_intf_override_eth_intf_types_only(self):
+
+        # load the json from playbooks
+        self.config_data = loadPlaybookData("dcnm_intf_common_configs")
+        self.have_all_payloads_data = loadPlaybookData(
+            "dcnm_intf_have_all_payloads"
+        )
+
+        # load required config data
+        self.playbook_config = self.config_data.get("override_eth_only_config")
+        self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
+        self.mock_ip_sn = self.config_data.get("mock_ip_sn")
+        self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
+        self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
+
+        set_module_args(
+            dict(
+                state="overridden",
+                fabric="test_fabric",
+                override_intf_types=["eth"],
+                deploy=False,
+                config=[],
+            )
+        )
+        result = self.execute_module(changed=True, failed=False)
+
+        ovr_if_names = []
+        del_if_names = []
+        rep_if_names = ["ethernet1/1", "ethernet1/2", "ethernet3/2"]
+
+        for intf in result["diff"][0]["replaced"]:
+            self.assertEqual(
+                (intf["interfaces"][0]["ifName"].lower() in rep_if_names), True
+            )
+
+        self.assertEqual(len(result["diff"][0]["deleted"]), 0)
+        self.assertEqual(len(result["diff"][0]["replaced"]), 3)
+        self.assertEqual(len(result["diff"][0]["overridden"]), 0)
+
+    def test_dcnm_intf_override_sub_int_intf_types_only(self):
+
+        # load the json from playbooks
+        self.config_data = loadPlaybookData("dcnm_intf_common_configs")
+        self.have_all_payloads_data = loadPlaybookData(
+            "dcnm_intf_have_all_payloads"
+        )
+
+        # load required config data
+        self.playbook_config = self.config_data.get(
+            "override_sub_int_only_config"
+        )
+        self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
+        self.mock_ip_sn = self.config_data.get("mock_ip_sn")
+        self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
+        self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
+
+        set_module_args(
+            dict(
+                state="overridden",
+                fabric="test_fabric",
+                override_intf_types=["sub_int"],
+                deploy=False,
+                config=[],
+            )
+        )
+        result = self.execute_module(changed=True, failed=False)
+
+        rep_if_names = []
+        ovr_if_names = []
+        del_if_names = ["ethernet1/3.2"]
+
+        for intf in result["diff"][0]["deleted"]:
+            self.assertEqual((intf["ifName"].lower() in del_if_names), True)
+
+        self.assertEqual(len(result["diff"][0]["deleted"]), 1)
+        self.assertEqual(len(result["diff"][0]["replaced"]), 0)
+        self.assertEqual(len(result["diff"][0]["overridden"]), 0)
+
+    def test_dcnm_intf_override_lo_intf_types_only(self):
+
+        # load the json from playbooks
+        self.config_data = loadPlaybookData("dcnm_intf_common_configs")
+        self.have_all_payloads_data = loadPlaybookData(
+            "dcnm_intf_have_all_payloads"
+        )
+
+        # load required config data
+        self.playbook_config = self.config_data.get("override_lo_only_config")
+        self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
+        self.mock_ip_sn = self.config_data.get("mock_ip_sn")
+        self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
+        self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
+
+        set_module_args(
+            dict(
+                state="overridden",
+                fabric="test_fabric",
+                override_intf_types=["lo"],
+                deploy=False,
+                config=[],
+            )
+        )
+        result = self.execute_module(changed=True, failed=False)
+
+        rep_if_names = []
+        ovr_if_names = []
+        del_if_names = ["loopback200"]
+
+        for intf in result["diff"][0]["deleted"]:
+            self.assertEqual((intf["ifName"].lower() in del_if_names), True)
+
+        self.assertEqual(len(result["diff"][0]["deleted"]), 1)
+        self.assertEqual(len(result["diff"][0]["replaced"]), 0)
+        self.assertEqual(len(result["diff"][0]["overridden"]), 0)
+
     def test_dcnm_intf_gen_missing_ip_sn(self):
 
         # load the json from playbooks
@@ -4805,8 +5727,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = []
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
         set_module_args(
             dict(
@@ -4837,8 +5763,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
 
         set_module_args(
             dict(
@@ -4870,8 +5800,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
 
         set_module_args(
             dict(
@@ -4920,8 +5854,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -4952,8 +5890,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -4987,8 +5929,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
 
         set_module_args(
             dict(
@@ -5024,8 +5970,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -5059,8 +6009,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -5078,7 +6032,9 @@ class TestDcnmIntfModule(TestDcnmModule):
         except Exception as e:
             self.assertEqual(result, None)
             self.assertEqual(("is in Monitoring mode" in str(e)), True)
-            self.assertEqual(("No changes are allowed on the fabric" in str(e)), True)
+            self.assertEqual(
+                ("No changes are allowed on the fabric" in str(e)), True
+            )
 
     def test_dcnm_intf_merge_unmanagable_switch(self):
 
@@ -5090,12 +6046,18 @@ class TestDcnmIntfModule(TestDcnmModule):
         )
 
         # load required config data
-        self.playbook_config = self.config_data.get("pc_unmanagable_merged_config")
+        self.playbook_config = self.config_data.get(
+            "pc_unmanagable_merged_config"
+        )
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
         self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
-        self.mock_monitor_true_resp = self.config_data.get("mock_monitor_true_resp")
-        self.mock_monitor_false_resp = self.config_data.get("mock_monitor_false_resp")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
         set_module_args(
@@ -5113,4 +6075,6 @@ class TestDcnmIntfModule(TestDcnmModule):
         except Exception as e:
             self.assertEqual(result, None)
             self.assertEqual(("are not managable in Fabric" in str(e)), True)
-            self.assertEqual(("No changes are allowed on these switches" in str(e)), True)
+            self.assertEqual(
+                ("No changes are allowed on these switches" in str(e)), True
+            )


### PR DESCRIPTION
By default interface module will delete/default all interface types during overridden/deleted states. The module has been updated to do the following:

- provide an optional list parameter in the playbook to include specific interface types
- if this list is empty, then the behaviour will be similar to what is already implemented i.e. all interface types will be handled during overridden and deleted states
- if this list includes specific interface types, then only those interface types will be handled during overridden and deleted states.
- this commit also fixes a couple of deploy issues during overridden/deleted states.