### PR TITLE
dcnm_fabric: Fix evaluation of controller features

### DIFF
--- a/plugins/module_utils/common/controller_version.py
+++ b/plugins/module_utils/common/controller_version.py
@@ -276,3 +276,26 @@ class ControllerVersion:
         if self.version is None:
             return None
         return (self._get("version").split("."))[2]
+
+    @property
+    def is_controller_version_4x(self) -> bool:
+        """
+        ### Summary
+
+        -   Return True if the controller version implies ND 4.0 or higher.
+        -   Return False otherwise.
+        """
+        method_name = inspect.stack()[0][3]
+
+        result = None
+        if int(self.version_major) == 12 and int(self.version_minor) < 3:
+            result = False
+        else:
+            result = True
+
+        msg = f"{self.class_name}.{method_name}: "
+        msg = f"self.version: {self.version}, "
+        msg += f"Controller is version 4.x: {result}"
+        self.log.debug(msg)
+
+        return result

--- a/plugins/module_utils/common/controller_version.py
+++ b/plugins/module_utils/common/controller_version.py
@@ -229,14 +229,14 @@ class ControllerVersion:
     @property
     def version_major(self):
         """
-        Return the controller major version, if it exists.
+        Return the controller major version as a string, if it exists.
         Return None otherwise
 
         We are assuming semantic versioning based on:
         https://semver.org
 
         Possible values:
-            if version is 12.1.2e, return 12
+            if version is 12.1.2e, return "12"
             None
         """
         if self.version is None:
@@ -246,7 +246,7 @@ class ControllerVersion:
     @property
     def version_minor(self):
         """
-        Return the controller minor version, if it exists.
+        Return the controller minor version as a string, if it exists.
         Return None otherwise
 
         We are assuming semantic versioning based on:
@@ -263,7 +263,7 @@ class ControllerVersion:
     @property
     def version_patch(self):
         """
-        Return the controller minor version, if it exists.
+        Return the controller patch version as a string, if it exists.
         Return None otherwise
 
         We are assuming semantic versioning based on:

--- a/plugins/modules/dcnm_fabric.py
+++ b/plugins/modules/dcnm_fabric.py
@@ -3060,21 +3060,15 @@ class Merged(Common):
             msg += f"self.features: {self.features}"
             self.log.debug(msg)
 
+            is_4x = self.controller_version.is_controller_version_4x
+
             msg = f"{self.class_name}.{method_name}: "
             msg += f"fabric_type: {fabric_type}, "
-            msg += f"configurable: {self.features.get(fabric_type)}"
+            msg += f"configurable: {self.features.get(fabric_type)}, "
+            msg += f"is_4x: {is_4x}"
             self.log.debug(msg)
 
-            msg = f"{self.class_name}.{method_name}: "
-            msg += "self.controller_version.version: "
-            msg += f"{self.controller_version.version}"
-            self.log.debug(msg)
-
-            if (
-                self.features.get(fabric_type) is False
-                and int(self.controller_version.version_major) == 12
-                and int(self.controller_version.version_minor) < 3
-            ):
+            if self.features.get(fabric_type) is False and is_4x is False:
                 msg = f"{self.class_name}.{method_name}: "
                 msg += f"Features required for fabric {fabric_name} "
                 msg += f"of type {fabric_type} are not running on the "
@@ -3405,21 +3399,15 @@ class Replaced(Common):
                 self.need_create.append(want)
                 continue
 
+            is_4x = self.controller_version.is_controller_version_4x
+
             msg = f"{self.class_name}.{method_name}: "
             msg += f"fabric_type: {fabric_type}, "
-            msg += f"configurable: {self.features.get(fabric_type)}"
+            msg += f"configurable: {self.features.get(fabric_type)}, "
+            msg += f"is_4x: {is_4x}"
             self.log.debug(msg)
 
-            msg = f"{self.class_name}.{method_name}: "
-            msg += "self.controller_version.version: "
-            msg += f"{self.controller_version.version}"
-            self.log.debug(msg)
-
-            if (
-                self.features.get(fabric_type) is False
-                and int(self.controller_version.version_major) == 12
-                and int(self.controller_version.version_minor) < 3
-            ):
+            if self.features.get(fabric_type) is False and is_4x is False:
                 msg = f"{self.class_name}.{method_name}: "
                 msg += f"Features required for fabric {fabric_name} "
                 msg += f"of type {fabric_type} are not running on the "

