### PR TITLE
Issue #352 : more preparatory changes

### DIFF
--- a/plugins/modules/dcnm_vrf.py
+++ b/plugins/modules/dcnm_vrf.py
@@ -595,6 +595,11 @@ dcnm_vrf_paths = {
 
 
 class DcnmVrf:
+    """
+    # Summary
+
+    dcnm_vrf module implementation.
+    """
 
     def __init__(self, module):
         self.class_name = self.__class__.__name__
@@ -1641,7 +1646,7 @@ class DcnmVrf:
             attach_list = vrf_attach["lanAttachList"]
             deploy_vrf = ""
             for attach in attach_list:
-                attach_state = False if attach["lanAttachState"] == "NA" else True
+                attach_state = not attach["isLanAttached"] == "NA"
                 deploy = attach["isLanAttached"]
                 deployed = False
                 if deploy and (
@@ -2773,7 +2778,15 @@ class DcnmVrf:
         if self.diff_create_update:
             for vrf in self.diff_create_update:
                 update_path = f"{path}/{vrf['vrfName']}"
-                self.send_to_controller(action, verb, update_path, vrf, is_rollback)
+
+                self.send_to_controller(
+                    action,
+                    verb,
+                    update_path,
+                    vrf,
+                    log_response=True,
+                    is_rollback=is_rollback,
+                )
 
     def push_diff_detach(self, is_rollback=False):
         """
@@ -2810,8 +2823,14 @@ class DcnmVrf:
         path = self.paths["GET_VRF"].format(self.fabric)
         detach_path = path + "/attachments"
         verb = "POST"
+
         self.send_to_controller(
-            action, verb, detach_path, self.diff_detach, is_rollback
+            action,
+            verb,
+            detach_path,
+            self.diff_detach,
+            log_response=True,
+            is_rollback=is_rollback,
         )
 
     def push_diff_undeploy(self, is_rollback=False):
@@ -2839,7 +2858,12 @@ class DcnmVrf:
         verb = "POST"
 
         self.send_to_controller(
-            action, verb, deploy_path, self.diff_undeploy, is_rollback
+            action,
+            verb,
+            deploy_path,
+            self.diff_undeploy,
+            log_response=True,
+            is_rollback=is_rollback,
         )
 
     def push_diff_delete(self, is_rollback=False):
@@ -2874,7 +2898,12 @@ class DcnmVrf:
                 continue
             delete_path = f"{path}/{vrf}"
             self.send_to_controller(
-                action, verb, delete_path, self.diff_detach, is_rollback
+                action,
+                verb,
+                delete_path,
+                self.diff_detach,
+                log_response=True,
+                is_rollback=is_rollback,
             )
 
         if del_failure:
@@ -2981,8 +3010,11 @@ class DcnmVrf:
             action = "create"
             verb = "POST"
             path = self.paths["GET_VRF"].format(self.fabric)
+            payload = copy.deepcopy(vrf)
 
-            self.send_to_controller(action, verb, path, vrf, is_rollback)
+            self.send_to_controller(
+                action, verb, path, payload, log_response=True, is_rollback=is_rollback
+            )
 
     def is_border_switch(self, serial_number) -> bool:
         """
@@ -3255,7 +3287,30 @@ class DcnmVrf:
 
         return self.sn_ip.get(serial_number)
 
-    def send_to_controller(self, action, verb, path, payload, is_rollback=False):
+    def send_to_controller(
+        self,
+        action: str,
+        verb: str,
+        path: str,
+        payload: dict,
+        log_response: bool = True,
+        is_rollback: bool = False,
+    ):
+        """
+        # Summary
+
+        Send a request to the controller.
+
+        ## params
+
+        -   `action`: The action to perform (create, update, delete, etc.)
+        -   `verb`: The HTTP verb to use (GET, POST, PUT, DELETE)
+        -   `path`: The URL path to send the request to
+        -   `payload`: The payload to send with the request (None for no payload)
+        -   `log_response`: If True, log the response in the result, else
+            do not include the response in the result
+        -   `is_rollback`: If True, attempt to rollback on failure
+        """
         caller = inspect.stack()[1][3]
         method_name = inspect.stack()[0][3]
 
@@ -3267,6 +3322,7 @@ class DcnmVrf:
         msg += f"action: {action}, "
         msg += f"verb: {verb}, "
         msg += f"path: {path}, "
+        msg += f"log_response: {log_response}, "
         msg += "type(payload): "
         msg += f"{type(payload)}, "
         msg += "payload: "
@@ -3290,7 +3346,9 @@ class DcnmVrf:
         msg += f"{self.result['changed']}"
         self.log.debug(msg)
 
-        self.result["response"].append(response)
+        if log_response is True:
+            self.result["response"].append(response)
+
         fail, self.result["changed"] = self.handle_response(response, action)
 
         msg = f"caller: {caller}, "
@@ -3509,7 +3567,12 @@ class DcnmVrf:
         attach_path = path + "/attachments"
 
         self.send_to_controller(
-            action, verb, attach_path, new_diff_attach_list, is_rollback
+            action,
+            verb,
+            attach_path,
+            new_diff_attach_list,
+            log_response=True,
+            is_rollback=is_rollback,
         )
 
     def push_diff_deploy(self, is_rollback=False):
@@ -3535,7 +3598,12 @@ class DcnmVrf:
         deploy_path = path + "/deployments"
 
         self.send_to_controller(
-            action, verb, deploy_path, self.diff_deploy, is_rollback
+            action,
+            verb,
+            deploy_path,
+            self.diff_deploy,
+            log_response=True,
+            is_rollback=is_rollback,
         )
 
     def release_resources_by_id(self, id_list=None):
@@ -3581,17 +3649,17 @@ class DcnmVrf:
         # likely ever only have one resulting list.
         id_list_of_lists = self.get_list_of_lists([str(x) for x in id_list], 512)
 
-        for id_list in id_list_of_lists:
+        for item in id_list_of_lists:
             msg = "Releasing resource IDs: "
-            msg += f"{','.join(id_list)}"
+            msg += f"{','.join(item)}"
             self.log.debug(msg)
 
             action = "deploy"
             path = "/appcenter/cisco/ndfc/api/v1/lan-fabric"
             path += "/rest/resource-manager/resources"
-            path += f"?id={','.join(id_list)}"
+            path += f"?id={','.join(item)}"
             verb = "DELETE"
-            self.send_to_controller(action, verb, path, None)
+            self.send_to_controller(action, verb, path, None, log_response=False)
 
     def release_orphaned_resources(self, vrf, is_rollback=False):
         """
@@ -4114,8 +4182,10 @@ class DcnmVrf:
                 )
                 res.update({"DATA": data})
 
+        # pylint: disable=protected-access
         if self.module._verbosity >= 5:
             self.module.fail_json(msg=res)
+        # pylint: enable=protected-access
 
         self.module.fail_json(msg=res)
 

--- a/tests/integration/targets/dcnm_vrf/tests/dcnm/merged.yaml
+++ b/tests/integration/targets/dcnm_vrf/tests/dcnm/merged.yaml
@@ -61,7 +61,7 @@
 
 - assert:
     that:
-    - 'result.response.DATA != None'
+    - result.response.DATA != None
 
 - name: SETUP.2 - MERGED - [deleted] Delete all VRFs
   cisco.dcnm.dcnm_vrf:
@@ -113,17 +113,17 @@
 
 - assert:
     that:
-    - 'result_1.changed == true'
-    - 'result_1.response[0].RETURN_CODE == 200'
-    - 'result_1.response[1].RETURN_CODE == 200'
-    - 'result_1.response[2].RETURN_CODE == 200'
-    - '(result_1.response[1].DATA|dict2items)[0].value == "SUCCESS"'
-    - '(result_1.response[1].DATA|dict2items)[1].value == "SUCCESS"'
-    - 'result_1.diff[0].attach[0].deploy == true'
-    - 'result_1.diff[0].attach[1].deploy == true'
-    - '"{{ switch_1 }}" in result_1.diff[0].attach[0].ip_address'
-    - '"{{ switch_2 }}" in result_1.diff[0].attach[1].ip_address'
-    - 'result_1.diff[0].vrf_name == "ansible-vrf-int1"'
+    - result_1.changed == true
+    - result_1.response[0].RETURN_CODE == 200
+    - result_1.response[1].RETURN_CODE == 200
+    - result_1.response[2].RETURN_CODE == 200
+    - (result_1.response[1].DATA|dict2items)[0].value == "SUCCESS"
+    - (result_1.response[1].DATA|dict2items)[1].value == "SUCCESS"
+    - result_1.diff[0].attach[0].deploy == true
+    - result_1.diff[0].attach[1].deploy == true
+    - switch_1 in result_1.diff[0].attach[0].ip_address
+    - switch_2 in result_1.diff[0].attach[1].ip_address
+    - result_1.diff[0].vrf_name == "ansible-vrf-int1"
 
 - name: TEST.1c - MERGED - [merged] conf1 - Idempotence
   cisco.dcnm.dcnm_vrf: *conf1
@@ -135,8 +135,8 @@
 
 - assert:
     that:
-    - 'result_1c.changed == false'
-    - 'result_1c.response|length == 0'
+    - result_1c.changed == false
+    - result_1c.response|length == 0
 
 - name: TEST.1e - MERGED - [deleted] Delete all VRFs
   cisco.dcnm.dcnm_vrf:
@@ -183,17 +183,17 @@
 
 - assert:
     that:
-    - 'result_2.changed == true'
-    - 'result_2.response[0].RETURN_CODE == 200'
-    - 'result_2.response[1].RETURN_CODE == 200'
-    - 'result_2.response[2].RETURN_CODE == 200'
-    - '(result_2.response[1].DATA|dict2items)[0].value == "SUCCESS"'
-    - '(result_2.response[1].DATA|dict2items)[1].value == "SUCCESS"'
-    - 'result_2.diff[0].attach[0].deploy == true'
-    - 'result_2.diff[0].attach[1].deploy == true'
-    - '"{{ switch_1 }}" in result_2.diff[0].attach[0].ip_address'
-    - '"{{ switch_2 }}" in result_2.diff[0].attach[1].ip_address'
-    - 'result_2.diff[0].vrf_name == "ansible-vrf-int1"'
+    - result_2.changed == true
+    - result_2.response[0].RETURN_CODE == 200
+    - result_2.response[1].RETURN_CODE == 200
+    - result_2.response[2].RETURN_CODE == 200
+    - (result_2.response[1].DATA|dict2items)[0].value == "SUCCESS"
+    - (result_2.response[1].DATA|dict2items)[1].value == "SUCCESS"
+    - result_2.diff[0].attach[0].deploy == true
+    - result_2.diff[0].attach[1].deploy == true
+    - switch_1 in result_2.diff[0].attach[0].ip_address
+    - switch_2 in result_2.diff[0].attach[1].ip_address
+    - result_2.diff[0].vrf_name == "ansible-vrf-int1"
 
 - name: TEST.2c - MERGED - [merged] conf2 - Idempotence
   cisco.dcnm.dcnm_vrf: *conf2
@@ -205,8 +205,8 @@
 
 - assert:
     that:
-    - 'result_2c.changed == false'
-    - 'result_2c.response|length == 0'
+    - result_2c.changed == false
+    - result_2c.response|length == 0
 
 - name: TEST.2e - MERGED - [deleted] Delete all VRFs
   cisco.dcnm.dcnm_vrf:
@@ -259,17 +259,17 @@
 
 - assert:
     that:
-    - 'result_3.changed == true'
-    - 'result_3.response[0].RETURN_CODE == 200'
-    - 'result_3.response[1].RETURN_CODE == 200'
-    - 'result_3.response[2].RETURN_CODE == 200'
-    - '(result_3.response[1].DATA|dict2items)[0].value == "SUCCESS"'
-    - '(result_3.response[1].DATA|dict2items)[1].value == "SUCCESS"'
-    - 'result_3.diff[0].attach[0].deploy == true'
-    - 'result_3.diff[0].attach[1].deploy == true'
-    - '"{{ switch_1 }}" in result_3.diff[0].attach[0].ip_address'
-    - '"{{ switch_2 }}" in result_3.diff[0].attach[1].ip_address'
-    - 'result_3.diff[0].vrf_name == "ansible-vrf-int1"'
+    - result_3.changed == true
+    - result_3.response[0].RETURN_CODE == 200
+    - result_3.response[1].RETURN_CODE == 200
+    - result_3.response[2].RETURN_CODE == 200
+    - (result_3.response[1].DATA|dict2items)[0].value == "SUCCESS"
+    - (result_3.response[1].DATA|dict2items)[1].value == "SUCCESS"
+    - result_3.diff[0].attach[0].deploy == true
+    - result_3.diff[0].attach[1].deploy == true
+    - switch_1 in result_3.diff[0].attach[0].ip_address
+    - switch_2 in result_3.diff[0].attach[1].ip_address
+    - result_3.diff[0].vrf_name == "ansible-vrf-int1"
 
 - name: TEST.3c - MERGED - [merged] conf3 - Idempotence
   cisco.dcnm.dcnm_vrf: *conf3
@@ -281,8 +281,8 @@
 
 - assert:
     that:
-    - 'result_3c.changed == false'
-    - 'result_3c.response|length == 0'
+    - result_3c.changed == false
+    - result_3c.response|length == 0
 
 - name: TEST.3e - MERGED - [deleted] Delete all VRFs
   cisco.dcnm.dcnm_vrf:
@@ -330,17 +330,17 @@
 
 - assert:
     that:
-    - 'result_4.changed == true'
-    - 'result_4.response[0].RETURN_CODE == 200'
-    - 'result_4.response[1].RETURN_CODE == 200'
-    - 'result_4.response[2].RETURN_CODE == 200'
-    - '(result_4.response[1].DATA|dict2items)[0].value == "SUCCESS"'
-    - '(result_4.response[1].DATA|dict2items)[1].value == "SUCCESS"'
-    - 'result_4.diff[0].attach[0].deploy == true'
-    - 'result_4.diff[0].attach[1].deploy == true'
-    - '"{{ switch_1 }}" in result_4.diff[0].attach[0].ip_address'
-    - '"{{ switch_2 }}" in result_4.diff[0].attach[1].ip_address'
-    - 'result_4.diff[0].vrf_name == "ansible-vrf-int1"'
+    - result_4.changed == true
+    - result_4.response[0].RETURN_CODE == 200
+    - result_4.response[1].RETURN_CODE == 200
+    - result_4.response[2].RETURN_CODE == 200
+    - (result_4.response[1].DATA|dict2items)[0].value == "SUCCESS"
+    - (result_4.response[1].DATA|dict2items)[1].value == "SUCCESS"
+    - result_4.diff[0].attach[0].deploy == true
+    - result_4.diff[0].attach[1].deploy == true
+    - switch_1 in result_4.diff[0].attach[0].ip_address
+    - switch_2 in result_4.diff[0].attach[1].ip_address
+    - result_4.diff[0].vrf_name == "ansible-vrf-int1"
 
 - name: TEST.5 - MERGED - [merged] Create, Attach, Deploy VRF - Update with incorrect VRF ID.
   cisco.dcnm.dcnm_vrf:
@@ -362,10 +362,14 @@
   ansible.builtin.debug:
     var: result_5
 
+- name: set fact
+  set_fact:
+    TEST_PHRASE: "cannot be updated to a different value"
+
 - assert:
     that:
-    - 'result_5.changed == false'
-    - '"cannot be updated to a different value" in result_5.msg'
+    - result_5.changed == false
+    - TEST_PHRASE in result_5.msg
 
 - name: TEST.6 - MERGED - [merged] Create, Attach, Deploy VRF - Update with Out of Range VRF ID.
   cisco.dcnm.dcnm_vrf:
@@ -387,10 +391,14 @@
   ansible.builtin.debug:
     var: result_6
 
+- name: set fact
+  set_fact:
+    TEST_PHRASE: "The item exceeds the allowed range of max"
+
 - assert:
     that:
-    - 'result_6.changed == false'
-    - '"The item exceeds the allowed range of max" in result_6.msg'
+    - result_6.changed == false
+    - TEST_PHRASE in result_6.msg
 
 - name: TEST.7 - MERGED - [merged] Create, Attach, Deploy VRF - VRF LITE missing required parameter
   cisco.dcnm.dcnm_vrf:
@@ -415,10 +423,14 @@
   ansible.builtin.debug:
     var: result_7
 
+- name: set fact
+  set_fact:
+    TEST_PHRASE: "Invalid parameters in playbook: interface : Required parameter not found"
+
 - assert:
     that:
-    - 'result_7.changed == false'
-    - '"Invalid parameters in playbook: interface : Required parameter not found" in result_7.msg'
+    - result_7.changed == false
+    - TEST_PHRASE in result_7.msg
 
 - name: TEST.8 - MERGED - [merged] Create, Attach and Deploy VRF - configure VRF LITE on non border switch
   cisco.dcnm.dcnm_vrf:
@@ -448,10 +460,14 @@
   ansible.builtin.debug:
     var: result_8
 
+- name: set fact
+  set_fact:
+    TEST_PHRASE: "VRF LITE attachments are appropriate only for switches with Border roles"
+
 - assert:
     that:
-    - 'result_8.changed == false'
-    - '"VRF LITE cannot be attached to switch" in result_8.msg'
+    - result_8.changed == false
+    - TEST_PHRASE in result_8.msg
 
 ###############################################
 ###                 CLEAN-UP                 ##


### PR DESCRIPTION
# Summary

This PR for `dcnm_vrf` includes the following:

1. Modifies method `send_to_controller()` to add a parameter `log_response` that controls whether the controller response is added to the Ansible playbook result output.  This allows us to suppress results that would not be of interest to the user.
2. Simplifies a conditional in `get_have()`
3. Fixes a pylint error in `release_resources_by_id()`
4. Cleans up the merged integration test
5. Adds an `__init__.py` file to appease pylint

## Detail

1. plugins/modules/dcnm.vrf

- send_to_controller()

Add a log_response parameter which controls whether the controller response will be added to the ansible response.

- get_have() - simplify conditional

attach_state = False if attach["lanAttachState"] == "NA" else True

Changed to:

attach_state = not attach["isLanAttached"] == "NA"

- release_resources_by_id()

Fix pylint error (id_list was being redefined in the for loop, so renamed to item).

- failure(): disable pylint check for protected-access

2. tests/integration/targets/dcnm_vrf/tests/dcnm/merged.yaml

There are no functional changes here.  We've only done the following:

- Remove single-quotes from all asserts
- Remove jinja2 templating around variables in asserts (these generate warnings and are not needed).
- Removing the single-quotes broke asserts of the following form:

- "test phrase" in var

To fix this, added set fact for "test phrase" like so:

```yaml
- name: set fact
  set_fact: TEST_PHRASE: "test phrase"

- assert:
  that:
    - TEST_PHRASE in var
```

6. plugins/__init__.py

- Added to appease pylint