### PR TITLE
dcnm_fabric: Fix for issue 343

### DIFF
--- a/plugins/module_utils/fabric/create.py
+++ b/plugins/module_utils/fabric/create.py
@@ -115,7 +115,7 @@ class FabricCreateCommon(FabricCommon):
         self.path = self.ep_fabric_create.path
         self.verb = self.ep_fabric_create.verb
 
-    def _fixup_payload_ext_fabric_type(self, payload: dict) -> dict:
+    def _add_ext_fabric_type_to_payload(self, payload: dict) -> dict:
         """
         # Summary
 
@@ -128,7 +128,8 @@ class FabricCreateCommon(FabricCommon):
 
         None
         """
-        self.log.debug(f"ZZZ: payload {json.dumps(payload, indent=4, sort_keys=True)}")
+        method_name = inspect.stack()[0][3]
+
         fabric_type = payload.get("FABRIC_TYPE")
         if fabric_type not in self.fabric_types.external_fabric_types:
             return payload
@@ -138,6 +139,12 @@ class FabricCreateCommon(FabricCommon):
         if value is None:
             return payload
         payload["EXT_FABRIC_TYPE"] = value
+
+        msg = f"{self.class_name}.{method_name}: "
+        msg += "Added EXT_FABRIC_TYPE to payload. "
+        msg += f"fabric_type: {fabric_type}, "
+        msg += f"value: {value}"
+        self.log.debug(msg)
         return payload
 
     def _send_payloads(self):
@@ -153,7 +160,7 @@ class FabricCreateCommon(FabricCommon):
         -   This overrides the parent class method.
         """
         for payload in self._payloads_to_commit:
-            payload = self._fixup_payload_ext_fabric_type(payload)
+            payload = self._add_ext_fabric_type_to_payload(payload)
 
             try:
                 self._set_fabric_create_endpoint(payload)

--- a/plugins/module_utils/fabric/fabric_types.py
+++ b/plugins/module_utils/fabric/fabric_types.py
@@ -88,7 +88,25 @@ class FabricTypes:
         self._fabric_type_to_feature_name_map["VXLAN_EVPN"] = "vxlan"
         self._fabric_type_to_feature_name_map["VXLAN_EVPN_MSD"] = "vxlan"
 
+        # Map fabric type to the value that the controller GUI displays
+        # in the Fabric Type column at NDFC -> Manage -> Fabrics
+        # This is needed only for fabrics that use the External_Fabric
+        # template, e.g. ISN, and will be inserted into the POST request
+        # payload for external fabrics as (in the case of ISN fabric type):
+        # "EXT_FABRIC_TYPE": "Multi-Site External Network"
+        #
+        # Exposed via property fabric_type_to_ext_fabric_type_map
+        self._fabric_type_to_ext_fabric_type_map = {}
+        self._fabric_type_to_ext_fabric_type_map["ISN"] = "Multi-Site External Network"
+
         self._valid_fabric_types = sorted(self._fabric_type_to_template_name_map.keys())
+
+        # Adding self._external_fabric_types to be used in conjunction with
+        # self._fabric_type_to_ext_fabric_type_map.  This is used in (at least)
+        # FabricCreateCommon() to determine if EXT_FABRIC_TYPE key needs to be
+        # added to a payload.
+        self._external_fabric_types = set()
+        self._external_fabric_types.add("ISN")
 
         self._mandatory_parameters_all_fabrics = []
         self._mandatory_parameters_all_fabrics.append("FABRIC_NAME")
@@ -129,6 +147,19 @@ class FabricTypes:
         self._properties["valid_fabric_types"] = self._valid_fabric_types
 
     @property
+    def external_fabric_types(self):
+        """
+        # Summary
+
+        set() containing all external fabric types e.g. ISN.
+
+        # Raises
+
+        None
+        """
+        return self._external_fabric_types
+
+    @property
     def fabric_type(self):
         """
         -   getter: Return the currently-set fabric type.
@@ -149,6 +180,19 @@ class FabricTypes:
             msg += f"Expected one of: {', '.join(self.valid_fabric_types)}."
             raise ValueError(msg)
         self._properties["fabric_type"] = value
+
+    @property
+    def fabric_type_to_ext_fabric_type_map(self):
+        """
+        # Summary
+
+        Returns a dictionary, keyed on fabric_type (e.g. "ISN"),
+        whose value is a string that the NDFC GUI uses to describe the
+        external fabric type. See the Fabric Type column at
+        NDFC -> Manage -> Fabrics for an example of how this is used
+        by the NDFC GUI.
+        """
+        return self._fabric_type_to_ext_fabric_type_map
 
     @property
     def feature_name(self):

--- a/plugins/module_utils/fabric/fabric_types.py
+++ b/plugins/module_utils/fabric/fabric_types.py
@@ -101,10 +101,12 @@ class FabricTypes:
 
         self._valid_fabric_types = sorted(self._fabric_type_to_template_name_map.keys())
 
-        # Adding self._external_fabric_types to be used in conjunction with
+        # self._external_fabric_types is used in conjunction with
         # self._fabric_type_to_ext_fabric_type_map.  This is used in (at least)
         # FabricCreateCommon() to determine if EXT_FABRIC_TYPE key needs to be
         # added to a payload.
+        #
+        # Exposed via property external_fabric_types
         self._external_fabric_types = set()
         self._external_fabric_types.add("ISN")
 


### PR DESCRIPTION
# Summary

Fixes an issue found by Alessandro De Prato where Ansible-created external fabrics (e.g. ISN) are displayed with incorrect Fabric Type column value in the NDFC GUI on page:

NDFC -> Manage -> Fabrics

## Details

For example, ISN fabric types are displayed with a column value of "Custom Fabric" but SHOULD be displayed with a column value of "Multi-Site External Network".

The reason is that the NDFC GUI adds the key `EXT_FABRIC_TYPE` to the payload with the value (in the case of ISN) of "Multi-Site External Network".

This only affects fabrics using the `External_Fabric` template.

## Testing

I've tested to verify the fix and have tested to verify that the fix does not change behavior for non-External fabric types.

## Other

Have made the fix extensible, so that it can be applied to other fabric types that use the `External_Fabric` template, should we decide to add them.

## Resolves

#343 
