### PR TITLE
Fix Typo in dcnm_policy Module Example

### DIFF
--- a/docs/cisco.dcnm.dcnm_policy_module.rst
+++ b/docs/cisco.dcnm.dcnm_policy_module.rst
@@ -484,7 +484,7 @@ Examples
 
                   - name: POLICY-105105  # This must be a valid POLICY ID
                     create_additional_policy: false  # Do not create a policy if it already exists
-                  - ip: "{{ ansible_switch2 }}"
+              - ip: "{{ ansible_switch2 }}"
 
     # DELETE POLICY
 

--- a/plugins/modules/dcnm_policy.py
+++ b/plugins/modules/dcnm_policy.py
@@ -279,7 +279,7 @@ EXAMPLES = """
 
               - name: POLICY-105105  # This must be a valid POLICY ID
                 create_additional_policy: false  # Do not create a policy if it already exists
-              - ip: "{{ ansible_switch2 }}"
+          - ip: "{{ ansible_switch2 }}"
 
 # DELETE POLICY
 


### PR DESCRIPTION
Fix typo in dcnm_policy module example where there is an incorrect switch list entry indentation.