### PR TITLE
Case agnostic checks for interface names in dcnm_links module

### DIFF
--- a/plugins/modules/dcnm_links.py
+++ b/plugins/modules/dcnm_links.py
@@ -898,8 +898,7 @@ class DcnmLinks:
             "ext_multisite_underlay_setup": "ext_multisite_underlay_setup_11_1",
             "ext_evpn_multisite_overlay_setup": "ext_evpn_multisite_overlay_setup",
             "ext_vxlan_mpls_overlay_setup": "ext_vxlan_mpls_overlay_setup",
-            "ext_vxlan_mpls_underlay_setup": "ext_vxlan_mpls_underlay_setup"
-
+            "ext_vxlan_mpls_underlay_setup": "ext_vxlan_mpls_underlay_setup",
         },
         12: {
             "int_intra_fabric_ipv6_link_local": "int_intra_fabric_ipv6_link_local",
@@ -912,7 +911,7 @@ class DcnmLinks:
             "ext_multisite_underlay_setup": "ext_multisite_underlay_setup",
             "ext_evpn_multisite_overlay_setup": "ext_evpn_multisite_overlay_setup",
             "ext_vxlan_mpls_overlay_setup": "ext_vxlan_mpls_overlay_setup",
-            "ext_vxlan_mpls_underlay_setup": "ext_vxlan_mpls_underlay_setup"
+            "ext_vxlan_mpls_underlay_setup": "ext_vxlan_mpls_underlay_setup",
         },
     }
 
@@ -928,7 +927,7 @@ class DcnmLinks:
             "ext_multisite_underlay_setup_11_1",
             "ext_evpn_multisite_overlay_setup",
             "ext_vxlan_mpls_overlay_setup",
-            "ext_vxlan_mpls_underlay_setup"
+            "ext_vxlan_mpls_underlay_setup",
         ],
         12: [
             "int_intra_fabric_ipv6_link_local",
@@ -941,7 +940,7 @@ class DcnmLinks:
             "ext_multisite_underlay_setup",
             "ext_evpn_multisite_overlay_setup",
             "ext_vxlan_mpls_overlay_setup",
-            "ext_vxlan_mpls_underlay_setup"
+            "ext_vxlan_mpls_underlay_setup",
         ],
     }
 
