### PR TITLE
Issue 368: #368

### DIFF
--- a/plugins/modules/dcnm_inventory.py
+++ b/plugins/modules/dcnm_inventory.py
@@ -740,6 +740,7 @@ class DcnmInventory:
                 "cdpSecondTimeout": "5",
                 "role": inv["role"].replace(" ", "_"),
                 "preserveConfig": inv["preserve_config"],
+                "discoveryCredForLan": "true",
             }
 
             resp = self.update_discover_params(inv_upd)
@@ -1186,7 +1187,7 @@ class DcnmInventory:
         if self.nd:
             path = self.nd_prefix + path
         # create_path = path + '/inventory/discover?gfBlockingCall=true'
-        create_path = path + "/inventory/discover"
+        create_path = path + "/inventory/discover?setAndUseDiscoveryCredForLan=true"
 
         if self.diff_create:
             for create in self.diff_create:

--- a/tests/integration/targets/dcnm_fabric/tests/dcnm_fabric_replaced_save_deploy.yaml
+++ b/tests/integration/targets/dcnm_fabric/tests/dcnm_fabric_replaced_save_deploy.yaml
@@ -246,7 +246,7 @@
       - seed_ip: "{{ leaf_1 }}"
         auth_proto: MD5
         user_name: admin
-        password: Cisco!2345
+        password: "{{ nxos_password }}"
         max_hops: 0
         role: leaf
         preserve_config: false
@@ -265,7 +265,7 @@
       - seed_ip: "{{ leaf_2 }}"
         auth_proto: MD5
         user_name: admin
-        password: Cisco!2345
+        password: "{{ nxos_password }}"
         max_hops: 0
         role: leaf
         # preserve_config must be True for LAN_CLASSIC


### PR DESCRIPTION
#368 

**Testing Completed for Older NDFC version**
Issue:
Switch addition to inventory fails if Default credentials are not set in NDFC.

Solution:

- While discovering the switch adding the additional attribute discoveryCredForLan to discover using individual switch credentials.
- Also added dcnm_fabric IT issue fix as well.