### PR TITLE
dcnm_network: Fix key not found issue

### DIFF
--- a/playbooks/roles/dcnm_network/ansible.cfg
+++ b/playbooks/roles/dcnm_network/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+# This ansible.cfg file is only used for testing purposes in this directory.
+roles_path = <path to targets>/collections/ansible_collections/cisco/dcnm/tests/integration/targets

--- a/playbooks/roles/dcnm_network/dcnm_hosts.yaml
+++ b/playbooks/roles/dcnm_network/dcnm_hosts.yaml
@@ -1,0 +1,15 @@
+all:
+  vars:
+    ansible_user: "admin"
+    ansible_password: "password-secret"
+    ansible_python_interpreter: python
+    ansible_httpapi_validate_certs: False
+    ansible_httpapi_use_ssl: True
+  children:
+    dcnm:
+      vars:
+        ansible_connection: ansible.netcommon.httpapi
+        ansible_network_os: cisco.dcnm.dcnm
+      hosts:
+        nac-ndfc1:
+          ansible_host: 10.10.5.1

--- a/playbooks/roles/dcnm_network/dcnm_tests.yaml
+++ b/playbooks/roles/dcnm_network/dcnm_tests.yaml
@@ -1,0 +1,35 @@
+---
+# This playbook can be used to execute integration tests for
+# the role located in:
+#
+# tests/integration/targets/dcnm_network
+#
+# Modify the vars section with details for your testing setup.
+#
+# NOTES:
+# 1. Ensure that the switches defined by ansible_switch1 and ansible_switch2 are
+#    not vPC Pairs.
+- hosts: dcnm
+  gather_facts: no
+  connection: ansible.netcommon.httpapi
+
+  vars:
+    # Uncomment testcase to run a specific test
+    # testcase: replaced_net_all
+    test_fabric: nac-ndfc1
+    ansible_switch1: 192.168.1.1
+    ansible_switch2: 192.168.1.2
+    ansible_sw1_int1: Ethernet1/15
+    ansible_sw1_int2: Ethernet1/16
+    ansible_sw1_int3: Ethernet1/17
+    ansible_sw1_int4: Ethernet1/18
+    #---
+    ansible_sw2_int1: Ethernet1/15
+    ansible_sw2_int2: Ethernet1/16
+    ansible_sw2_int3: Ethernet1/17
+    ansible_sw2_int4: Ethernet1/18
+    ansible_sw2_int5: Ethernet1/19
+    ansible_sw2_int6: Ethernet1/20
+
+  roles:
+    - dcnm_network

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -759,8 +759,8 @@ class DcnmNetwork:
                             if bool(want["is_deploy"]):
                                 dep_net = True
 
-                        if bool(want["is_deploy"]) is not bool(have["is_deploy"]):
-                            if bool(want["is_deploy"]):
+                        if bool(want.get("is_deploy")) is not bool(have.get("is_deploy")):
+                            if bool(want.get("is_deploy")):
                                 dep_net = True
 
             if not found:


### PR DESCRIPTION
This fixes an intermittent issue deleting networks where key `is_deploy` is not defined.  This updates the code to use the safer `get` to access the dictionary key.

This also creates a test playbook directory to make it easier to run the `dcnm_network` integration tests.