### PR TITLE
dcnm_fabric: hardening

### DIFF
--- a/plugins/module_utils/fabric/replaced.py
+++ b/plugins/module_utils/fabric/replaced.py
@@ -468,7 +468,7 @@ class FabricReplacedCommon(FabricCommon):
 
         for payload in self._payloads_to_commit:
             commit_payload = copy.deepcopy(payload)
-            if commit_payload.get("DEPLOY", None) is not None:
+            if "DEPLOY" in commit_payload:
                 commit_payload.pop("DEPLOY")
             try:
                 self._send_payload(commit_payload)

--- a/plugins/modules/dcnm_fabric.py
+++ b/plugins/modules/dcnm_fabric.py
@@ -3032,7 +3032,7 @@ class Merged(Common):
             fabric_name = want.get("FABRIC_NAME", None)
             fabric_type = want.get("FABRIC_TYPE", None)
 
-            if self.features[fabric_type] is False:
+            if self.features.get("fabric_type") is False:
                 msg = f"{self.class_name}.{method_name}: "
                 msg += f"Features required for fabric {fabric_name} "
                 msg += f"of type {fabric_type} are not running on the "
@@ -3361,7 +3361,7 @@ class Replaced(Common):
                 self.need_create.append(want)
                 continue
 
-            if self.features[fabric_type] is False:
+            if self.features.get("fabric_type") is False:
                 msg = f"{self.class_name}.{method_name}: "
                 msg += f"Features required for fabric {fabric_name} "
                 msg += f"of type {fabric_type} are not running on the "


### PR DESCRIPTION
Two bits of vulnerable code found when porting to ndfc-python.

1. plugins/modules/dcnm_fabric.py

Accessing dictionary key directly can lead to a KeyError exception.

2. plugins/module_utils/fabric/replaced.py

If user omits the DEPLOY parameter from their playbook (ndfc-python) the DEPLOY key would be None, and not get popped from the payload.  This would cause NDFC to complain about an invalid key in the payload.  We need to unconditionally pop DEPLOY here, if it's present.  Hence, we've removed the value check.