### PR TITLE
Add support dot1q tunnel host on dcnm_interface

### DIFF
--- a/docs/cisco.dcnm.dcnm_interface_module.rst
+++ b/docs/cisco.dcnm.dcnm_interface_module.rst
@@ -390,7 +390,7 @@ Parameters
                         <b>Default:</b><br/><div style="color: blue">""</div>
                 </td>
                 <td>
-                        <div>Vlan for the interface. This option is applicable only for interfaces whose &#x27;mode&#x27; is &#x27;access&#x27; or &#x27;dot1q_tunnel_host&#x27;</div>
+                        <div>Vlan for the interface. This option is applicable only for interfaces whose &#x27;mode&#x27; is &#x27;access&#x27; or &#x27;dot1q&#x27;</div>
                 </td>
             </tr>
             <tr>
@@ -606,7 +606,7 @@ Parameters
                                     <li>routed</li>
                                     <li>monitor</li>
                                     <li>epl_routed</li>
-                                    <li>dot1q_tunnel_host</li>
+                                    <li>dot1q</li>
                         </ul>
                 </td>
                 <td>
@@ -916,7 +916,7 @@ Parameters
                         <b>Default:</b><br/><div style="color: blue">""</div>
                 </td>
                 <td>
-                        <div>Vlan for the interface. This option is applicable only for interfaces whose &#x27;mode&#x27; is &#x27;access&#x27;</div>
+                        <div>Vlan for the interface. This option is applicable only for interfaces whose &#x27;mode&#x27; is &#x27;access&#x27; or &#x27;dot1q&#x27;</div>
                 </td>
             </tr>
             <tr>
@@ -1068,6 +1068,7 @@ Parameters
                                     <li>trunk</li>
                                     <li>access</li>
                                     <li>l3</li>
+                                    <li>dot1q</li>
                                     <li>monitor</li>
                         </ul>
                 </td>
@@ -3344,7 +3345,7 @@ Examples
 
     # Dot1q Tunnel host
 
-    - name: Configure dot1q_tunnel_host on interface E1/12
+    - name: Configure dot1q on interface E1/12
       cisco.dcnm.dcnm_interface:
         fabric: "{{ ansible_fabric }}"
         state: merged
@@ -3356,7 +3357,7 @@ Examples
             deploy: true
             profile:
             admin_state: true
-            mode: dot1q_tunnel_host
+            mode: dot1q
             access_vlan: 41
             description: "ETH 1/12 Dot1q Tunnel"
 

--- a/docs/cisco.dcnm.dcnm_interface_module.rst
+++ b/docs/cisco.dcnm.dcnm_interface_module.rst
@@ -390,7 +390,7 @@ Parameters
                         <b>Default:</b><br/><div style="color: blue">""</div>
                 </td>
                 <td>
-                        <div>Vlan for the interface. This option is applicable only for interfaces whose &#x27;mode&#x27; is &#x27;access&#x27;</div>
+                        <div>Vlan for the interface. This option is applicable only for interfaces whose &#x27;mode&#x27; is &#x27;access&#x27; or &#x27;dot1q_tunnel_host&#x27;</div>
                 </td>
             </tr>
             <tr>
@@ -606,6 +606,7 @@ Parameters
                                     <li>routed</li>
                                     <li>monitor</li>
                                     <li>epl_routed</li>
+                                    <li>dot1q_tunnel_host</li>
                         </ul>
                 </td>
                 <td>
@@ -3340,6 +3341,24 @@ Examples
               admin_state: true                         # Flag to enable/disable FEX interface.
               enable_netflow: false                     # optional, flag to enable netflow, default is false
               mode: port_channel_st                     # choose from [port_channel_st], default is "port_channel_st"
+
+    # Dot1q Tunnel host
+
+    - name: Configure dot1q_tunnel_host on interface E1/12
+      cisco.dcnm.dcnm_interface:
+        fabric: "{{ ansible_fabric }}"
+        state: merged
+        config:
+          - name: eth1/12
+            type: eth
+            switch:
+              - "{{ ansible_switch1 }}"
+            deploy: true
+            profile:
+            admin_state: true
+            mode: dot1q_tunnel_host
+            access_vlan: 41
+            description: "ETH 1/12 Dot1q Tunnel"
 
     # QUERY
 

--- a/plugins/action/tests/unit/ndfc_pc_members_validate.py
+++ b/plugins/action/tests/unit/ndfc_pc_members_validate.py
@@ -27,6 +27,8 @@ class ActionModule(ActionBase):
         expected_state['pc_access_member_description'] = test_data['eth_access_desc']
         expected_state['pc_l3_description'] = test_data['pc_l3_desc']
         expected_state['pc_l3_member_description'] = test_data['eth_l3_desc']
