### PR TITLE
dcnm_vrf: get_want(): Fix key used to determine attach_state

### DIFF
--- a/plugins/modules/dcnm_vrf.py
+++ b/plugins/modules/dcnm_vrf.py
@@ -1646,7 +1646,7 @@ class DcnmVrf:
             attach_list = vrf_attach["lanAttachList"]
             deploy_vrf = ""
             for attach in attach_list:
-                attach_state = not attach["isLanAttached"] == "NA"
+                attach_state = not attach["lanAttachState"] == "NA"
                 deploy = attach["isLanAttached"]
                 deployed = False
                 if deploy and (


### PR DESCRIPTION
# Summary

In an earlier commit (873da75a), the following line in `get_want()` was changed to simplify the logic, but the key being used (`lanAttachState`) was also changed to (`isLanAttached`), which broke proper determination of lanAttachState and caused the replace-state integration test to fail.

This PR reverts the key back to `lanAttachState`, but retains the new logic (which I've tested against the original logic with a test script to verify that they both return the same result).

## Original line (pre-problematic-commit):

```python
attach_state = False if attach["lanAttachState"] == "NA" else True
```

## Problematic commit

```python
attach_state = not attach["isLanAttached"] == "NA"
```

## Fixed line

```python
attach_state = not attach["lanAttachState"] == "NA"
```
