### PR TITLE
dcnm_fabric IT fix for ND 321e

### DIFF
--- a/tests/integration/targets/dcnm_fabric/tests/dcnm_fabric_merged_basic.yaml
+++ b/tests/integration/targets/dcnm_fabric/tests/dcnm_fabric_merged_basic.yaml
@@ -405,6 +405,8 @@
         FABRIC_TYPE: "{{ fabric_type_1 }}"
         ANYCAST_GW_MAC: aaaabbbbcccc
         BGP_AS: 65535
+        ENABLE_PVLAN: false
+        ENABLE_SGT: false
         REPLICATION_MODE: Ingress
         SITE_ID: 65000
         UNDERLAY_IS_V6: false

--- a/tests/integration/targets/dcnm_fabric/tests/dcnm_fabric_merged_basic.yaml
+++ b/tests/integration/targets/dcnm_fabric/tests/dcnm_fabric_merged_basic.yaml
@@ -319,7 +319,6 @@
 #                         "FABRIC_NAME": "VXLAN_EVPN_Fabric",
 #                         "REPLICATION_MODE": "Ingress",
 #                         "SITE_ID": "65000",
-#                         "UNDERLAY_IS_V6": "false",
 #                     }
 #                 },
 #                 "MESSAGE": "OK",
@@ -405,11 +404,8 @@
         FABRIC_TYPE: "{{ fabric_type_1 }}"
         ANYCAST_GW_MAC: aaaabbbbcccc
         BGP_AS: 65535
-        ENABLE_PVLAN: false
-        ENABLE_SGT: false
         REPLICATION_MODE: Ingress
         SITE_ID: 65000
-        UNDERLAY_IS_V6: false
         DEPLOY: false
       - FABRIC_NAME: "{{ fabric_name_2 }}"
         FABRIC_TYPE: "{{ fabric_type_2 }}"
@@ -464,7 +460,6 @@
       - result.response[0].DATA.nvPairs.BGP_AS == "65535"
       - result.response[0].DATA.nvPairs.REPLICATION_MODE == "Ingress"
       - result.response[0].DATA.nvPairs.SITE_ID == "65000"
-      - result.response[0].DATA.nvPairs.UNDERLAY_IS_V6 == "false"
       - result.response[0].DATA.nvPairs.FABRIC_NAME == "VXLAN_EVPN_Fabric"
       - result.response[1].sequence_number == 2
       - result.response[1].MESSAGE == "OK"

--- a/tests/integration/targets/dcnm_fabric/tests/dcnm_fabric_merged_save_deploy.yaml
+++ b/tests/integration/targets/dcnm_fabric/tests/dcnm_fabric_merged_save_deploy.yaml
@@ -336,7 +336,6 @@
 #                         "ANYCAST_GW_MAC": "aaaa.bbbb.cccc",
 #                         "FABRIC_NAME": "VXLAN_EVPN_Fabric",
 #                         "REPLICATION_MODE": "Ingress",
-#                         "UNDERLAY_IS_V6": "false",
 #                     }
 #                 },
 #                 "MESSAGE": "OK",
@@ -445,7 +444,6 @@
         BGP_AS: 65535
         ANYCAST_GW_MAC: aaaabbbbcccc
         REPLICATION_MODE: Ingress
-        UNDERLAY_IS_V6: false
         DEPLOY: true
       - FABRIC_NAME: "{{ fabric_name_3 }}"
         FABRIC_TYPE: "{{ fabric_type_3 }}"
@@ -497,7 +495,6 @@
       - result.response[0].RETURN_CODE == 200
       - result.response[0].DATA.nvPairs.ANYCAST_GW_MAC == "aaaa.bbbb.cccc"
       - result.response[0].DATA.nvPairs.REPLICATION_MODE == "Ingress"
-      - result.response[0].DATA.nvPairs.UNDERLAY_IS_V6 == "false"
       - result.response[0].DATA.nvPairs.FABRIC_NAME == fabric_name_1
       - result.response[1].sequence_number == 2
       - result.response[1].DATA.nvPairs.SUBINTERFACE_RANGE == "2-101"

--- a/tests/integration/targets/dcnm_fabric/tests/dcnm_fabric_replaced_basic.yaml
+++ b/tests/integration/targets/dcnm_fabric/tests/dcnm_fabric_replaced_basic.yaml
@@ -84,11 +84,8 @@
 #                 "ADVERTISE_PIP_BGP": true,
 #                 "ANYCAST_GW_MAC": "00aa.bbcc.ddee",
 #                 "BGP_AS": 65535,
