### PR TITLE
Add support for  BGP Fabric type into the DCNM_FABRIC module

### DIFF
--- a/plugins/module_utils/fabric/fabric_types.py
+++ b/plugins/module_utils/fabric/fabric_types.py
@@ -73,22 +73,22 @@ class FabricTypes:
             - Value is a list of mandatory parameters for the fabric type
         """
         self._fabric_type_to_template_name_map = {}
+        self._fabric_type_to_template_name_map["BGP"] = "Easy_Fabric_eBGP"
         self._fabric_type_to_template_name_map["IPFM"] = "Easy_Fabric_IPFM"
         self._fabric_type_to_template_name_map["ISN"] = "External_Fabric"
         self._fabric_type_to_template_name_map["LAN_CLASSIC"] = "LAN_Classic"
         self._fabric_type_to_template_name_map["VXLAN_EVPN"] = "Easy_Fabric"
         self._fabric_type_to_template_name_map["VXLAN_EVPN_MSD"] = "MSD_Fabric"
-        self._fabric_type_to_template_name_map["BGP"] = "Easy_Fabric_eBGP"
 
         # Map fabric type to the feature name that must be running
         # on the controller to enable the fabric type.
         self._fabric_type_to_feature_name_map = {}
+        self._fabric_type_to_feature_name_map["BGP"] = "vxlan"
         self._fabric_type_to_feature_name_map["IPFM"] = "pmn"
         self._fabric_type_to_feature_name_map["ISN"] = "vxlan"
         self._fabric_type_to_feature_name_map["LAN_CLASSIC"] = "lan"
         self._fabric_type_to_feature_name_map["VXLAN_EVPN"] = "vxlan"
         self._fabric_type_to_feature_name_map["VXLAN_EVPN_MSD"] = "vxlan"
-        self._fabric_type_to_feature_name_map["BGP"] = "vxlan"
 
         # Map fabric type to the value that the controller GUI displays
         # in the Fabric Type column at NDFC -> Manage -> Fabrics
@@ -117,6 +117,9 @@ class FabricTypes:
         self._mandatory_parameters_all_fabrics.append("FABRIC_TYPE")
 
         self._mandatory_parameters = {}
+        self._mandatory_parameters["BGP"] = copy.copy(
+            self._mandatory_parameters_all_fabrics
+        )
         self._mandatory_parameters["IPFM"] = copy.copy(
             self._mandatory_parameters_all_fabrics
         )
@@ -129,22 +132,19 @@ class FabricTypes:
         self._mandatory_parameters["VXLAN_EVPN"] = copy.copy(
             self._mandatory_parameters_all_fabrics
         )
-        self._mandatory_parameters["BGP"] = copy.copy(
-            self._mandatory_parameters_all_fabrics
-        )
+        self._mandatory_parameters["BGP"].append("BGP_AS")
         self._mandatory_parameters["ISN"].append("BGP_AS")
         self._mandatory_parameters["VXLAN_EVPN"].append("BGP_AS")
-        self._mandatory_parameters["BGP"].append("BGP_AS")
         self._mandatory_parameters["VXLAN_EVPN_MSD"] = copy.copy(
             self._mandatory_parameters_all_fabrics
         )
 
+        self._mandatory_parameters["BGP"].sort()
         self._mandatory_parameters["IPFM"].sort()
         self._mandatory_parameters["ISN"].sort()
         self._mandatory_parameters["LAN_CLASSIC"].sort()
         self._mandatory_parameters["VXLAN_EVPN"].sort()
         self._mandatory_parameters["VXLAN_EVPN_MSD"].sort()
-        self._mandatory_parameters["BGP"].sort()
 
     def _init_properties(self) -> None:
         """

--- a/plugins/modules/dcnm_fabric.py
+++ b/plugins/modules/dcnm_fabric.py
@@ -61,12 +61,12 @@ options:
                 type: str
             FABRIC_TYPE:
                 choices:
+                - BGP
                 - IPFM
                 - ISN
                 - LAN_CLASSIC
                 - VXLAN_EVPN
                 - VXLAN_EVPN_MSD
-                - BGP
                 description:
                 - The type of fabric.
                 required: true


### PR DESCRIPTION
- Created necessary code and documentation to add support for BGP Fabric Type in dcnm_fabric module
- Decided to use the "BGP" as the FABRIC_TYPE without any "vxlan/evpn" keyword, as evpn support is optional in this type of fabric.
- To match the GUI requirements the fabric has only three mandatory parameters (same as VXLAN_EVPN type): FABRIC_NAME, FABRIC_TYPE and BGP_AS.
- In order to crate the fabric exactly the same API is used as for other/already supported fabric types, so no significant changes in the module are required 
- Module also doesn't specify/limit/translate parameters of the fabric.
- In order to document the supported parameters I took a list of returned nvPairs returned after the fabric is created.

Example playbook to verify the module operations:
'''
- hosts: BGP_FAB1
  any_errors_fatal: true
  gather_facts: no
  collections:
    - cisco.dcnm
  
  tasks:
    - name: Update fabrics
      cisco.dcnm.dcnm_fabric:
        state: merged
        config:
        -   FABRIC_NAME: BGP_Fabric
            FABRIC_TYPE: BGP
            BGP_AS: 65001
            DEPLOY: false
      register: result
    - debug:
        var: result
'''