--- a/tests/unit/module_utils/common/fixtures/responses_ep_version.json
+++ b/tests/unit/module_utils/common/fixtures/responses_ep_version.json
@@ -449,5 +449,43 @@
             "uuid": "",
             "is_upgrade_inprogress": "false"
         }
+    },
+    "test_controller_version_00300a": {
+        "TEST_NOTES": [
+            "12.2.2.238 implies ND 3.x"
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
+        "MESSAGE": "OK",
+        "DATA": {
+            "version": "12.2.2.238",
+            "mode": "LAN",
+            "isMediaController": "false",
+            "dev": "false",
+            "isHaEnabled": "false",
+            "install": "EASYFABRIC",
+            "uuid": "",
+            "is_upgrade_inprogress": "false"
+        }
+    },
+    "test_controller_version_00300b": {
+        "TEST_NOTES": [
+            "12.3.1.248 implies ND 4.x"
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
+        "MESSAGE": "OK",
+        "DATA": {
+            "version": "12.3.1.248",
+            "mode": "LAN",
+            "isMediaController": "false",
+            "dev": "false",
+            "isHaEnabled": "false",
+            "install": "EASYFABRIC",
+            "uuid": "",
+            "is_upgrade_inprogress": "false"
+        }
     }
 }

--- a/tests/unit/module_utils/common/test_controller_version.py
+++ b/tests/unit/module_utils/common/test_controller_version.py
@@ -827,3 +827,54 @@ def test_controller_version_00250(controller_version, key, expected) -> None:
         instance.rest_send = rest_send
         instance.refresh()
     assert instance.version_patch == expected
+
+
+@pytest.mark.parametrize(
+    "key, expected",
+    [
+        ("test_controller_version_00300a", False),
+        ("test_controller_version_00300b", True),
+    ],
+)
+def test_controller_version_00300(controller_version, key, expected) -> None:
+    """
+    ### Classes and Methods
+
+    -   ``ControllerVersion()``
+            -   ``refresh``
+            -   ``is_controller_version_4x``
+
+    ### Test
+
+    - is_controller_version_4x returns expected values
+
+    ### Description
+
+    ``is_controller_version_4x`` returns:
+
+    - True, if int(self.version_major) == 12 and int(self.version_minor) >= 3.
+    - False, if int(self.version_major) == 12 and int(self.version_minor) < 3.
+
+    ### Expected result
+
+    1. test_controller_version_00300a is True
+    2. test_controller_version_00300b is False
+    """
+
+    def responses():
+        yield responses_ep_version(key)
+
+    gen_responses = ResponseGenerator(responses())
+
+    sender = Sender()
+    sender.ansible_module = MockAnsibleModule()
+    sender.gen = gen_responses
+    rest_send = RestSend(params)
+    rest_send.response_handler = ResponseHandler()
+    rest_send.sender = sender
+
+    with does_not_raise():
+        instance = controller_version
+        instance.rest_send = rest_send
+        instance.refresh()
+    assert instance.is_controller_version_4x == expected


### PR DESCRIPTION
# Summary

closes #360

The evaluation of controller features in dcnm_fabric.py was broken due to using the wrong key to access the features dictionary.  This PR fixes this, and also bypasses controller feature evaluation for ND 4.x.

## Changes

### 1. plugins/modules/dcnm_fabric.py

1a. Fix dictionary access in `Merged.get_need()` and `Replaced.get_need()`

In the above methods, we were trying to retrieve the key `"fabric_type"` from the dict  `self.features`. But this dict is keyed on the fabric type (e.g. keys in this dict are `"ISN"`, `"VXLAN_EVPN"`, etc).

```python
self.features == {'IPFM': False, 'ISN': True, 'LAN_CLASSIC': True, 'VXLAN_EVPN': True, 'VXLAN_EVPN_MSD': True}
```

The fix is to remove the quotes around "fabric_type" -> fabric_type, which is a var containing the fabric type (`ISN`, `VXLAN_EVPN`, etc).

1b. Update feature evaluation checks for ND 4.0.

The NDFC versions (as returned by `ControllerVersion()`) for  ND 3.2.1e and ND 4.0 respectively are:

`12.2.2.238` -> ND 3.2.1e
`12.3.1.248` -> ND 4.0 dev version 86

The unified architecture for ND 4.0 means that it no longer includes information about controller features relevant to fabrics at the endpoint `/appcenter/cisco/ndfc/api/v1/fm/features`.   This impacts the contents of the `self.features` dictionary, for which all values are now `False`:

```python
self.features == {'IPFM': False, 'ISN': False, 'LAN_CLASSIC': False, 'VXLAN_EVPN': False, 'VXLAN_EVPN_MSD': False}
```
Previously, (in ND 3.x) the `oper_state` for the `"vxlan"` feature at endpoint `/appcenter/cisco/ndfc/api/v1/fm/features` was expected to be `"started"` for `VXLAN_EVPN` fabric creation/modification and, similarly, `oper_state` for `"pmn"` feature was expected to  be `"started"` for IPFM fabric creation/modification, etc).  Since these keys are no longer in the endpoint's output, the values of the `self.features` dict are now all `False`. Hence, feature evaluation should be  run only if NDFC `int(version_minor)` is less than 3 (and `int(version_major)` == 12).