+        expected_state['pc_dot1q_description'] = test_data['pc_dot1q_desc']
+        expected_state['pc_dot1q_member_description'] = test_data['eth_dot1q_desc']
         # --
         expected_state['pc_trunk_host_policy'] = 'int_port_channel_trunk_host'
         expected_state['pc_trunk_member_policy'] = 'int_port_channel_trunk_member_11_1'
@@ -36,10 +38,14 @@ class ActionModule(ActionBase):
         # --
         expected_state['pc_l3_policy'] = 'int_l3_port_channel'
         expected_state['pc_l3_member_policy'] = 'int_l3_port_channel_member'
+        # --
+        expected_state['pc_dot1q_policy'] = 'int_port_channel_dot1q_tunnel_host'
+        expected_state['pc_dot1q_member_policy'] = 'int_port_channel_dot1q_tunnel_member_11_1'
 
         interface_list = [test_data['pc1'], test_data['eth_intf8'], test_data['eth_intf9'],
                           test_data['pc2'], test_data['eth_intf10'], test_data['eth_intf11'],
-                          test_data['pc3'], test_data['eth_intf12'], test_data['eth_intf13']]
+                          test_data['pc3'], test_data['eth_intf12'], test_data['eth_intf13'],
+                          test_data['pc4'], test_data['eth_intf14'], test_data['eth_intf15']]
 
         if len(ndfc_data['response']) == 0:
             results['failed'] = True
@@ -115,6 +121,25 @@ class ActionModule(ActionBase):
                 if ndfc_data_dict[interface]['nvPairs']['DESC'] != expected_state['pc_l3_member_description']:
                     results['failed'] = True
                     results['msg'] = f'Interface {interface} description is not {expected_state["pc_l3_member_description"]}'
+                    return results
+
+            if interface == test_data['pc4']:
+                if ndfc_data_dict[interface]['policy'] != expected_state['pc_dot1q_policy']:
+                    results['failed'] = True
+                    results['msg'] = f'Interface {interface} policy is not {expected_state["pc_dot1q_policy"]}'
+                    return results
+                if ndfc_data_dict[interface]['nvPairs']['DESC'] != expected_state['pc_dot1q_description']:
+                    results['failed'] = True
+                    results['msg'] = f'Interface {interface} description is not {expected_state["pc_dot1q_description"]}'
+                    return results
+            if interface == test_data['eth_intf14'] or interface == test_data['eth_intf15']:
+                if ndfc_data_dict[interface]['policy'] != expected_state['pc_dot1q_member_policy']:
+                    results['failed'] = True
+                    results['msg'] = f'Interface {interface} policy is not {expected_state["pc_dot1q_member_policy"]}'
+                    return results
+                if ndfc_data_dict[interface]['nvPairs']['DESC'] != expected_state['pc_dot1q_member_description']:
+                    results['failed'] = True
+                    results['msg'] = f'Interface {interface} description is not {expected_state["pc_dot1q_member_description"]}'
                     return results
 
         return results

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -113,7 +113,7 @@ options:
           mode:
             description:
             - Interface mode
-            choices: ['trunk', 'access', 'l3', 'monitor']
+            choices: ['trunk', 'access', 'l3', 'dot1q', 'monitor']
             type: str
             required: true
           members:
@@ -124,7 +124,7 @@ options:
             required: true
           access_vlan:
             description:
