### PR TITLE
Issues #251 and #264 in ansible solutions.

### DIFF
--- a/plugins/module_utils/common/conversion.py
+++ b/plugins/module_utils/common/conversion.py
@@ -19,6 +19,7 @@ __author__ = "Allen Robel"
 
 import inspect
 import re
+import ipaddress
 
 
 class ConversionUtils:
@@ -171,3 +172,13 @@ class ConversionUtils:
         msg += "Fabric name must start with a letter A-Z or a-z and "
         msg += "contain only the characters in: [A-Z,a-z,0-9,-,_]."
         raise ValueError(msg)
+
+    @staticmethod
+    def make_ipv4_or_ipv6_address(ip_addr):
+        try:
+            if (isinstance(ipaddress.ip_address(ip_addr), ipaddress.IPv6Address)
+                    or isinstance(ipaddress.ip_address(ip_addr), ipaddress.IPv4Address)):
+                sw_ip = str(ipaddress.ip_address(ip_addr))
+        except ValueError:
+            sw_ip = ip_addr
+        return sw_ip

--- a/tests/integration/targets/dcnm_inventory/tasks/dcnm.yaml
+++ b/tests/integration/targets/dcnm_inventory/tasks/dcnm.yaml
@@ -17,7 +17,7 @@
   tags: sanity
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }}"
+  include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/dcnm_inventory/tasks/main.yaml
+++ b/tests/integration/targets/dcnm_inventory/tasks/main.yaml
@@ -38,4 +38,4 @@
     - 'controller_version != "Unable to determine controller version"'
   tags: sanity
 
-- { include: dcnm.yaml, tags: ['dcnm'] }
+- { include_tasks: dcnm.yaml, tags: ['dcnm'] }

--- a/tests/integration/targets/dcnm_vrf/tasks/main.yaml
+++ b/tests/integration/targets/dcnm_vrf/tasks/main.yaml
@@ -38,4 +38,4 @@
     - 'controller_version != "Unable to determine controller version"'
   tags: sanity
 
-- { include: dcnm.yaml, tags: ['dcnm'] }
+- { include_tasks: dcnm.yaml, tags: ['dcnm'] }


### PR DESCRIPTION
IPv6 address inventory failure.
NDFC returns ipv6 address with unabbrevated form (e.g) 2001:0:0:12 instead of 2001::12 for below requests. /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/lanConfig/getLanSwitchCredentials
        "ipAddress": "2001:420:448b:8006:fab2:0:0:13",
/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/hello/inventory/test-reachability

in https://github.com/netascode/ansible-dc-vxlan/issues/251