-#                 "ENABLE_PVLAN": false,
-#                 "ENABLE_SGT": false,
 #                 "FABRIC_NAME": "VXLAN_EVPN_Fabric",
 #                 "REPLICATION_MODE": "Ingress",
-#                 "UNDERLAY_IS_V6": false,
 #                 "sequence_number": 1
 #             },
 #             {
@@ -133,11 +130,8 @@
 #                         "ADVERTISE_PIP_BGP": "true",
 #                         "ANYCAST_GW_MAC": "00aa.bbcc.ddee",
 #                         "BGP_AS": "65535",
-#                         "ENABLE_PVLAN": "false",
-#                         "ENABLE_SGT": "false",
 #                         "FABRIC_NAME": "VXLAN_EVPN_Fabric",
 #                         "REPLICATION_MODE": "Ingress",
-#                         "UNDERLAY_IS_V6": "false",
 #                     }
 #                 },
 #                 "MESSAGE": "OK",
@@ -205,10 +199,7 @@
         ADVERTISE_PIP_BGP: true
         ANYCAST_GW_MAC: 00:aa:bb:cc:dd:ee
         BGP_AS: 65535
-        ENABLE_PVLAN: false
-        ENABLE_SGT: false
         REPLICATION_MODE: Ingress
-        UNDERLAY_IS_V6: false
         DEPLOY: false
       - FABRIC_NAME: "{{ fabric_name_2 }}"
         FABRIC_TYPE: "{{ fabric_type_2 }}"
@@ -235,10 +226,7 @@
       - result.diff[0].sequence_number == 1
       - result.diff[0].ADVERTISE_PIP_BGP == true
       - result.diff[0].ANYCAST_GW_MAC == "00aa.bbcc.ddee"
-      - result.diff[0].ENABLE_PVLAN == false
-      - result.diff[0].ENABLE_SGT == false
       - result.diff[0].REPLICATION_MODE == "Ingress"
-      - result.diff[0].UNDERLAY_IS_V6 == false
       - result.diff[1].ANYCAST_GW_MAC == "00aa.bbcc.ddee"
       - result.diff[1].FABRIC_NAME == fabric_name_2
       - result.diff[1].sequence_number == 2
@@ -268,11 +256,8 @@
       - result.response[0].DATA.nvPairs.ADVERTISE_PIP_BGP == "true"
       - result.response[0].DATA.nvPairs.ANYCAST_GW_MAC == "00aa.bbcc.ddee"
       - result.response[0].DATA.nvPairs.BGP_AS == "65535"
-      - result.response[0].DATA.nvPairs.ENABLE_PVLAN == "false"
-      - result.response[0].DATA.nvPairs.ENABLE_SGT == "false"
       - result.response[0].DATA.nvPairs.FABRIC_NAME == "VXLAN_EVPN_Fabric"
       - result.response[0].DATA.nvPairs.REPLICATION_MODE == "Ingress"
-      - result.response[0].DATA.nvPairs.UNDERLAY_IS_V6 == "false"
       - result.response[1].sequence_number == 2
       - result.response[1].MESSAGE == "OK"
       - result.response[1].METHOD == "POST"
@@ -370,7 +355,6 @@
 #                         "ANYCAST_GW_MAC": "2020.0000.00aa",
 #                         "FABRIC_NAME": "VXLAN_EVPN_Fabric",
 #                         "REPLICATION_MODE": "Multicast",
-#                         "UNDERLAY_IS_V6": "false",
 #                     }
 #                 }
 #                 "MESSAGE": "OK",
@@ -513,7 +497,6 @@
       - result.response[0].DATA.nvPairs.ANYCAST_GW_MAC == "2020.0000.00aa"
       - result.response[0].DATA.nvPairs.FABRIC_NAME == "VXLAN_EVPN_Fabric"
       - result.response[0].DATA.nvPairs.REPLICATION_MODE == "Multicast"
-      - result.response[0].DATA.nvPairs.UNDERLAY_IS_V6 == "false"
       - result.response[1].sequence_number == 2
       - result.response[1].MESSAGE == "OK"
       - result.response[1].METHOD == "PUT"