-            - Vlan for the interface. This option is applicable only for interfaces whose 'mode' is 'access'
+            - Vlan for the interface. This option is applicable only for interfaces whose 'mode' is 'access' or 'dot1q'
             type: str
             default: ""
           int_vrf:

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -1582,21 +1582,21 @@ EXAMPLES = """
 
 # Dot1q Tunnel host
 
-  - name: Configure dot1q_tunnel_host on interface E1/12
-    cisco.dcnm.dcnm_interface:
-      fabric: "{{ ansible_fabric }}"
-      state: merged
-      config:
-        - name: eth1/12
-          type: eth
-          switch:
-            - "{{ ansible_switch1 }}"
-          deploy: true
-          profile:
-            admin_state: true
-            mode: dot1q_tunnel_host
-            access_vlan: 41
-            description: "ETH 1/12 Dot1q Tunnel"
+- name: Configure dot1q_tunnel_host on interface E1/12
+  cisco.dcnm.dcnm_interface:
+    fabric: "{{ ansible_fabric }}"
+    state: merged
+    config:
+      - name: eth1/12
+        type: eth
+        switch:
+          - "{{ ansible_switch1 }}"
+        deploy: true
+        profile:
+        admin_state: true
+        mode: dot1q_tunnel_host
+        access_vlan: 41
+        description: "ETH 1/12 Dot1q Tunnel"
 
 # QUERY
 
@@ -2345,7 +2345,7 @@ class DcnmIntf:
             description=dict(type="str", default=""),
             admin_state=dict(type="bool", default=True),
         )
-        
+
         if "trunk" == cfg[0]["profile"]["mode"]:
             self.dcnm_intf_validate_interface_input(
                 cfg, eth_spec, eth_prof_spec_trunk
@@ -2368,7 +2368,7 @@ class DcnmIntf:
             self.dcnm_intf_validate_interface_input(
                 cfg, eth_spec, eth_prof_spec_dot1q_tunnel_host
             )
-    
+
     def dcnm_intf_validate_vlan_interface_input(self, cfg):
 
         svi_spec = dict(

--- a/tests/integration/targets/ndfc_interface/templates/ndfc_pc_create.j2
+++ b/tests/integration/targets/ndfc_interface/templates/ndfc_pc_create.j2
@@ -74,3 +74,26 @@
     cmds:
       - no shutdown
     description: "{{ test_data.pc_l3_desc }}"
+
+# ------------------------------
+# DOT1Q PortChannel
+# ------------------------------
+- name: "{{ test_data.pc4 }}"
+  deploy: false
+  type: pc
+  switch:
+    - "{{ test_data.sw1 }}"
+  profile:
+    admin_state: true
+    mode: dot1q
+    members:
+      - "{{ test_data.eth_intf14 }}"
+      - "{{ test_data.eth_intf15 }}"
+    pc_mode: 'on'
+    ipv4_addr: 192.168.20.1
+    ipv4_mask_len: 24
+    mtu: jumbo
+    allowed_vlans: none
+    cmds:
+      - no shutdown
+    description: "{{ test_data.pc_dot1q_desc }}"

--- a/tests/integration/targets/ndfc_interface/templates/ndfc_pc_interfaces.j2
+++ b/tests/integration/targets/ndfc_interface/templates/ndfc_pc_interfaces.j2
@@ -32,3 +32,13 @@
 - name: "{{ test_data.eth_intf13 }}"
   switch:
     - "{{ test_data.sw1 }}"
+# ------------------------------
+- name: "{{ test_data.pc4 }}"
+  switch:
+    - "{{ test_data.sw1 }}"
+- name: "{{ test_data.eth_intf14 }}"
+  switch:
+    - "{{ test_data.sw1 }}"
+- name: "{{ test_data.eth_intf15 }}"
+  switch:
+    - "{{ test_data.sw1 }}"

--- a/tests/integration/targets/ndfc_interface/templates/ndfc_pc_members.j2
+++ b/tests/integration/targets/ndfc_interface/templates/ndfc_pc_members.j2
@@ -93,3 +93,35 @@
     cmds:
       - no shutdown
     description: "{{ test_data.eth_l3_desc }}"
+
+# ------------------------------
+# DOT1Q Tunnel Members
+# ------------------------------
+- name: "{{ test_data.eth_intf14 }}"
+  deploy: false
+  type: eth
+  switch:
+    - "{{ test_data.sw1 }}"
+  profile:
+    admin_state: true
+    mode: dot1q
+    access_vlan: 41
+    cmds: |
+      no lldp transmit
+      no lldp receive
+      no cdp enable
+    description: "{{ test_data.eth_dot1q_desc }}"
+- name: "{{ test_data.eth_intf15 }}"
+  deploy: false
+  type: eth
+  switch:
+    - "{{ test_data.sw1 }}"
+  profile:
+    admin_state: true
+    mode: dot1q
+    access_vlan: 42
+    cmds: |
+      no lldp transmit
+      no lldp receive
+      no cdp enable
+    description: "{{ test_data.eth_dot1q_desc }}"

--- a/tests/integration/targets/ndfc_interface/tests/ndfc_pc_members.yaml
+++ b/tests/integration/targets/ndfc_interface/tests/ndfc_pc_members.yaml
@@ -16,6 +16,7 @@
       pc1: "{{ port_channel_1 }}"
       pc2: "{{ port_channel_2 }}"
       pc3: "{{ port_channel_3 }}"
+      pc4: "{{ port_channel_4 }}"
       sw1: "{{ ansible_switch1 }}"
       sw2: "{{ ansible_switch2 }}"
       eth_intf8: "{{ ansible_eth_intf8 }}"
@@ -24,12 +25,16 @@
       eth_intf11: "{{ ansible_eth_intf11 }}"
       eth_intf12: "{{ ansible_eth_intf12 }}"
       eth_intf13: "{{ ansible_eth_intf13 }}"
+      eth_intf14: "{{ ansible_eth_intf14 }}"
+      eth_intf15: "{{ ansible_eth_intf15 }}"
       pc_trunk_desc: "Trunk PC Configured by Ansible"
       pc_access_desc: "Access PC Configured by Ansible"
       pc_l3_desc: "L3 PC Configured by Ansible"
+      pc_dot1q_desc: "DOT1Q PC Configured by Ansible"
       eth_trunk_desc: "Trunk Member Configured by Ansible"
       eth_access_desc: "Access Member Configured by Ansible"
       eth_l3_desc: "L3 Member Configured by Ansible"
+      eth_dot1q_desc: "DOT1Q Member Configured by Ansible"
   delegate_to: localhost
 
 # ----------------------------------------------


### PR DESCRIPTION
Fix #350 
Add support Dot1q tunnel host

```
    - name: Configure E1/12 interfaces
      cisco.dcnm.dcnm_interface:
        fabric: nac-ndfc3
        state: replaced
        config:
          - name: eth1/14
            type: eth
            switch:
              - 10.229.42.82
            deploy: true
            profile:
              admin_state: true
              mode: dot1q_tunnel_host
              access_vlan: 46
              # mode: access
              description: "test dot1q tunnel host"
              cmds: |
                no lldp transmit
                no lldp receive
                no cdp enable
```

```
changed: [nac-ndfc3] => {
    "changed": true,
    "diff": [
        {
            "debugs": [],
            "deferred": [],
            "delete_deploy": [],
            "deleted": [],
            "deploy": [
                {
                    "fabricName": "nac-ndfc3",
                    "ifName": "Ethernet1/14",
                    "serialNumber": "9XANRS8T83Y"
                }
            ],
            "merged": [],
            "overridden": [],
            "query": [],
            "replaced": [
                {
                    "interfaceType": "INTERFACE_ETHERNET",
                    "interfaces": [
                        {
                            "fabricName": "nac-ndfc3",
                            "ifName": "Ethernet1/14",
                            "interfaceType": "INTERFACE_ETHERNET",
                            "nvPairs": {
                                "ACCESS_VLAN": "46",
                                "ADMIN_STATE": "true",
                                "BPDUGUARD_ENABLED": "true",
                                "CONF": "no lldp transmit\nno lldp receive\nno cdp enable",
                                "DESC": "test dot1q tunnel host",
                                "INTF_NAME": "Ethernet1/14",
                                "MTU": "jumbo",
                                "PORTTYPE_FAST_ENABLED": "true",
                                "SPEED": "Auto"
                            },
                            "serialNumber": "9XANRS8T83Y"
                        }
                    ],
                    "policy": "int_dot1q_tunnel_host"
                }
            ],
            "skipped": []
        }
    ],
    "invocation": {
        "module_args": {
            "check_deploy": false,
            "config": [
                {
                    "deploy": true,
                    "name": "eth1/14",
                    "profile": {
                        "access_vlan": 46,
                        "admin_state": true,
                        "cmds": "no lldp transmit\nno lldp receive\nno cdp enable",
                        "description": "test dot1q tunnel host",
                        "mode": "dot1q_tunnel_host"
                    },
                    "switch": [
                        "10.229.42.82"
                    ],
                    "type": "eth"
                }
            ],
            "deploy": true,
            "fabric": "nac-ndfc3",
            "override_intf_types": [],
            "state": "replaced"
        }
    },
    "response": [
        {
            "DATA": {},
            "MESSAGE": "OK",
            "METHOD": "PUT",
            "REQUEST_PATH": "https://10.60.3.55:443/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/interface",
            "RETURN_CODE": 200
        },
        {
            "DATA": {
                "message": "Interface deployed successfully",
                "value": [
                    {
                        "IfName": "Ethernet1/14",
                        "serialNumber": "9XANRS8T83Y"
                    }
                ]
            },
            "MESSAGE": "OK",
            "METHOD": "POST",
            "REQUEST_PATH": "https://10.60.3.55:443/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface/deploy",
            "RETURN_CODE": 200
        }
    ]
}

![image](https://github.com/user-attachments/assets/5c920dae-fbd3-4095-9142-4966adce2cc0)

![image](https://github.com/user-attachments/assets/a023b4ee-e8b1-4333-8b44-a3b9fd0ff6d9)


```