### PR TITLE
Add breakout interface

### DIFF
--- a/docs/cisco.dcnm.dcnm_interface_module.rst
+++ b/docs/cisco.dcnm.dcnm_interface_module.rst
@@ -3494,10 +3494,6 @@ Examples
             deploy: true
             profile:
               map: 10g-4x
-            admin_state: true
-            mode: dot1q
-            access_vlan: 41
-            description: "ETH 1/12 Dot1q Tunnel"
           - name: ethernet1/101
             type: breakout
             switch:

--- a/docs/cisco.dcnm.dcnm_interface_module.rst
+++ b/docs/cisco.dcnm.dcnm_interface_module.rst
@@ -362,6 +362,51 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>profile_breakout</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Though the key shown here is &#x27;profile_breakout&#x27; the actual key to be used in playbook is &#x27;profile&#x27;. The key &#x27;profile_breakout&#x27; is used here to logically segregate the interface objects applicable for this profile</div>
+                        <div>Interface must be parent interface. Ex: Ethernet1/49. Short name is not supported.</div>
+                </td>
+            </tr>
+                                <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>map</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>10g-4x</li>
+                                    <li>25g-4x</li>
+                                    <li>50g-2x</li>
+                                    <li>50g-4x</li>
+                                    <li>100g-2x</li>
+                                    <li>100g-4x</li>
+                                    <li>200g-2x</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>type of breakout</div>
+                </td>
+            </tr>
+
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>profile_eth</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -2516,6 +2561,7 @@ Parameters
                                     <li>svi</li>
                                     <li>st-fex</li>
                                     <li>aa-fex</li>
+                                    <li>breakout</li>
                         </ul>
                 </td>
                 <td>
@@ -2581,6 +2627,7 @@ Parameters
                                     <li>svi</li>
                                     <li>st_fex</li>
                                     <li>aa_fex</li>
+                                    <li>breakout</li>
                         </ul>
                         <b>Default:</b><br/><div style="color: blue">[]</div>
                 </td>
@@ -3432,6 +3479,57 @@ Examples
             mode: dot1q
             access_vlan: 41
             description: "ETH 1/12 Dot1q Tunnel"
+
+    # Breakout interfaces
+
+    - name: Configure breakout interface
+      cisco.dcnm.dcnm_interface:
+        fabric: "{{ ansible_svi_fabric }}"
+        state: merged
+        config:
+          - name: ethernet1/100
+            type: breakout
+            switch:
+              - "{{ ansible_switch1 }}"
+            deploy: true
+            profile:
+              map: 10g-4x
+            admin_state: true
+            mode: dot1q
+            access_vlan: 41
+            description: "ETH 1/12 Dot1q Tunnel"
+          - name: ethernet1/101
+            type: breakout
+            switch:
+              - "{{ ansible_switch1 }}"
+            deploy: true
+            profile:
+              map: 10g-4x
+          - name: ethernet1/102
+            type: breakout
+            switch:
+              - "{{ ansible_switch1 }}"
+            deploy: true
+            profile:
+              map: 10g-4x
+
+    - name: Configure breakout interface
+      cisco.dcnm.dcnm_interface:
+        fabric: "{{ ansible_svi_fabric }}"
+        state: deleted
+        config:
+          - name: ethernet1/100
+            type: breakout
+            switch:
+              - "{{ ansible_switch1 }}"
+          - name: ethernet1/101
+            type: breakout
+            switch:
+              - "{{ ansible_switch1 }}"
+          - name: ethernet1/102
+            type: breakout
+            switch:
+              - "{{ ansible_switch1 }}"
 
     # QUERY
 

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -4513,7 +4513,7 @@ class DcnmIntf:
                                 continue
                         if found is False:
                             payload = {"serialNumber": have['serialNo'],
-                                        "ifName": have["ifName"]}
+                                       "ifName": have["ifName"]}
                             self.diff_delete[
                                 self.int_index[self.int_types['breakout']]].append(payload)
                             self.changed_dict[0]["deleted"].append(

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -1647,11 +1647,11 @@ EXAMPLES = """
           - "{{ ansible_switch1 }}"
         deploy: true
         profile:
+          map: 10g-4x
         admin_state: true
         mode: dot1q
         access_vlan: 41
         description: "ETH 1/12 Dot1q Tunnel"
-          map: 10g-4x
       - name: ethernet1/101
         type: breakout
         switch:

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -2640,8 +2640,8 @@ class DcnmIntf:
 
         breakout_prof_spec = dict(
             map=dict(required=True, type="str",
-                default="",
-                choices=["10g-4x", "25g-4x", "50g-2x", "50g-4x", "100g-2x", "100g-4x", "200g-2x"]),
+                     default="",
+                     choices=["10g-4x", "25g-4x", "50g-2x", "50g-4x", "100g-2x", "100g-4x", "200g-2x"]),
         )
         self.dcnm_intf_validate_interface_input(cfg, breakout_spec, breakout_prof_spec)
 

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -4390,8 +4390,8 @@ class DcnmIntf:
 
         deploy = False
         self.diff_create = []
-        self.diff_delete = [[], [], [], [], [], [], [], []]
-        self.diff_delete_deploy = [[], [], [], [], [], [], [], []]
+        self.diff_delete = [[], [], [], [], [], [], [], [], []]
+        self.diff_delete_deploy = [[], [], [], [], [], [], [], [], []]
         self.diff_deploy = []
         self.diff_replace = []
 
@@ -4500,6 +4500,25 @@ class DcnmIntf:
                     self.dcnm_compare_default_payload(uelem, intf)
                     == "DCNM_INTF_MATCH"
                 ):
+                    # In case of breakout, check if parent interface is in cfg
+                    if re.findall(r"\d+\/\d+\/\d+", name):
+                        port_id = re.search(r"(\d+/\d+)/\d+", name)
+                        found = False
+                        for interface in cfg:
+                            intfmatch = "ethernet" + port_id.group(1)
+                            if intfmatch == interface['name'] and interface['type'] == 'breakout':
+                                # If parent interface is present in cfg, we keep interface breakout
+                                # Else we need to the interface to replace list and build payload.
+                                found = True
+                                continue
+                        if found is False:
+                            payload = {"serialNumber": have['serialNo'],
+                                        "ifName": have["ifName"]}
+                            self.diff_delete[
+                                self.int_index[self.int_types['breakout']]].append(payload)
+                            self.changed_dict[0]["deleted"].append(
+                                copy.deepcopy(payload)
+                            )
                     continue
 
                 if uelem is not None:

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -1648,10 +1648,6 @@ EXAMPLES = """
         deploy: true
         profile:
           map: 10g-4x
-        admin_state: true
-        mode: dot1q
-        access_vlan: 41
-        description: "ETH 1/12 Dot1q Tunnel"
       - name: ethernet1/101
         type: breakout
         switch:

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -2641,8 +2641,8 @@ class DcnmIntf:
 
         breakout_prof_spec = dict(
             map=dict(required=True, type="str",
-                default="",
-                choices=["10g-4x","25g-4x","50g-2x","50g-4x","100g-2x","100g-4x","200g-2x"]),
+            default="",
+            choices=["10g-4x", "25g-4x", "50g-2x", "50g-4x", "100g-2x", "100g-4x", "200g-2x"]),
         )
         self.dcnm_intf_validate_interface_input(cfg, breakout_spec, breakout_prof_spec)
 
