### PR TITLE
Update links module to fix error message when MACSEC status of have link doesn't exist

### DIFF
--- a/plugins/modules/dcnm_links.py
+++ b/plugins/modules/dcnm_links.py
@@ -3032,7 +3032,7 @@ class DcnmLinks:
                     {
                         "ENABLE_MACSEC_MISMATCH": [
                             str(wlink["nvPairs"]["ENABLE_MACSEC"]).lower(),
-                            str(hlink["nvPairs"]["ENABLE_MACSEC"]).lower(),
+                            str(hlink["nvPairs"].get("ENABLE_MACSEC")).lower(),
                         ]
                     }
                 )


### PR DESCRIPTION
Update to fix https://github.com/CiscoDevNet/ansible-dcnm/issues/379