### PR TITLE
changed unpublished endpoints to published ones

### DIFF
--- a/plugins/modules/dcnm_inventory.py
+++ b/plugins/modules/dcnm_inventory.py
@@ -1447,7 +1447,7 @@ class DcnmInventory:
                         self.fabric
                     )
                     self.module.fail_json(msg=msg)
-                if not role["serialNumber"]:
+                if not role.get("serialNumber"):
                     msg = "Unable to get serial number using getLanSwitchCredentials under fabric: {0}".format(
                         self.fabric
                     )
@@ -1460,8 +1460,7 @@ class DcnmInventory:
                     data = None
                     if self.nd:
                         method = "POST"
-                        path = "/rest/control/switches/roles"
-                        path = self.nd_prefix + "/" + path
+                        path = f"{self.nd_prefix}/rest/control/switches/roles"
                         data = json.dumps(
                             {
                                 "serialNumber": role["serialNumber"],
@@ -1483,7 +1482,7 @@ class DcnmInventory:
                         self.fabric
                     )
                     self.module.fail_json(msg=msg)
-                if not role["serialNumber"]:
+                if not role.get("serialNumber"):
                     msg = "Unable to get serial number using getLanSwitchCredentials under fabric: {0}".format(
                         self.fabric
                     )
@@ -1496,8 +1495,7 @@ class DcnmInventory:
                     data = None
                     if self.nd:
                         method = "POST"
-                        path = "/rest/control/switches/roles"
-                        path = self.nd_prefix + "/" + path
+                        path = f"{self.nd_prefix}/rest/control/switches/roles"
                         data = json.dumps(
                             {
                                 "serialNumber": role["serialNumber"],

--- a/plugins/modules/dcnm_inventory.py
+++ b/plugins/modules/dcnm_inventory.py
@@ -752,7 +752,7 @@ class DcnmInventory:
     def get_have(self):
 
         method = "GET"
-        path = "/rest/control/fabrics/{0}/inventory".format(self.fabric)
+        path = "/rest/control/fabrics/{0}/inventory/switchesByFabric".format(self.fabric)
         if self.nd:
             path = self.nd_prefix + path
         inv_objects = dcnm_send(self.module, method, path)
@@ -783,7 +783,7 @@ class DcnmInventory:
             get_switch.update({"sysName": inv["logicalName"]})
             get_switch.update({"serialNumber": inv["serialNumber"]})
             get_switch.update({"ipaddr": inv["ipAddress"]})
-            get_switch.update({"platform": inv["nonMdsModel"]})
+            get_switch.update({"platform": inv["model"]})
             get_switch.update({"version": inv["release"]})
             get_switch.update(
                 {"deviceIndex": inv["logicalName"] + "(" + inv["serialNumber"] + ")"}
@@ -1219,7 +1219,7 @@ class DcnmInventory:
 
         # Get Fabric Inventory Details
         method = "GET"
-        path = "/rest/control/fabrics/{0}/inventory".format(self.fabric)
+        path = "/rest/control/fabrics/{0}/inventory/switchesByFabric".format(self.fabric)
         if self.nd:
             path = self.nd_prefix + path
         get_inv = dcnm_send(self.module, method, path)
@@ -1339,7 +1339,7 @@ class DcnmInventory:
         all_ok = True
         # Get Fabric Inventory Details
         method = "GET"
-        path = "/rest/control/fabrics/{0}/inventory".format(self.fabric)
+        path = "/rest/control/fabrics/{0}/inventory/switchesByFabric".format(self.fabric)
         if self.nd:
             path = self.nd_prefix + path
         get_inv = dcnm_send(self.module, method, path)
@@ -1390,7 +1390,7 @@ class DcnmInventory:
         method = "GET"
         path = "/fm/fmrest/lanConfig/getLanSwitchCredentials"
         if self.nd:
-            path = self.nd_prefix + "/" + path[6:]
+            path = self.nd_prefix + "/" + path[6:] + "WithType"
             # lan_path = '/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/lanConfig/getLanSwitchCredentials'
         get_lan = dcnm_send(self.module, method, path)
         missing_fabric, not_ok = self.handle_response(get_lan, "query_dcnm")
@@ -1426,7 +1426,7 @@ class DcnmInventory:
     def assign_role(self):
 
         method = "GET"
-        path = "/rest/control/fabrics/{0}/inventory".format(self.fabric)
+        path = "/rest/control/fabrics/{0}/inventory/switchesByFabric".format(self.fabric)
         if self.nd:
             path = self.nd_prefix + path
         get_role = dcnm_send(self.module, method, path)
@@ -1447,14 +1447,28 @@ class DcnmInventory:
                         self.fabric
                     )
                     self.module.fail_json(msg=msg)
+                if not role["serialNumber"]:
+                    msg = "Unable to get serial number using getLanSwitchCredentials under fabric: {0}".format(
+                        self.fabric
+                    )
+                    self.module.fail_json(msg=msg)
                 if role["ipAddress"] == create["switches"][0]["ipaddr"]:
                     method = "PUT"
                     path = "/fm/fmrest/topology/role/{0}?newRole={1}".format(
                         role["switchDbID"], create["role"].replace("_", "%20")
                     )
+                    data = None
                     if self.nd:
-                        path = self.nd_prefix + "/" + path[6:]
-                    response = dcnm_send(self.module, method, path)
+                        method = "POST"
+                        path = "/rest/control/switches/roles"
+                        path = self.nd_prefix + "/" + path
+                        data = json.dumps(
+                            {
+                                "serialNumber": role["serialNumber"],
+                                "role": create["role"],
+                            }
+                        )
+                    response = dcnm_send(self.module, method, path, data)
                     self.result["response"].append(response)
                     fail, self.result["changed"] = self.handle_response(
                         response, "create"
@@ -1469,14 +1483,28 @@ class DcnmInventory:
                         self.fabric
                     )
                     self.module.fail_json(msg=msg)
+                if not role["serialNumber"]:
+                    msg = "Unable to get serial number using getLanSwitchCredentials under fabric: {0}".format(
+                        self.fabric
+                    )
+                    self.module.fail_json(msg=msg)
                 if role["ipAddress"] == create["ipAddress"]:
                     method = "PUT"
                     path = "/fm/fmrest/topology/role/{0}?newRole={1}".format(
                         role["switchDbID"], create["role"].replace("_", "%20")
                     )
+                    data = None
                     if self.nd:
-                        path = self.nd_prefix + "/" + path[6:]
-                    response = dcnm_send(self.module, method, path)
+                        method = "POST"
+                        path = "/rest/control/switches/roles"
+                        path = self.nd_prefix + "/" + path
+                        data = json.dumps(
+                            {
+                                "serialNumber": role["serialNumber"],
+                                "role": create["role"],
+                            }
+                        )
+                    response = dcnm_send(self.module, method, path, data)
                     self.result["response"].append(response)
                     fail, self.result["changed"] = self.handle_response(
                         response, "create"
@@ -1589,7 +1617,7 @@ class DcnmInventory:
         query_poap = self.params["query_poap"]
 
         method = "GET"
-        path = "/rest/control/fabrics/{0}/inventory".format(self.fabric)
+        path = "/rest/control/fabrics/{0}/inventory/switchesByFabric".format(self.fabric)
         if self.nd:
             path = self.nd_prefix + path
         inv_objects = dcnm_send(self.module, method, path)


### PR DESCRIPTION
Resolves https://github.com/CiscoDevNet/ansible-dcnm/issues/389

Had to change nonMdsModel to Model and when switching roles, now we use serial number instead of switchDbID. 


Old endpoints
--
GET /appcenter/cisco/ndfc/api/about/version
GET /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{fabricName}/inventory
GET /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/lanConfig/getLanSwitchCredentials
PUT /fm/fmrest/topology/role/{switchDbId}?newRole=leaf

New endpoints
--
GET /appcenter/cisco/ndfc/api/v1/fm/about/version
GET /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{fabricName}}/inventory/switchesByFabric
GET /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/lanConfig/getLanSwitchCredentialsWithType
POST /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/switches/roles


