### PR TITLE
Enable useVirtualPeerlink in dcnm_vpc_pair module

### DIFF
--- a/plugins/module_utils/network/dcnm/dcnm_vpc_pair_utils.py
+++ b/plugins/module_utils/network/dcnm/dcnm_vpc_pair_utils.py
@@ -213,6 +213,7 @@ def dcnm_vpc_pair_utils_get_vpc_pair_info_from_dcnm(self, swid):
     # Get useVirtualPeerlink information
     path = self.paths["VPC_PEER_LINK_GET_PATH"]
     path = path.format(peerOneId)
+
     resp = dcnm_send(self.module, "GET", path)
 
     if (

--- a/plugins/modules/dcnm_vpc_pair.py
+++ b/plugins/modules/dcnm_vpc_pair.py
@@ -909,7 +909,7 @@ class DcnmVpcPair:
             "peerOneId": {"required": "True", "type": "ipv4"},
             "peerTwoId": {"required": "True", "type": "ipv4"},
             "templateName": {"type": "str"},
-            "useVirtualPeerLink": {"type": "bool"},
+            "useVirtualPeerlink": {"type": "bool"},
             "profile": {"type": "dict"},
         }
 

--- a/tests/unit/modules/dcnm/fixtures/dcnm_vpc_pair/dcnm_vpc_pair_response.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_vpc_pair/dcnm_vpc_pair_response.json
@@ -1193,6 +1193,32 @@
       }
     },
 
+    "vpc_pair_info_virtual_peer_link_resp":
+    {
+      "DATA": [{
+        "blockSelection": "False",
+        "currentPeer": "True",
+        "ethSwitchId": 178800,
+        "fabricName": "None",
+        "ipAddress": "172.31.217.103",
+        "lanId": 0,
+        "logicalName": "93180YC-FX3S-L1-S1",
+        "nxosVersion": "10.4(3)",
+        "platformType": "None",
+        "recommendationReason": "Switches have same role and support Virtual Fabric Peering",
+        "recommended": "True",
+        "serialNumber": "FDO24020JMT",
+        "useVirtualPeerlink": "False",
+        "uuid": "None",
+        "vdcId": 0,
+        "vdcName": "None"
+        }],
+      "MESSAGE": "OK",
+      "METHOD": "GET",
+      "REQUEST_PATH": "https://10.78.210.227:443/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/vpcpair/recommendation?serialNumber=FDO24020JMB&useVirtualPeerlink=true",
+      "RETURN_CODE": 200
+    },
+
     "vpc_pair_policy_resp_84":
     {
       "RETURN_CODE": 200,

--- a/tests/unit/modules/dcnm/test_dcnm_vpc_pair.py
+++ b/tests/unit/modules/dcnm/test_dcnm_vpc_pair.py
@@ -185,8 +185,10 @@ def test_dcnm_vpc_pair_00003(
 
     if tc_id < 7:
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_00003"))
+        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_policy_resp_00003"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_00003"))
+        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
         dcnm_send_side_effect.append(
             copy.deepcopy(resp.get("vpc_pair_policy_resp_00003"))
         )