Added call to `ControllerVersion()` and updated the feature evaluation check in `Merged.get_need()` and `Replaced.get_need()` such that we skip the check if the controller version implies ND 4.x.

### 2. plugins/module_utils/common/controller_version.py

2a. Added a property that returns `True` if the controller version implies ND 4.x and `False` otherwise.

2b. Updated docstrings in `controller_version.py`

Updated accessor property docstrings in `ControllerVersion()` to mention explicitly that a string is returned for `version_major`, `version_minor`, and `version_patch`.

### 3. Add unit tests for ControllerVersion().is_controller_version_4x

Add two unit tests to verify that `ControllerVersion().is_controller_version_4x ` returns correct values for ND 3.x and ND 4.x NDFC versions.

### Other

At endpoint `/appcenter/cisco/ndfc/api/v1/fm/about/version` which is used by the `ControllerVersion()` class, the version string has changed format (somewhere between 12.1.x and 12.2.x).  Below are the old and new formats:

#### Old

12.1.3b (corresponding to ` version_major`.`version_minor`.`version_patch`)

#### New (as of ND 3.2.1e)

12.2.1.238

The existing regex still works for the new format for `version_major` ("12" in this case), `version_minor` ("2" in this case). 

But, `version_patch` now returns "1" rather than e.g. "1a", "1b", etc.  And the regex does not accommodate ".238" at all.

Since nothing is currently breaking, I'm inclined to leave things as they are for now.  We can add an additional property for the "238" portion of the version string when/if it becomes necessary.

## Unit Tests

All unit tests pass.

## Integration Tests

I ran the dcnm_fabric integration tests against ND 3.2.1e and ND 4.0 (dev version 86).

All tests pass for ND 3.2.1e.

The following tests fails for ND 4.0.

`dcnm_fabric_replaced_basic_vxlan`

Will open a separate issue to investigate.  The template entries for `ANYCAST_RP_IP_RANGE`, `MULTICAST_GROUP_SUBNET`, and `RP_LB_ID` are identical between ND 3.2.1e and ND 4.0 version 86

```
fatal: [172.22.150.244]: FAILED! => {"changed": false, "metadata": [{"action": "fabric_replace", "check_mode": false, "sequence_number": 1, "state": "replaced"}], "msg": "Module failed.", "response": [{"DATA": "Invalid JSON response: Error in validating provided name value pair: [ANYCAST_RP_IP_RANGE, MULTICAST_GROUP_SUBNET, RP_LB_ID]", "MESSAGE": "Internal Server Error", "METHOD": "PUT", "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/VXLAN_EVPN_Fabric/Easy_Fabric", "RETURN_CODE": 500, "sequence_number": 1}], "result": [{"changed": false, "sequence_number": 1, "success": false}]}
```