@@ -4722,11 +4722,11 @@ class DcnmIntf:
                         # ]
                         if cfg['type'] == "breakout":
                             payload = {"serialNumber": self.ip_sn[sw],
-                                       "ifName": cfg["name"]+"/1"}
+                                       "ifName": cfg["name"] + "/1"}
                             if_type = cfg['type']
                             self.diff_delete[
-                                    self.int_index[self.int_types[cfg['type']]]
-                                ].append(payload)
+                                self.int_index[self.int_types[cfg['type']]]
+                            ].append(payload)
                             self.changed_dict[0]["deleted"].append(
                                 copy.deepcopy(payload)
                             )

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -813,10 +813,12 @@ options:
         - Interface must be parent interface. Ex: Ethernet1/49. Short name is not supported.
         suboptions:
           map:
+            description:
+            - type of breakout
             type: str
             required: true
             choices: ["10g-4x","25g-4x","50g-2x","50g-4x","100g-2x","100g-4x","200g-2x"]
-            default: []
+            default: ""
 """
 
 EXAMPLES = """
@@ -2068,7 +2070,7 @@ class DcnmIntf:
         if "breakout" == if_type:
             port_id = re.findall(r"\d+\/\d+", name)
             return ("Ethernet" + str(port_id[0]), port_id[0])
-    
+
     def dcnm_intf_get_vpc_serial_number(self, sw):
 
         path = self.paths["VPC_SNO"].format(self.ip_sn[sw])
@@ -5250,7 +5252,7 @@ class DcnmIntf:
                     breakout.pop("interfaceType")
                 json_payload = json.dumps(payload['interfaces'])
                 resp = dcnm_send(self.module, "POST", path, json_payload)
