### PR TITLE
Fix for issue #305 (dcnm_fabric replaced state, implicit change handling)

### DIFF
--- a/plugins/module_utils/fabric/replaced.py
+++ b/plugins/module_utils/fabric/replaced.py
@@ -149,13 +149,12 @@ class FabricReplacedCommon(FabricCommon):
         ```
         """
         if playbook is None:
-            if default is None:
-                return None
-            if controller == default:
-                return None
-            if controller is None or controller == "":
-                return None
-            return {parameter: default}
+            if controller != default:
+                if default is None:
+                    # The controller prefers empty string over null.
+                    return {parameter: ""}
+                return {parameter: default}
+            return None
         if playbook == controller:
             return None
         return {parameter: playbook}

--- a/tests/unit/modules/dcnm/dcnm_fabric/test_fabric_replaced_bulk.py
+++ b/tests/unit/modules/dcnm/dcnm_fabric/test_fabric_replaced_bulk.py
@@ -390,14 +390,14 @@ def test_fabric_replaced_bulk_00031(
         ("PARAM_5", "c", "c", "c", None),
         ("PARAM_6", None, "c", "c", None),
         ("PARAM_7", None, "b", "c", {"PARAM_7": "c"}),
-        ("PARAM_8", None, "b", None, None),
+        ("PARAM_8", None, "b", None, {"PARAM_8": ""}),
         ("PARAM_9", None, None, None, None),
         ("PARAM_10", "a", None, None, {"PARAM_10": "a"}),
         ("PARAM_11", "a", "a", None, None),
         ("PARAM_12", "a", "b", None, {"PARAM_12": "a"}),
         ("PARAM_13", "a", None, "a", {"PARAM_13": "a"}),
         ("PARAM_14", "a", None, "c", {"PARAM_14": "a"}),
-        ("PARAM_15", None, None, "c", None),
+        ("PARAM_15", None, None, "c", {"PARAM_15": "c"}),
     ],
 )
 def test_fabric_replaced_bulk_00040(


### PR DESCRIPTION
This fix addresses an issue Mike found with dcnm_fabric replaced state -> #305.

Changes include:

1. FabricReplacedCommon().update_replaced_payload()

If the playbook value for a parameter is None (which is the case when the playbook config does not contain the parameter), then the only thing we need to ensure is that the controller value is set to the default value.  If the default value is null, we change it to the empty string "" since NDFC throws a 500 error for null parameter values.

2. Update unit tests to reflect the above change.  The following test was modified.  Specifically two cases where the playbook parameter value is None (PARAM_8 and PARAM_15).

- test_fabric_replaced_bulk_00040