### PR TITLE
Module: dcnm_interface - Remove Manageable Check for Interfaces

### DIFF
--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -5023,13 +5023,6 @@ class DcnmIntf:
                     )
                 )
 
-            if ronly_sw_list:
-                self.module.fail_json(
-                    msg="Error: Switches {0} are not managable in Fabric '{1}', No changes are allowed on these switches\n".format(
-                        ronly_sw_list, self.fabric
-                    )
-                )
-
         # Based on the updated inventory_data, update ip_sn, hn_sn and sn_hn objects
         self.ip_sn, self.hn_sn = get_ip_sn_dict(self.inventory_data)
 


### PR DESCRIPTION
The `dcnm_interface` module currently has a check to see if devices are in a `manageable` state before attempting to create interfaces but this check is not needed and in fact breaks pre-provision workflows.

A device or switch state can be unmanageable for a variety of reasons but we should not be checking this state to use it for making configuration decisions.
