### PR TITLE
Fix for Issue #80 "dcnm_network requires ports attribute when attaching to switch"

### DIFF
--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -2605,7 +2605,7 @@ class DcnmNetwork:
             )
             att_spec = dict(
                 ip_address=dict(required=True, type="str"),
-                ports=dict(required=True, type="list", default=[]),
+                ports=dict(type="list", default=[]),
                 deploy=dict(type="bool", default=True),
             )
 
@@ -2671,7 +2671,7 @@ class DcnmNetwork:
             )
             att_spec = dict(
                 ip_address=dict(required=True, type="str"),
-                ports=dict(required=True, type="list"),
+                ports=dict(type="list", default=[]),
                 deploy=dict(type="bool", default=True),
                 tor_ports=dict(required=False, type="list", elements="dict"),
             )


### PR DESCRIPTION
Issue:
https://github.com/CiscoDevNet/ansible-dcnm/issues/80

Code Changes Description:
From the ports parameter in the DCNM Network Class, remove "required" constraint and add default value.
