### PR TITLE
Module: dcnm_vpc_pair - Remove Manageable Check for Devices

### DIFF
--- a/plugins/module_utils/network/dcnm/dcnm_vpc_pair_utils.py
+++ b/plugins/module_utils/network/dcnm/dcnm_vpc_pair_utils.py
@@ -65,41 +65,6 @@ def dcnm_vpc_pair_utils_validate_profile(self, profile, arg_spec):
     return vpc_pair_profile_info
 
 
-def dcnm_vpc_pair_utils_check_if_meta(self, dev):
-
-    for elem in self.meta_switches:
-        if dev in elem:
-            return True
-    return False
-
-
-def dcnm_vpc_pair_utils_validate_devices(self, cfg):
-
-    if (cfg.get("peerOneId", None) is not None) and (
-        cfg["peerOneId"] not in self.managable
-    ):
-        mesg = "Switch {0} is not Manageable".format(cfg["peerOneId"])
-        self.module.fail_json(msg=mesg)
-
-    if (cfg.get("peerTwoId", None) is not None) and (
-        cfg["peerTwoId"] not in self.managable
-    ):
-        mesg = "Switch {0} is not Manageable".format(cfg["peerTwoId"])
-        self.module.fail_json(msg=mesg)
-
-    if (cfg.get("peerOneId", None) is not None) and (
-        dcnm_vpc_pair_utils_check_if_meta(self, cfg["peerOneId"]) is True
-    ):
-        mesg = "Switch {0} is not Manageable".format(cfg["peerOneId"])
-        self.module.fail_json(msg=mesg)
-
-    if (cfg.get("peerTwoId", None) is not None) and (
-        dcnm_vpc_pair_utils_check_if_meta(self, cfg["peerTwoId"]) is True
-    ):
-        mesg = "Switch {0} is not Manageable".format(cfg["peerTwoId"])
-        self.module.fail_json(msg=mesg)
-
-
 def dcnm_vpc_pair_utils_translate_config(self, cfg):
 
     if cfg.get("peerOneId", "") != "":

--- a/plugins/modules/dcnm_vpc_pair.py
+++ b/plugins/modules/dcnm_vpc_pair.py
@@ -436,7 +436,6 @@ from ansible_collections.cisco.dcnm.plugins.module_utils.network.dcnm.dcnm_vpc_p
     dcnm_vpc_pair_utils_get_sync_status,
     dcnm_vpc_pair_utils_get_delete_list,
     dcnm_vpc_pair_utils_get_all_filtered_vpc_pair_pairs,
-    dcnm_vpc_pair_utils_validate_devices,
 )
 
 

--- a/plugins/modules/dcnm_vpc_pair.py
+++ b/plugins/modules/dcnm_vpc_pair.py
@@ -1104,9 +1104,6 @@ class DcnmVpcPair:
             # Add other translations as required
             dcnm_vpc_pair_utils_translate_config(self, cfg)
 
-            # Check if the switches included in the config are Manageable.
-            dcnm_vpc_pair_utils_validate_devices(self, cfg)
-
     def dcnm_vpc_pair_fetch_template_details(self, template_info):
 
         """


### PR DESCRIPTION
The `dcnm_vpc_pair` module currently has a check to see if devices are in a `manageable` state before attempting to put them into a vpc pair but this check is not needed and in fact breaks pre-provision workflows.

A device or switch state can be unmanageable for a variety of reasons but we should not be checking this state to use it for making configuration decisions.  A device that is in this state can still be configured as a vpc pair.

Removing this check but leaving the function in the library if we decide we need it down the road for different use cases.