@@ -1228,7 +1227,9 @@ class DcnmLinks:
             )
         ):
             if (
-                self.src_fabric_info["nvPairs"]["UNDERLAY_IS_V6"].lower()
+                self.src_fabric_info["nvPairs"]
+                .get("UNDERLAY_IS_V6", "false")
+                .lower()
                 == "false"
             ):
                 link_spec["profile"]["peer1_ipv4_addr"] = dict(
@@ -1324,12 +1325,18 @@ class DcnmLinks:
             self.module.fail_json(msg="Required parameter not found: template")
 
         if (
-            cfg[0].get("template", "")
-            == self.templates["ext_multisite_underlay_setup"]
-        ) or (
-            cfg[0].get("template", "") == self.templates["ext_fabric_setup"]
-        ) or (
-            cfg[0].get("template", "") == self.templates["ext_vxlan_mpls_underlay_setup"]
+            (
+                cfg[0].get("template", "")
+                == self.templates["ext_multisite_underlay_setup"]
+            )
+            or (
+                cfg[0].get("template", "")
+                == self.templates["ext_fabric_setup"]
+            )
+            or (
+                cfg[0].get("template", "")
+                == self.templates["ext_vxlan_mpls_underlay_setup"]
+            )
         ):
             link_spec["profile"]["ipv4_subnet"] = dict(
                 required=True, type="ipv4_subnet"
@@ -1343,7 +1350,10 @@ class DcnmLinks:
             )
             link_spec["profile"]["peer1_cmds"] = dict(type="list", default=[])
             link_spec["profile"]["peer2_cmds"] = dict(type="list", default=[])
-        elif cfg[0].get("template") != self.templates["ext_vxlan_mpls_overlay_setup"]:
+        elif (
+            cfg[0].get("template")
+            != self.templates["ext_vxlan_mpls_overlay_setup"]
+        ):
             link_spec["profile"]["ipv4_addr"] = dict(
                 required=True, type="ipv4"
             )
@@ -1351,12 +1361,18 @@ class DcnmLinks:
         link_spec["profile"]["neighbor_ip"] = dict(required=True, type="ipv4")
         # src_asn and dst_asn are not common parameters
         if (
-            cfg[0].get("template", "")
-            == self.templates["ext_multisite_underlay_setup"]
-        ) or (
-            cfg[0].get("template", "") == self.templates["ext_fabric_setup"]
-        ) or (
-            cfg[0].get("template", "") == self.templates["ext_vxlan_mpls_overlay_setup"]
+            (
+                cfg[0].get("template", "")
+                == self.templates["ext_multisite_underlay_setup"]
+            )
+            or (
+                cfg[0].get("template", "")
+                == self.templates["ext_fabric_setup"]
+            )
+            or (
+                cfg[0].get("template", "")
+                == self.templates["ext_vxlan_mpls_overlay_setup"]
+            )
         ):
             link_spec["profile"]["src_asn"] = dict(required=True, type="int")
             link_spec["profile"]["dst_asn"] = dict(required=True, type="int")
@@ -1609,10 +1625,16 @@ class DcnmLinks:
         """
         link_payload["nvPairs"] = {}
         if (
-            link["template"] == self.templates["ext_multisite_underlay_setup"]
-        ) or (
-            link["template"] == self.templates["ext_fabric_setup"]
-        ) or (link["template"] == self.templates["ext_vxlan_mpls_underlay_setup"]):
+            (
+                link["template"]
+                == self.templates["ext_multisite_underlay_setup"]
+            )
+            or (link["template"] == self.templates["ext_fabric_setup"])
+            or (
+                link["template"]
+                == self.templates["ext_vxlan_mpls_underlay_setup"]
+            )
+        ):
             ip_prefix = link["profile"]["ipv4_subnet"].split("/")
 
             link_payload["nvPairs"]["IP_MASK"] = (
@@ -1639,7 +1661,9 @@ class DcnmLinks:
                 link_payload["nvPairs"]["PEER2_CONF"] = "\n".join(
                     link["profile"].get("peer2_cmds")
                 )
-        elif link["template"] != self.templates["ext_vxlan_mpls_overlay_setup"]:
+        elif (
+            link["template"] != self.templates["ext_vxlan_mpls_overlay_setup"]
+        ):
             link_payload["nvPairs"]["SOURCE_IP"] = str(
                 ipaddress.ip_address(link["profile"]["ipv4_addr"])
             )
@@ -1648,12 +1672,20 @@ class DcnmLinks:
             ipaddress.ip_address(link["profile"]["neighbor_ip"])
         )
         if (
-            link["template"] == self.templates["ext_multisite_underlay_setup"]
-        ) or (
-            link["template"] == self.templates["ext_fabric_setup"]
-        ) or (link["template"] == self.templates["ext_vxlan_mpls_overlay_setup"]):
+            (
+                link["template"]
+                == self.templates["ext_multisite_underlay_setup"]
+            )
+            or (link["template"] == self.templates["ext_fabric_setup"])
+            or (
+                link["template"]
+                == self.templates["ext_vxlan_mpls_overlay_setup"]
+            )
+        ):
             link_payload["nvPairs"]["asn"] = link["profile"]["src_asn"]
-            link_payload["nvPairs"]["NEIGHBOR_ASN"] = link["profile"]["dst_asn"]
+            link_payload["nvPairs"]["NEIGHBOR_ASN"] = link["profile"][
+                "dst_asn"
+            ]
 
         if link["template"] == self.templates["ext_fabric_setup"]:
             link_payload["nvPairs"]["AUTO_VRF_LITE_FLAG"] = link["profile"][
@@ -1706,13 +1738,27 @@ class DcnmLinks:
                         "profile"
                     ]["ebgp_auth_key_type"]
         if link["template"] == self.templates["ext_vxlan_mpls_underlay_setup"]:
-            link_payload["nvPairs"]["MPLS_FABRIC"] = link["profile"]["mpls_fabric"]
-            link_payload["nvPairs"]["DCI_ROUTING_PROTO"] = link["profile"]["dci_routing_proto"]
-            link_payload["nvPairs"]["DCI_ROUTING_TAG"] = link["profile"]["dci_routing_tag"]
-            link_payload["nvPairs"]["PEER1_SR_MPLS_INDEX"] = link["profile"]["peer1_sr_mpls_index"]
-            link_payload["nvPairs"]["PEER2_SR_MPLS_INDEX"] = link["profile"]["peer2_sr_mpls_index"]
-            link_payload["nvPairs"]["GB_BLOCK_RANGE"] = link["profile"]["global_block_range"]
-            link_payload["nvPairs"]["OSPF_AREA_ID"] = link["profile"]["ospf_area_id"]
+            link_payload["nvPairs"]["MPLS_FABRIC"] = link["profile"][
+                "mpls_fabric"
+            ]
+            link_payload["nvPairs"]["DCI_ROUTING_PROTO"] = link["profile"][
+                "dci_routing_proto"
+            ]
+            link_payload["nvPairs"]["DCI_ROUTING_TAG"] = link["profile"][
+                "dci_routing_tag"
+            ]
+            link_payload["nvPairs"]["PEER1_SR_MPLS_INDEX"] = link["profile"][
+                "peer1_sr_mpls_index"
+            ]
+            link_payload["nvPairs"]["PEER2_SR_MPLS_INDEX"] = link["profile"][
+                "peer2_sr_mpls_index"
+            ]
+            link_payload["nvPairs"]["GB_BLOCK_RANGE"] = link["profile"][
+                "global_block_range"
+            ]
+            link_payload["nvPairs"]["OSPF_AREA_ID"] = link["profile"][
+                "ospf_area_id"
+            ]
 
     def dcnm_links_get_intra_fabric_links_payload(self, link, link_payload):
 
@@ -1770,7 +1816,9 @@ class DcnmLinks:
             )
         ):
             if (
-                self.src_fabric_info["nvPairs"]["UNDERLAY_IS_V6"].lower()
+                self.src_fabric_info["nvPairs"]
+                .get("UNDERLAY_IS_V6", "false")
+                .lower()
                 == "false"
             ):
                 link_payload["nvPairs"]["PEER1_IP"] = str(
@@ -1868,12 +1916,15 @@ class DcnmLinks:
             return
 
         if (
-            wlink["templateName"]
-            == self.templates["ext_multisite_underlay_setup"]
-        ) or (
-            wlink["templateName"] == self.templates["ext_fabric_setup"]
-        ) or (
-            wlink["templateName"] == self.templates["ext_vxlan_mpls_underlay_setup"]
+            (
+                wlink["templateName"]
+                == self.templates["ext_multisite_underlay_setup"]
+            )
+            or (wlink["templateName"] == self.templates["ext_fabric_setup"])
+            or (
+                wlink["templateName"]
+                == self.templates["ext_vxlan_mpls_underlay_setup"]
+            )
         ):
             if cfg["profile"].get("ipv4_subnet", None) is None:
                 wlink["nvPairs"]["IP_MASK"] = hlink["nvPairs"]["IP_MASK"]
@@ -1894,7 +1945,10 @@ class DcnmLinks:
             if cfg["profile"].get("peer2_cmds", None) is None:
                 wlink["nvPairs"]["PEER2_CONF"] = hlink["nvPairs"]["PEER2_CONF"]
                 wlink["peer2_conf_defaulted"] = True
-        elif wlink["templateName"] != self.templates["ext_vxlan_mpls_overlay_setup"]:
+        elif (
+            wlink["templateName"]
+            != self.templates["ext_vxlan_mpls_overlay_setup"]
+        ):
             if cfg["profile"].get("ipv4_addr", None) is None:
                 wlink["nvPairs"]["SOURCE_IP"] = hlink["nvPairs"]["SOURCE_IP"]
 
@@ -1907,16 +1961,22 @@ class DcnmLinks:
             wlink["nvPairs"]["NEIGHBOR_IP"] = hlink["nvPairs"]["NEIGHBOR_IP"]
 
         if (
-            wlink["templateName"] == self.templates["ext_multisite_underlay_setup"]
-        ) or (
-            wlink["templateName"] == self.templates["ext_fabric_setup"]
-        ) or (
-            wlink["templateName"] == self.templates["ext_vxlan_mpls_overlay_setup"]
+            (
+                wlink["templateName"]
+                == self.templates["ext_multisite_underlay_setup"]
+            )
+            or (wlink["templateName"] == self.templates["ext_fabric_setup"])
+            or (
+                wlink["templateName"]
+                == self.templates["ext_vxlan_mpls_overlay_setup"]
+            )
         ):
             if cfg["profile"].get("src_asn", None) is None:
                 wlink["nvPairs"]["asn"] = hlink["nvPairs"]["asn"]
             if cfg["profile"].get("dst_asn", None) is None:
-                wlink["nvPairs"]["NEIGHBOR_ASN"] = hlink["nvPairs"]["NEIGHBOR_ASN"]
+                wlink["nvPairs"]["NEIGHBOR_ASN"] = hlink["nvPairs"][
+                    "NEIGHBOR_ASN"
+                ]
 
         if wlink["templateName"] == self.templates["ext_fabric_setup"]:
             if cfg["profile"].get("auto_deploy", None) is None:
@@ -2025,7 +2085,9 @@ class DcnmLinks:
             )
         ):
             if (
-                self.src_fabric_info["nvPairs"]["UNDERLAY_IS_V6"].lower()
+                self.src_fabric_info["nvPairs"]
+                .get("UNDERLAY_IS_V6", "false")
+                .lower()
                 == "false"
             ):
                 if cfg["profile"].get("peer1_ipv4_addr", None) is None:
@@ -2111,11 +2173,12 @@ class DcnmLinks:
                         == want["destinationFabric"]
                     )
                     and (
-                        have["sw1-info"]["if-name"] == want["sourceInterface"]
+                        have["sw1-info"]["if-name"].lower()
+                        == want["sourceInterface"].lower()
                     )
                     and (
-                        have["sw2-info"]["if-name"]
-                        == want["destinationInterface"]
+                        have["sw2-info"]["if-name"].lower()
+                        == want["destinationInterface"].lower()
                     )
                     and (
                         have["sw1-info"]["sw-serial-number"]
@@ -2279,12 +2342,12 @@ class DcnmLinks:
                         )
                     )
                     and (
-                        link["sourceInterface"]
-                        == link_elem["sw1-info"]["if-name"]
+                        link["sourceInterface"].lower()
+                        == link_elem["sw1-info"]["if-name"].lower()
                     )
                     and (
-                        link["destinationInterface"]
-                        == link_elem["sw2-info"]["if-name"]
+                        link["destinationInterface"].lower()
+                        == link_elem["sw2-info"]["if-name"].lower()
                     )
                 )
             ]
@@ -2353,11 +2416,16 @@ class DcnmLinks:
             return "DCNM_LINK_EXIST", [], []
 
         if (
-            wlink["templateName"]
-            == self.templates["ext_multisite_underlay_setup"]
-        ) or (
-            wlink["templateName"] == self.templates["ext_fabric_setup"]
-        ) or (wlink["templateName"] == self.templates["ext_vxlan_mpls_underlay_setup"]):
+            (
+                wlink["templateName"]
+                == self.templates["ext_multisite_underlay_setup"]
+            )
+            or (wlink["templateName"] == self.templates["ext_fabric_setup"])
+            or (
+                wlink["templateName"]
+                == self.templates["ext_vxlan_mpls_underlay_setup"]
+            )
+        ):
             if (
                 self.dcnm_links_compare_ip_addresses(
                     wlink["nvPairs"]["IP_MASK"], hlink["nvPairs"]["IP_MASK"]
@@ -2433,7 +2501,10 @@ class DcnmLinks:
                         ]
                     }
                 )
-        elif wlink["templateName"] != self.templates["ext_vxlan_mpls_overlay_setup"]:
+        elif (
+            wlink["templateName"]
+            != self.templates["ext_vxlan_mpls_overlay_setup"]
+        ):
             if (
                 self.dcnm_links_compare_ip_addresses(
                     wlink["nvPairs"]["SOURCE_IP"],
@@ -2466,11 +2537,16 @@ class DcnmLinks:
                 }
             )
         if (
-            wlink["templateName"]
-            == self.templates["ext_multisite_underlay_setup"]
-        ) or (
-            wlink["templateName"] == self.templates["ext_fabric_setup"]
-        ) or (wlink["templateName"] == self.templates["ext_vxlan_mpls_overlay_setup"]):
+            (
+                wlink["templateName"]
+                == self.templates["ext_multisite_underlay_setup"]
+            )
+            or (wlink["templateName"] == self.templates["ext_fabric_setup"])
+            or (
+                wlink["templateName"]
+                == self.templates["ext_vxlan_mpls_overlay_setup"]
+            )
+        ):
             if (
                 str(wlink["nvPairs"]["asn"]).lower()
                 != str(hlink["nvPairs"]["asn"]).lower()
@@ -2698,7 +2774,8 @@ class DcnmLinks:
                 "PEER1_SR_MPLS_INDEX",
                 "PEER2_SR_MPLS_INDEX",
                 "GB_BLOCK_RANGE",
-                "OSPF_AREA_ID"]
+                "OSPF_AREA_ID",
+            ]
             for nv_pair in mpls_underlay_spec_nvpairs:
                 if (
                     str(wlink["nvPairs"][nv_pair]).lower()
@@ -2707,12 +2784,8 @@ class DcnmLinks:
                     mismatch_reasons.append(
                         {
                             f"{nv_pair}_MISMATCH": [
-                                str(
-                                    wlink["nvPairs"][nv_pair]
-                                ).lower(),
-                                str(
-                                    hlink["nvPairs"][nv_pair]
-                                ).lower(),
+                                str(wlink["nvPairs"][nv_pair]).lower(),
+                                str(hlink["nvPairs"][nv_pair]).lower(),
                             ]
                         }
                     )
@@ -2834,7 +2907,9 @@ class DcnmLinks:
             )
         ):
             if (
-                self.src_fabric_info["nvPairs"]["UNDERLAY_IS_V6"].lower()
+                self.src_fabric_info["nvPairs"]
+                .get("UNDERLAY_IS_V6", "false")
+                .lower()
                 == "false"
             ):
                 if (
@@ -3040,15 +3115,21 @@ class DcnmLinks:
             have
             for have in self.have
             if (
-                (have.get("templateName") is not None)  # if templateName is empty, link is autodicovered, consider link is new
+                (
+                    have.get("templateName") is not None
+                )  # if templateName is empty, link is autodicovered, consider link is new
                 and (have["sw1-info"]["fabric-name"] == want["sourceFabric"])
                 and (
                     have["sw2-info"]["fabric-name"]
                     == want["destinationFabric"]
                 )
-                and (have["sw1-info"]["if-name"] == want["sourceInterface"])
                 and (
-                    have["sw2-info"]["if-name"] == want["destinationInterface"]
+                    have["sw1-info"]["if-name"].lower()
+                    == want["sourceInterface"].lower()
+                )
+                and (
+                    have["sw2-info"]["if-name"].lower()
+                    == want["destinationInterface"].lower()
                 )
                 and (
                     have["sw1-info"]["sw-serial-number"]
@@ -3056,9 +3137,11 @@ class DcnmLinks:
                 )
                 and (
                     have["sw2-info"]["sw-serial-number"]
-                    == want["destinationDevice"] or
-                    have["sw2-info"]["sw-serial-number"]
-                    == want["destinationSwitchName"] + "-" + want["destinationFabric"]
+                    == want["destinationDevice"]
+                    or have["sw2-info"]["sw-serial-number"]
+                    == want["destinationSwitchName"]
+                    + "-"
+                    + want["destinationFabric"]
                 )
             )
         ]
@@ -3237,8 +3320,14 @@ class DcnmLinks:
                 if (
                     (have["sw1-info"]["fabric-name"] == self.fabric)
                     and (have["sw2-info"]["fabric-name"] == link["dst_fabric"])
-                    and (have["sw1-info"]["if-name"] == link["src_interface"])
-                    and (have["sw2-info"]["if-name"] == link["dst_interface"])
+                    and (
+                        have["sw1-info"]["if-name"].lower()
+                        == link["src_interface"].lower()
+                    )
+                    and (
+                        have["sw2-info"]["if-name"].lower()
+                        == link["dst_interface"].lower()
+                    )
                     and (
                         link["src_device"] in self.ip_sn
                         and have["sw1-info"]["sw-serial-number"]
@@ -3342,15 +3431,15 @@ class DcnmLinks:
                         and (
                             (link["src_interface"] == "")
                             or (
-                                rlink["sw1-info"]["if-name"]
-                                == link["src_interface"]
+                                rlink["sw1-info"]["if-name"].lower()
+                                == link["src_interface"].lower()
                             )
                         )
                         and (
                             (link["dst_interface"] == "")
                             or (
-                                rlink["sw2-info"]["if-name"]
-                                == link["dst_interface"]
+                                rlink["sw2-info"]["if-name"].lower()
+                                == link["dst_interface"].lower()
                             )
                         )
                         and (

--- a/tests/unit/modules/dcnm/fixtures/dcnm_links_payloads.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_links_payloads.json
@@ -328,7 +328,7 @@
         "link-uuid": "LINK-UUID-1446600",
         "sw2-info": {
           "fabric-name": "mmudigon-numbered",
-          "if-name": "Ethernet1/1",
+          "if-name": "ethernet1/1",
           "sw-sys-name": "n9kv-num-2",
           "sw-serial-number": "9FX7O3TU2QM"
         },
@@ -388,7 +388,7 @@
         "templateName": "int_pre_provision_intra_fabric_link",
         "sw1-info": {
           "fabric-name": "mmudigon-numbered",
-          "if-name": "Ethernet1/2",
+          "if-name": "ethernet1/2",
           "sw-sys-name": "n9kv-num-1",
           "sw-serial-number": "9IF87L089SZ"
         },
@@ -406,7 +406,7 @@
         "link-uuid": "LINK-UUID-1419160",
         "sw2-info": {
           "fabric-name": "mmudigon-numbered",
-          "if-name": "Ethernet1/3",
+          "if-name": "ethernet1/3",
           "sw-sys-name": "n9kv-num-2",
           "sw-serial-number": "9FX7O3TU2QM"
         },
@@ -431,7 +431,7 @@
         "templateName": "ios_xe_int_intra_fabric_num_link",
         "sw1-info": {
           "fabric-name": "mmudigon-numbered",
-          "if-name": "Ethernet1/3",
+          "if-name": "ethernet1/3",
           "sw-sys-name": "n9kv-num-1",
           "sw-serial-number": "9IF87L089SZ"
         },
@@ -449,7 +449,7 @@
         "link-uuid": "LINK-UUID-1435300",
         "sw2-info": {
           "fabric-name": "mmudigon-unnumbered",
-          "if-name": "Ethernet1/1",
+          "if-name": "ethernet1/1",
           "sw-sys-name": "n9kv-unnum-2",
           "sw-serial-number": "9AF3VNZYAKS"
         },
@@ -502,7 +502,7 @@
         "templateName": "int_pre_provision_intra_fabric_link",
         "sw1-info": {
           "fabric-name": "mmudigon-unnumbered",
-          "if-name": "Ethernet1/2",
+          "if-name": "ethernet1/2",
           "sw-sys-name": "n9kv-unnum-1",
           "sw-serial-number": "9EFX823RUL3"
         },
@@ -520,7 +520,7 @@
         "link-uuid": "LINK-UUID-1419050",
         "sw2-info": {
           "fabric-name": "mmudigon-ipv6-underlay",
-          "if-name": "Ethernet1/1",
+          "if-name": "ethernet1/1",
           "sw-sys-name": "n9kv-ipv6-2",
           "sw-serial-number": "9ITWBH9OIAH"
         },
@@ -564,7 +564,7 @@
         "link-uuid": "LINK-UUID-1419110",
         "sw2-info": {
           "fabric-name": "mmudigon-ipv6-underlay",
-          "if-name": "Ethernet1/2",
+          "if-name": "ethernet1/2",
           "sw-sys-name": "n9kv-ipv6-2",
           "sw-serial-number": "9ITWBH9OIAH"
         },
@@ -574,7 +574,7 @@
         "templateName": "int_pre_provision_intra_fabric_link",
         "sw1-info": {
           "fabric-name": "mmudigon-ipv6-underlay",
-          "if-name": "Ethernet1/2",
+          "if-name": "ethernet1/2",
           "sw-sys-name": "n9kv-ipv6-1",
           "sw-serial-number": "9BH0813WFWT"
         },
@@ -592,7 +592,7 @@
         "link-uuid": "LINK-UUID-1419180",
         "sw2-info": {
           "fabric-name": "mmudigon-ipv6-underlay",
-          "if-name": "Ethernet1/3",
+          "if-name": "ethernet1/3",
           "sw-sys-name": "n9kv-ipv6-2",
           "sw-serial-number": "9ITWBH9OIAH"
         },
@@ -669,7 +669,7 @@
         "templateName": "int_intra_vpc_peer_keep_alive_link",
         "sw1-info": {
           "fabric-name": "mmudigon",
-          "if-name": "Ethernet1/4",
+          "if-name": "ethernet1/4",
           "sw-sys-name": "n9kv-100",
           "sw-serial-number": "9M99N34RDED"
         },
@@ -687,14 +687,14 @@
         "link-uuid": "LINK-UUID-1446600",
         "templateName": "ext_fabric_setup",
         "sw2-info": {
-          "if-name": "Ethernet1/3",
+          "if-name": "ethernet1/3",
           "sw-sys-name": "test22",
           "sw-serial-number": "9E15XSEM5MS",
           "fabric-name": "test_net"
         },
         "sw1-info": {
           "fabric-name": "mmudigon-numbered",
-          "if-name": "Ethernet1/3",
+          "if-name": "ethernet1/3",
           "sw-sys-name": "n9kv-227",
           "sw-serial-number": "953E68OKK1L"
         },
@@ -742,7 +742,7 @@
         "link-dbid": 1467700,
         "sw1-info": {
           "fabric-name": "mmudigon-numbered",
-          "if-name": "Ethernet1/4",
+          "if-name": "ethernet1/4",
           "sw-serial-number": "953E68OKK1L",
           "sw-sys-name": "n9kv-test3"
         },
@@ -785,7 +785,7 @@
         "link-uuid": "LINK-UUID-1446600",
         "templateName": "ext_evpn_multisite_overlay_setup",
         "sw2-info": {
-          "if-name": "Ethernet1/5",
+          "if-name": "ethernet1/5",
           "sw-serial-number": "9E15XSEM5MS",
           "fabric-name": "test_net",
           "sw-sys-name": "test22"
@@ -837,7 +837,7 @@
         },
         "sw1-info": {
           "fabric-name": "mmudigon-numbered",
-          "if-name": "Ethernet1/6",
+          "if-name": "ethernet1/6",
           "sw-serial-number": "953E68OKK1L",
           "sw-sys-name": "n9kv-test3"
         },
@@ -876,7 +876,7 @@
         "link-uuid": "LINK-UUID-1446600",
         "templateName": "ext_multisite_underlay_setup",
         "sw2-info": {
-          "if-name": "Ethernet1/7",
+          "if-name": "ethernet1/7",
           "sw-serial-number": "98YWRN9WCSC",
           "fabric-name": "test_net1",
           "sw-sys-name": "n9kv-test1"
@@ -934,7 +934,7 @@
         },
         "sw1-info": {
           "fabric-name": "mmudigon-numbered",
-          "if-name": "Ethernet1/8",
+          "if-name": "ethernet1/8",
           "sw-serial-number": "953E68OKK1L",
           "sw-sys-name": "n9kv-test3"
         },
@@ -970,14 +970,14 @@
       "DATA": {
         "link-uuid": "LINK-UUID-1446600",
         "sw2-info": {
-          "if-name": "Ethernet1/9",
+          "if-name": "ethernet1/9",
           "sw-serial-number": "98YWRN9WCSC",
           "fabric-name": "test_net1",
           "sw-sys-name": "n9kv-test1"
         },
         "sw1-info": {
           "fabric-name": "mmudigon-numbered",
-          "if-name": "Ethernet1/9",
+          "if-name": "ethernet1/9",
           "sw-serial-number": "953E68OKK1L",
           "sw-sys-name": "n9kv-test3"
         }
@@ -1112,7 +1112,7 @@
         },
         "sw1-info": {
           "fabric-name": "mmudigon-unnumbered",
-          "if-name": "Ethernet1/1",
+          "if-name": "ethernet1/1",
           "sw-serial-number": "9EFX823RUL3"
         },
         "sw2-info": {
@@ -1134,7 +1134,7 @@
         },
         "sw2-info": {
           "fabric-name": "mmudigon-unnumbered",
-          "if-name": "Ethernet1/2",
+          "if-name": "ethernet1/2",
           "sw-serial-number": "9AF3VNZYAKS"
         },
         "templateName": "int_pre_provision_intra_fabric_link"
@@ -1173,13 +1173,13 @@
         },
         "sw1-info": {
           "fabric-name": "mmudigon-ipv6-underlay",
-          "if-name": "Ethernet1/1",
+          "if-name": "ethernet1/1",
           "if-op-reason": "Link not connected",
           "sw-serial-number": "9BH0813WFWT"
         },
         "sw2-info": {
           "fabric-name": "mmudigon-ipv6-underlay",
-          "if-name": "Ethernet1/1",
+          "if-name": "ethernet1/1",
           "sw-serial-number": "9ITWBH9OIAH"
         },
         "templateName": "int_intra_fabric_ipv6_link_local"
@@ -1230,7 +1230,7 @@
         },
         "sw1-info": {
           "fabric-name": "mmudigon-ipv6-underlay",
-          "if-name": "Ethernet1/3",
+          "if-name": "ethernet1/3",
           "sw-serial-number": "9BH0813WFWT"
         },
         "sw2-info": {
@@ -1273,12 +1273,12 @@
         },
         "sw1-info": {
           "fabric-name": "mmudigon",
-          "if-name": "Ethernet1/4",
+          "if-name": "ethernet1/4",
           "sw-serial-number": "9M99N34RDED"
         },
         "sw2-info": {
           "fabric-name": "mmudigon",
-          "if-name": "Ethernet1/4",
+          "if-name": "ethernet1/4",
           "sw-serial-number": "9NXHSNTEO6C"
         },
         "templateName": "int_intra_vpc_peer_keep_alive_link"
@@ -1320,7 +1320,7 @@
         },
         "sw2-info": {
           "fabric-name": "test_net1",
-          "if-name": "Ethernet1/8",
+          "if-name": "ethernet1/8",
           "sw-serial-number": "98YWRN9WCSC"
         },
         "templateName": "ext_evpn_multisite_overlay_setup"
@@ -1355,7 +1355,7 @@
         },
         "sw1-info": {
           "fabric-name": "mmudigon-numbered",
-          "if-name": "Ethernet1/7",
+          "if-name": "ethernet1/7",
           "sw-serial-number": "953E68OKK1L"
         },
         "sw2-info": {
@@ -1424,12 +1424,12 @@
         },
         "sw1-info": {
           "fabric-name": "mmudigon-numbered",
-          "if-name": "Ethernet1/5",
+          "if-name": "ethernet1/5",
           "sw-serial-number": "953E68OKK1L"
         },
         "sw2-info": {
           "fabric-name": "test_net",
-          "if-name": "Ethernet1/5",
+          "if-name": "ethernet1/5",
           "sw-serial-number": "9E15XSEM5MS"
         },
         "templateName": "ext_evpn_multisite_overlay_setup"
@@ -1463,7 +1463,7 @@
         },
         "sw1-info": {
           "fabric-name": "mmudigon-numbered",
-          "if-name": "Ethernet1/4",
+          "if-name": "ethernet1/4",
           "sw-serial-number": "953E68OKK1L"
         },
         "sw2-info": {
@@ -1504,7 +1504,7 @@
         },
         "sw2-info": {
           "fabric-name": "test_net",
-          "if-name": "Ethernet1/3",
+          "if-name": "ethernet1/3",
           "sw-serial-number": "9E15XSEM5MS"
         },
         "templateName": "ext_fabric_setup"


### PR DESCRIPTION
Interface names can be specific to type of box used. In some cases a loopback interface may be like loopback100 and in some cases it will be like Loopback100. To make this transparent to the user, dcnm_links module has been updated to handle these cases.