--- a/tests/integration/targets/dcnm_fabric/tests/dcnm_fabric_replaced_basic.yaml
+++ b/tests/integration/targets/dcnm_fabric/tests/dcnm_fabric_replaced_basic.yaml
@@ -84,6 +84,8 @@
 #                 "ADVERTISE_PIP_BGP": true,
 #                 "ANYCAST_GW_MAC": "00aa.bbcc.ddee",
 #                 "BGP_AS": 65535,
+#                 "ENABLE_PVLAN": false,
+#                 "ENABLE_SGT": false,
 #                 "FABRIC_NAME": "VXLAN_EVPN_Fabric",
 #                 "REPLICATION_MODE": "Ingress",
 #                 "UNDERLAY_IS_V6": false,
@@ -131,6 +133,8 @@
 #                         "ADVERTISE_PIP_BGP": "true",
 #                         "ANYCAST_GW_MAC": "00aa.bbcc.ddee",
 #                         "BGP_AS": "65535",
+#                         "ENABLE_PVLAN": "false",
+#                         "ENABLE_SGT": "false",
 #                         "FABRIC_NAME": "VXLAN_EVPN_Fabric",
 #                         "REPLICATION_MODE": "Ingress",
 #                         "UNDERLAY_IS_V6": "false",
@@ -201,6 +205,8 @@
         ADVERTISE_PIP_BGP: true
         ANYCAST_GW_MAC: 00:aa:bb:cc:dd:ee
         BGP_AS: 65535
+        ENABLE_PVLAN: false
+        ENABLE_SGT: false
         REPLICATION_MODE: Ingress
         UNDERLAY_IS_V6: false
         DEPLOY: false
@@ -229,6 +235,8 @@
       - result.diff[0].sequence_number == 1
       - result.diff[0].ADVERTISE_PIP_BGP == true
       - result.diff[0].ANYCAST_GW_MAC == "00aa.bbcc.ddee"
+      - result.diff[0].ENABLE_PVLAN == false
+      - result.diff[0].ENABLE_SGT == false
       - result.diff[0].REPLICATION_MODE == "Ingress"
       - result.diff[0].UNDERLAY_IS_V6 == false
       - result.diff[1].ANYCAST_GW_MAC == "00aa.bbcc.ddee"
@@ -260,6 +268,8 @@
       - result.response[0].DATA.nvPairs.ADVERTISE_PIP_BGP == "true"
       - result.response[0].DATA.nvPairs.ANYCAST_GW_MAC == "00aa.bbcc.ddee"
       - result.response[0].DATA.nvPairs.BGP_AS == "65535"
+      - result.response[0].DATA.nvPairs.ENABLE_PVLAN == "false"
+      - result.response[0].DATA.nvPairs.ENABLE_SGT == "false"
       - result.response[0].DATA.nvPairs.FABRIC_NAME == "VXLAN_EVPN_Fabric"
       - result.response[0].DATA.nvPairs.REPLICATION_MODE == "Ingress"
       - result.response[0].DATA.nvPairs.UNDERLAY_IS_V6 == "false"

--- a/tests/integration/targets/dcnm_fabric/tests/dcnm_fabric_replaced_basic_vxlan.yaml
+++ b/tests/integration/targets/dcnm_fabric/tests/dcnm_fabric_replaced_basic_vxlan.yaml
@@ -70,7 +70,6 @@
 #                 "BGP_AS": 65535,
 #                 "FABRIC_NAME": "VXLAN_EVPN_Fabric",
 #                 "REPLICATION_MODE": "Ingress",
-#                 "UNDERLAY_IS_V6": false,
 #                 "sequence_number": 1
 #             }
 #         ],
@@ -92,7 +91,6 @@
 #                         "BGP_AS": "65535",
 #                         "FABRIC_NAME": "VXLAN_EVPN_Fabric",
 #                         "REPLICATION_MODE": "Ingress",
-#                         "UNDERLAY_IS_V6": "false",
 #                     }
 #                 },
 #                 "MESSAGE": "OK",
@@ -122,7 +120,6 @@
         ANYCAST_GW_MAC: 00:aa:bb:cc:dd:ee
         BGP_AS: 65535
         REPLICATION_MODE: Ingress
-        UNDERLAY_IS_V6: false
         DEPLOY: false
   register: result
 - debug:
@@ -138,7 +135,6 @@
       - result.diff[0].ADVERTISE_PIP_BGP == true
       - result.diff[0].ANYCAST_GW_MAC == "00aa.bbcc.ddee"
       - result.diff[0].REPLICATION_MODE == "Ingress"
-      - result.diff[0].UNDERLAY_IS_V6 == false
       - (result.metadata | length) == 1
       - result.metadata[0].action == "fabric_create"
       - result.metadata[0].check_mode == False
@@ -154,7 +150,6 @@
       - result.response[0].DATA.nvPairs.BGP_AS == "65535"
       - result.response[0].DATA.nvPairs.FABRIC_NAME == "VXLAN_EVPN_Fabric"
       - result.response[0].DATA.nvPairs.REPLICATION_MODE == "Ingress"
-      - result.response[0].DATA.nvPairs.UNDERLAY_IS_V6 == "false"
 ################################################################################
 # REPLACED - TEST - Replace config for fabric_1 with default config
 ################################################################################

--- a/tests/integration/targets/dcnm_fabric/tests/dcnm_fabric_replaced_save_deploy.yaml
+++ b/tests/integration/targets/dcnm_fabric/tests/dcnm_fabric_replaced_save_deploy.yaml
@@ -96,7 +96,6 @@
 #                 "BGP_AS": 65535,
 #                 "FABRIC_NAME": "VXLAN_EVPN_Fabric",
 #                 "REPLICATION_MODE": "Ingress",
-#                 "UNDERLAY_IS_V6": false,
 #                 "sequence_number": 1
 #             },
 #             {
@@ -176,7 +175,6 @@
         ANYCAST_GW_MAC: aaaabbbbcccc
         REPLICATION_MODE: Ingress
         SITE_ID: 65000
-        UNDERLAY_IS_V6: false
         DEPLOY: true
       - FABRIC_NAME: "{{ fabric_name_3 }}"
         FABRIC_TYPE: "{{ fabric_type_3 }}"
@@ -198,7 +196,6 @@
       - result.diff[0].ANYCAST_GW_MAC == "aaaa.bbbb.cccc"
       - result.diff[0].REPLICATION_MODE == "Ingress"
       - result.diff[0].SITE_ID == 65000
-      - result.diff[0].UNDERLAY_IS_V6 == false
       - result.diff[1].FABRIC_NAME == fabric_name_3
       - result.diff[1].sequence_number == 2
       - result.diff[1].BOOTSTRAP_ENABLE == false
@@ -223,7 +220,6 @@
       - result.response[0].DATA.nvPairs.ANYCAST_GW_MAC == "aaaa.bbbb.cccc"
       - result.response[0].DATA.nvPairs.REPLICATION_MODE == "Ingress"
       - result.response[0].DATA.nvPairs.SITE_ID == "65000"
-      - result.response[0].DATA.nvPairs.UNDERLAY_IS_V6 == "false"
       - result.response[1].sequence_number == 2
       - result.response[1].MESSAGE == "OK"
       - result.response[1].METHOD == "POST"
@@ -333,7 +329,6 @@
 #                         "ANYCAST_GW_MAC": "2020.0000.00aa",
 #                         "FABRIC_NAME": "VXLAN_EVPN_Fabric",
 #                         "REPLICATION_MODE": "Multicast",
-#                         "UNDERLAY_IS_V6": "false",
 #                     }
 #                 },
 #                 "MESSAGE": "OK",
@@ -432,7 +427,6 @@
       - result.response[0].DATA.nvPairs.FABRIC_NAME == fabric_name_1
       - result.response[0].DATA.nvPairs.REPLICATION_MODE == "Multicast"
       - result.response[0].DATA.nvPairs.SITE_ID == "65535"
-      - result.response[0].DATA.nvPairs.UNDERLAY_IS_V6 == "false"
       - result.response[1].sequence_number == 2
       - result.response[1].DATA.status == 'Config save is completed'
       - result.response[1].MESSAGE == "OK"


### PR DESCRIPTION
WIth ND 321e, if UNDERLAY_IS_V6 is false, the following must also be set:

```yaml
ENABLE_PVLAN: false
ENABLE_SGT:false
```

Since ``ENABLE_PVLAN`` is not backwards compatible with earlier versions of NDFC, we're removing UNDERLAY_IS_V6 from merged and replaced state integration tests so these tests can pass with both latest and earlier NDFC versions.