### PR TITLE
dcnm_fabric: Add per_vrf_loopback_auto_provision accessor property.

### DIFF
--- a/plugins/module_utils/fabric/fabric_details_v2.py
+++ b/plugins/module_utils/fabric/fabric_details_v2.py
@@ -382,7 +382,7 @@ class FabricDetails:
         try:
             return self._get_nv_pair("PER_VRF_LOOPBACK_AUTO_PROVISION")
         except ValueError as error:
-            msg = f"Failed to retrieve per_vrf_loopback_auto_provision: "
+            msg = "Failed to retrieve per_vrf_loopback_auto_provision: "
             msg += f"Error detail: {error}"
             self.log.debug(msg)
             return None

--- a/plugins/module_utils/fabric/fabric_details_v2.py
+++ b/plugins/module_utils/fabric/fabric_details_v2.py
@@ -362,6 +362,32 @@ class FabricDetails:
             return None
 
     @property
+    def per_vrf_loopback_auto_provision(self):
+        """
+        ### Summary
+        The ``nvPairs.PER_VRF_LOOPBACK_AUTO_PROVISION`` value of the fabric
+        specified with filter.
+
+        ### Raises
+        None
+
+        ### Type
+        boolean
+
+        ### Returns
+        - True
+        - False
+        - None
+        """
+        try:
+            return self._get_nv_pair("PER_VRF_LOOPBACK_AUTO_PROVISION")
+        except ValueError as error:
+            msg = f"Failed to retrieve per_vrf_loopback_auto_provision: "
+            msg += f"Error detail: {error}"
+            self.log.debug(msg)
+            return None
+
+    @property
     def replication_mode(self):
         """
         ### Summary

--- a/tests/unit/modules/dcnm/dcnm_fabric/test_fabric_details_by_name_v2.py
+++ b/tests/unit/modules/dcnm/dcnm_fabric/test_fabric_details_by_name_v2.py
@@ -161,6 +161,7 @@ def test_fabric_details_by_name_v2_00200(fabric_details_by_name_v2) -> None:
     assert instance.fabric_id == "FABRIC-2"
     assert instance.fabric_type == "Switch_Fabric"
     assert instance.is_read_only is None
+    assert instance.per_vrf_loopback_auto_provision is False
     assert instance.replication_mode == "Multicast"
     assert instance.template_name == "Easy_Fabric"
 


### PR DESCRIPTION
Adding a fabric property accessor that will be required by future commits for issue #352