@@ -250,22 +252,28 @@ def test_dcnm_vpc_pair_00004(
     resp = load_data("dcnm_vpc_pair_response")
 
     dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_1"))
+    dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
     dcnm_send_side_effect.append(resp.get("vpc_pair_policy_resp_1"))
     dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_1"))
+    dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
     dcnm_send_side_effect.append(
         copy.deepcopy(resp.get("vpc_pair_policy_resp_1"))
     )
 
     dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_2"))
+    dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
     dcnm_send_side_effect.append(resp.get("vpc_pair_policy_resp_2"))
     dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_2"))
+    dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
     dcnm_send_side_effect.append(
         copy.deepcopy(resp.get("vpc_pair_policy_resp_2"))
     )
 
     dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_3"))
+    dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
     dcnm_send_side_effect.append(resp.get("vpc_pair_policy_resp_3"))
     dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_3"))
+    dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
     dcnm_send_side_effect.append(
         copy.deepcopy(resp.get("vpc_pair_policy_resp_3"))
     )
@@ -341,12 +349,15 @@ def test_dcnm_vpc_pair_00005(
 
     if tc_id < 3:
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_1"))
+        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_policy_resp_1"))
 
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_2"))
+        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_policy_resp_2"))
 
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_3"))
+        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_policy_resp_3"))
     elif tc_id == 3:
         dcnm_send_side_effect.append([])
@@ -356,23 +367,29 @@ def test_dcnm_vpc_pair_00005(
         vpc_pair.vpc_pair_info[0]["peerOneId"] = "10.122.84.190"
 
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_1"))
+        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_policy_resp_1"))
 
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_2"))
+        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_policy_resp_2"))
 
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_3"))
+        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_policy_resp_3"))
     elif tc_id == 5:
         vpc_pair.vpc_pair_info[0]["peerTwoId"] = "10.122.84.190"
 
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_1"))
+        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_policy_resp_1"))
 
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_2"))
+        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_policy_resp_2"))
 
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_3"))
+        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_policy_resp_3"))
 
     update_delete_payloads_side_effect.append(
@@ -722,14 +739,18 @@ def test_dcnm_vpc_pair_00010(
     resp = load_data("dcnm_vpc_pair_response")
 
     dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_1"))
+    dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
     dcnm_send_side_effect.append(resp.get("vpc_pair_policy_resp_1"))
     dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_1"))
+    dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
     dcnm_send_side_effect.append(
         copy.deepcopy(resp.get("vpc_pair_policy_resp_1"))
     )
     dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_2"))
+    dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
     dcnm_send_side_effect.append(resp.get("vpc_pair_policy_resp_2"))
     dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_3"))
+    dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
     dcnm_send_side_effect.append(resp.get("vpc_pair_policy_resp_3"))
 
     mock_dcnm_send = Mock(side_effect=dcnm_send_side_effect)
@@ -778,6 +799,7 @@ def test_dcnm_vpc_pair_00010_2(
     resp = load_data("dcnm_vpc_pair_response")
 
     dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_1"))
+    dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
     dcnm_send_side_effect.append(resp.get("vpc_pair_policy_resp_1"))
 
     mock_dcnm_send = Mock(side_effect=dcnm_send_side_effect)
@@ -823,6 +845,7 @@ def test_dcnm_vpc_pair_00010_3(
     resp = load_data("dcnm_vpc_pair_response")
 
     dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_1"))
+    dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
     dcnm_send_side_effect.append(resp.get("vpc_pair_policy_resp_1"))
 
     mock_dcnm_send = Mock(side_effect=dcnm_send_side_effect)
@@ -1912,10 +1935,13 @@ class TestDcnmVpcPairModule(TestDcnmModule):
 
         # dcnm_send() invoked from module_utils/dcnm_vpc_pair_utils.py
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_84"))
+        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_policy_resp_84"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_85"))
+        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_policy_resp_85"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_86"))
+        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_policy_resp_86"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_sync_status_in_sync"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_sync_status_in_sync"))
@@ -2042,10 +2068,13 @@ class TestDcnmVpcPairModule(TestDcnmModule):
 
         # dcnm_send() invoked from module_utils/dcnm_vpc_pair_utils.py
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_84"))
+        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_policy_resp_84"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_85"))
+        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_policy_resp_85"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_86"))
+        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_policy_resp_86"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_delete_succ_resp"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_delete_succ_resp"))
@@ -2260,17 +2289,21 @@ class TestDcnmVpcPairModule(TestDcnmModule):
         # dcnm_send() invoked from module_utils/dcnm_vpc_pair_utils.py
         dcnm_send_side_effect.append(resp.get("vpc_pair_null_have"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_85"))
+        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_policy_resp_85"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_86"))
+        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_policy_resp_86"))
 
         dcnm_send_side_effect.append(resp.get("vpc_pair_null_have"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_null_have"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_85"))
+        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
         dcnm_send_side_effect.append(
             copy.deepcopy(resp.get("vpc_pair_policy_resp_85"))
         )
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_86"))
+        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
         dcnm_send_side_effect.append(
             copy.deepcopy(resp.get("vpc_pair_policy_resp_86"))
         )
@@ -2389,21 +2422,27 @@ class TestDcnmVpcPairModule(TestDcnmModule):
 
         # dcnm_send() invoked from module_utils/dcnm_vpc_pair_utils.py
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_84"))
+        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_policy_resp_84"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_85"))
+        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_policy_resp_85"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_86"))
+        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_policy_resp_86"))
 
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_84"))
+        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
         dcnm_send_side_effect.append(
             copy.deepcopy(resp.get("vpc_pair_policy_resp_84"))
         )
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_85"))
+        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
         dcnm_send_side_effect.append(
             copy.deepcopy(resp.get("vpc_pair_policy_resp_85"))
         )
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_86"))
+        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
         dcnm_send_side_effect.append(
             copy.deepcopy(resp.get("vpc_pair_policy_resp_86"))
         )
@@ -2507,21 +2546,27 @@ class TestDcnmVpcPairModule(TestDcnmModule):
 
         # dcnm_send() invoked from module_utils/dcnm_vpc_pair_utils.py
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_84"))
+        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_policy_resp_84"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_85"))
+        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_policy_resp_85"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_86"))
+        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_policy_resp_86"))
 
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_84"))
+        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
         dcnm_send_side_effect.append(
             copy.deepcopy(resp.get("vpc_pair_policy_resp_84"))
         )
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_85"))
+        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
         dcnm_send_side_effect.append(
             copy.deepcopy(resp.get("vpc_pair_policy_resp_85"))
         )
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_86"))
+        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
         dcnm_send_side_effect.append(
             copy.deepcopy(resp.get("vpc_pair_policy_resp_86"))
         )


### PR DESCRIPTION
This PR enabled the `useVirtualPeerlink` functionality for the `dcnm_vpc_pair` module

Resolves: https://github.com/CiscoDevNet/ansible-dcnm/issues/333