### PR TITLE
dcnm_vrf: Add L3VNI w/o VLAN support, #337

### DIFF
--- a/plugins/modules/dcnm_vrf.py
+++ b/plugins/modules/dcnm_vrf.py
@@ -1455,6 +1455,7 @@ class DcnmVrf:
             "maxBgpPaths": vrf.get("max_bgp_paths", ""),
             "maxIbgpPaths": vrf.get("max_ibgp_paths", ""),
             "ipv6LinkLocalFlag": vrf.get("ipv6_linklocal_enable", True),
+            "enableL3VniNoVlan": vrf.get("l3vni_wo_vlan", False),
             "trmEnabled": vrf.get("trm_enable", False),
             "isRPExternal": vrf.get("rp_external", False),
             "rpAddress": vrf.get("rp_address", ""),
@@ -1590,6 +1591,7 @@ class DcnmVrf:
                 "maxBgpPaths": json_to_dict.get("maxBgpPaths", 1),
                 "maxIbgpPaths": json_to_dict.get("maxIbgpPaths", 2),
                 "ipv6LinkLocalFlag": json_to_dict.get("ipv6LinkLocalFlag", True),
+                "enableL3VniNoVlan": json_to_dict.get("enableL3VniNoVlan", False),
                 "trmEnabled": json_to_dict.get("trmEnabled", False),
                 "isRPExternal": json_to_dict.get("isRPExternal", False),
                 "rpAddress": json_to_dict.get("rpAddress", ""),
@@ -2197,6 +2199,7 @@ class DcnmVrf:
                         "maxBgpPaths": json_to_dict.get("maxBgpPaths"),
                         "maxIbgpPaths": json_to_dict.get("maxIbgpPaths"),
                         "ipv6LinkLocalFlag": json_to_dict.get("ipv6LinkLocalFlag"),
+                        "enableL3VniNoVlan": json_to_dict.get("enableL3VniNoVlan"),
                         "trmEnabled": json_to_dict.get("trmEnabled"),
                         "isRPExternal": json_to_dict.get("isRPExternal"),
                         "rpAddress": json_to_dict.get("rpAddress"),
@@ -2487,6 +2490,7 @@ class DcnmVrf:
             found_c.update(
                 {"ipv6_linklocal_enable": json_to_dict.get("ipv6LinkLocalFlag", True)}
             )
+            found_c.update({"l3vni_wo_vlan": json_to_dict.get("enableL3VniNoVlan", False)})
             found_c.update({"trm_enable": json_to_dict.get("trmEnabled", False)})
             found_c.update({"rp_external": json_to_dict.get("isRPExternal", False)})
             found_c.update({"rp_address": json_to_dict.get("rpAddress", "")})
@@ -2964,6 +2968,7 @@ class DcnmVrf:
                 "maxBgpPaths": json_to_dict.get("maxBgpPaths"),
                 "maxIbgpPaths": json_to_dict.get("maxIbgpPaths"),
                 "ipv6LinkLocalFlag": json_to_dict.get("ipv6LinkLocalFlag"),
+                "enableL3VniNoVlan": json_to_dict.get("enableL3VniNoVlan"),
                 "trmEnabled": json_to_dict.get("trmEnabled"),
                 "isRPExternal": json_to_dict.get("isRPExternal"),
                 "rpAddress": json_to_dict.get("rpAddress"),
@@ -3902,6 +3907,7 @@ class DcnmVrf:
 
         spec["ipv6_linklocal_enable"] = {"default": True, "type": "bool"}
 
+        spec["l3vni_wo_vlan"] = {"default": False, "type": "bool"}
         spec["loopback_route_tag"] = {
             "default": 12345,
             "range_max": 4294967295,


### PR DESCRIPTION
Adding L3VNI w/o VLAN option support for dcnm_vrf module, requested through #337. 

Using "l3vni_wo_vlan" as the config parameter, which takes in "true" or "false" from the user end, to enable or disable the feature. By default, it is disabled (false).
JSON VRF Template Payload parameter, "enableL3VniNoVlan" is used to pass on the information to the NDFC.