### PR TITLE
EpTemplate() - remove template_name validation

### DIFF
--- a/plugins/module_utils/common/api/v1/configtemplate/rest/config/templates/templates.py
+++ b/plugins/module_utils/common/api/v1/configtemplate/rest/config/templates/templates.py
@@ -21,7 +21,6 @@ import inspect
 import logging
 
 from ..config import Config
-from ........fabric.fabric_types import FabricTypes
 
 
 class Templates(Config):
@@ -39,7 +38,6 @@ class Templates(Config):
         super().__init__()
         self.class_name = self.__class__.__name__
         self.log = logging.getLogger(f"dcnm.{self.class_name}")
-        self.fabric_types = FabricTypes()
 
         self.templates = f"{self.config}/templates"
         self._template_name = None
@@ -71,13 +69,6 @@ class Templates(Config):
 
     @template_name.setter
     def template_name(self, value):
-        method_name = inspect.stack()[0][3]
-        if value not in self.fabric_types.valid_fabric_template_names:
-            msg = f"{self.class_name}.{method_name}: "
-            msg += f"Invalid template_name: {value}. "
-            msg += "Expected one of: "
-            msg += f"{', '.join(self.fabric_types.valid_fabric_template_names)}."
-            raise ValueError(msg)
         self._template_name = value
 
 

--- a/tests/unit/module_utils/common/api/test_api_v1_configtemplate_rest_config_templates.py
+++ b/tests/unit/module_utils/common/api/test_api_v1_configtemplate_rest_config_templates.py
@@ -60,25 +60,6 @@ def test_ep_templates_00040():
         instance.path  # pylint: disable=pointless-statement
 
 
-def test_ep_templates_00050():
-    """
-    ### Class
-    -   EpFabricConfigDeploy
-
-    ### Summary
-    -   Verify ``ValueError`` is raised if ``template_name``
-        is invalid.
-    """
-    template_name = "Invalid_Template_Name"
-    with does_not_raise():
-        instance = EpTemplate()
-    match = r"EpTemplate.template_name:\s+"
-    match += r"Invalid template_name: Invalid_Template_Name.\s+"
-    match += r"Expected one of:\s+"
-    with pytest.raises(ValueError, match=match):
-        instance.template_name = template_name  # pylint: disable=pointless-statement
-
-
 def test_ep_templates_00100():
     """
     ### Class


### PR DESCRIPTION
# Summary

EpTemplate() used FabricTypes() to validate the template_name property against a list of supported fabric templates.  However, the intent of EpTemplate() is to retrieve other template types as well (interface, network, vrf, etc), so this validation isn't ideal in this larger context.

## Changes

1. Removes this validation and the associated import and instantiation of FabricTypes().

2. Removes unit test that verified a ValueError is raised if template_name did not match one of the templates in FabricTypes().