-            else: 
+            else:
                 json_payload = json.dumps(payload)
                 resp = dcnm_send(self.module, "PUT", path, json_payload)
 

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -1619,14 +1619,14 @@ EXAMPLES = """
 # Dot1q Tunnel host
 
 - name: Configure dot1q on interface E1/12
-    cisco.dcnm.dcnm_interface:
+  cisco.dcnm.dcnm_interface:
     fabric: "{{ ansible_fabric }}"
     state: merged
     config:
-        - name: eth1/12
+      - name: eth1/12
         type: eth
         switch:
-            - "{{ ansible_switch1 }}"
+          - "{{ ansible_switch1 }}"
         deploy: true
         profile:
         admin_state: true

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -97,7 +97,7 @@ options:
         - Interface type. Example, pc, vpc, sub_int, lo, eth, svi
         type: str
         required: true
-        choices: ['pc', 'vpc', 'sub_int', 'lo', 'eth', 'svi', 'st-fex', 'aa-fex', "breakout"]
+        choices: ['pc', 'vpc', 'sub_int', 'lo', 'eth', 'svi', 'st-fex', 'aa-fex', 'breakout']
       deploy:
         description:
         - Flag indicating if the configuration must be pushed to the switch. If not included
@@ -5556,6 +5556,7 @@ def main():
                 "svi",
                 "st_fex",
                 "aa_fex",
+                "breakout",
             ],
             default=[],
         ),

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -97,7 +97,7 @@ options:
         - Interface type. Example, pc, vpc, sub_int, lo, eth, svi
         type: str
         required: true
-        choices: ['pc', 'vpc', 'sub_int', 'lo', 'eth', 'svi', 'st-fex', 'aa-fex']
+        choices: ['pc', 'vpc', 'sub_int', 'lo', 'eth', 'svi', 'st-fex', 'aa-fex', "breakout"]
       deploy:
         description:
         - Flag indicating if the configuration must be pushed to the switch. If not included
@@ -817,8 +817,7 @@ options:
             - type of breakout
             type: str
             required: true
-            choices: ["10g-4x","25g-4x","50g-2x","50g-4x","100g-2x","100g-4x","200g-2x"]
-            default: ""
+            choices: ["10g-4x", "25g-4x", "50g-2x", "50g-4x", "100g-2x", "100g-4x", "200g-2x"]
 """
 
 EXAMPLES = """
@@ -2641,8 +2640,8 @@ class DcnmIntf:
 
         breakout_prof_spec = dict(
             map=dict(required=True, type="str",
-            default="",
-            choices=["10g-4x", "25g-4x", "50g-2x", "50g-4x", "100g-2x", "100g-4x", "200g-2x"]),
+                default="",
+                choices=["10g-4x", "25g-4x", "50g-2x", "50g-4x", "100g-2x", "100g-4x", "200g-2x"]),
         )
         self.dcnm_intf_validate_interface_input(cfg, breakout_spec, breakout_prof_spec)
 

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -810,7 +810,7 @@ options:
         - Though the key shown here is 'profile_breakout' the actual key to be used in playbook
           is 'profile'. The key 'profile_breakout' is used here to logically segregate the interface
           objects applicable for this profile
-        - Interface must be parent interface. Ex: Ethernet1/49. Short name is not supported.
+        - "Interface must be parent interface. Ex: Ethernet1/49. Short name is not supported."
         suboptions:
           map:
             description:

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -4719,17 +4719,18 @@ class DcnmIntf:
                         #         "ifName": "Ethernet1/100/1"
                         #     }
                         # ]
-                        if cfg['type'] == "breakout":
-                            payload = {"serialNumber": self.ip_sn[sw],
-                                       "ifName": cfg["name"] + "/1"}
-                            if_type = cfg['type']
-                            self.diff_delete[
-                                self.int_index[self.int_types[cfg['type']]]
-                            ].append(payload)
-                            self.changed_dict[0]["deleted"].append(
-                                copy.deepcopy(payload)
-                            )
-                            continue
+                        if cfg.get("type", None) is not None:
+                            if cfg['type'] == "breakout":
+                                payload = {"serialNumber": self.ip_sn[sw],
+                                           "ifName": cfg["name"] + "/1"}
+                                if_type = cfg['type']
+                                self.diff_delete[
+                                    self.int_index[self.int_types[cfg['type']]]
+                                ].append(payload)
+                                self.changed_dict[0]["deleted"].append(
+                                    copy.deepcopy(payload)
+                                )
+                                continue
                         if_name, if_type = self.dcnm_extract_if_name(cfg)
 
                         # Check if the interface is present in DCNM


### PR DESCRIPTION
add code for merge and delete breakout interface

```
   - name: Configure breakout interface
      tags: cr_breakout
      cisco.dcnm.dcnm_interface:
        fabric: "{{ fab }}"
        state: merged
        config:
          - name: ethernet1/100
            type: breakout
            switch:
              - "{{ switch }}"
            deploy: true
            profile:
              map: 10g-4x
          - name: ethernet1/101
            type: breakout
            switch:
              - "{{ switch }}"
            deploy: true
            profile:
              map: 10g-4x
          - name: ethernet1/102
            type: breakout
            switch:
              - "{{ switch }}"
            deploy: true
            profile:
              map: 10g-4x
          - name: ethernet1/102/1
            type: eth
            switch:
              - "{{ switch }}"
            deploy: true
            profile:
              mode: access
              description: "TEST breakout merged e1/102/1"
          - name: ethernet1/102/4
            type: eth
            switch:
              - "{{ switch }}"
            deploy: true
            profile:
              mode: access
              description: "TEST breakout merged e1/102/4"

    - name: Configure breakout interface
      tags: rm_breakout
      cisco.dcnm.dcnm_interface:
        fabric: "{{ fab }}"
        state: deleted
        config:
          - name: ethernet1/100
            type: breakout
            switch:
              - "{{ switch }}"
          - name: ethernet1/101
            type: breakout
            switch:
              - "{{ switch }}"
          - name: ethernet1/102
            type: breakout
            switch:
              - "{{ switch }}"
```