### PR TITLE
dcnm_inventory: Device not reachable fixes

### DIFF
--- a/plugins/modules/dcnm_inventory.py
+++ b/plugins/modules/dcnm_inventory.py
@@ -845,16 +845,31 @@ class DcnmInventory:
 
         self.diff_create = diff_create
 
+
     def get_diff_replace_delete(self):
 
         diff_delete = []
 
+        def check_have_c_in_want_list(have_c):
+            for want_c in self.want_create:
+                if have_c["switches"][0]["ipaddr"] == want_c["switches"][0]["ipaddr"]:
+                    return True
+
+            return False
+
         def have_in_want(have_c):
             match_found = False
+
+            # Check to see if have is in the want list and if not return match_found(False)
+            if not check_have_c_in_want_list(have_c):
+                return match_found
             for want_c in self.want_create:
                 match = re.search(r"\S+\((\S+)\)", want_c["switches"][0]["deviceIndex"])
                 if match is None:
-                    continue
+                    if have_c["switches"][0]["ipaddr"] == want_c["switches"][0]["ipaddr"]:
+                        match = re.search(r"\S+\((\S+)\)", have_c["switches"][0]["deviceIndex"])
+                if match is None:
+                    return match_found
                 want_serial_num = match.groups()[0]
                 if have_c["switches"][0]["serialNumber"] == want_serial_num:
                     if (
@@ -883,7 +898,6 @@ class DcnmInventory:
     def get_diff_delete(self):
 
         diff_delete = []
-
         if self.config:
             for want_c in self.want_create:
                 for have_c in self.have_create:

--- a/plugins/modules/dcnm_inventory.py
+++ b/plugins/modules/dcnm_inventory.py
@@ -845,7 +845,6 @@ class DcnmInventory:
 
         self.diff_create = diff_create
 
-
     def get_diff_replace_delete(self):
 
         diff_delete = []

--- a/plugins/modules/dcnm_inventory.py
+++ b/plugins/modules/dcnm_inventory.py
@@ -865,6 +865,10 @@ class DcnmInventory:
             for want_c in self.want_create:
                 match = re.search(r"\S+\((\S+)\)", want_c["switches"][0]["deviceIndex"])
                 if match is None:
+                    # If we get here this is typically because the device was pre-provisioned
+                    # and it does the regex expression above will not match in this case.
+                    # We need to make an additionl check using ipaddr to see if the device
+                    # is already part of the fabric.
                     if have_c["switches"][0]["ipaddr"] == want_c["switches"][0]["ipaddr"]:
                         match = re.search(r"\S+\((\S+)\)", have_c["switches"][0]["deviceIndex"])
                 if match is None:

--- a/plugins/modules/dcnm_inventory.py
+++ b/plugins/modules/dcnm_inventory.py
@@ -911,10 +911,12 @@ class DcnmInventory:
                 #     due to it being pre-provisioned or some other reason.
                 want_c_already_discovered = False
                 for have_c in self.have_create:
-                    # Check the have list to see if the device has alreacy been discovered.
+                    # Check the have list to see if the device has already been discovered and if so
+                    # don't error but use the have list to create the match.
                     if have_c["switches"][0]["ipaddr"] == want_c["switches"][0]["ipaddr"]:
                         want_c_already_discovered = True
                         match = re.search(r"\S+\((\S+)\)", have_c["switches"][0]["deviceIndex"])
+                # Device is not part of the fabric so return the error.
                 if not want_c_already_discovered:
                     msg = "Switch with IP {0} is not reachable or is not a valid IP".format(want_c["seedIP"])
                     self.module.fail_json(msg=msg)

--- a/plugins/modules/dcnm_inventory.py
+++ b/plugins/modules/dcnm_inventory.py
@@ -866,7 +866,7 @@ class DcnmInventory:
                 match = re.search(r"\S+\((\S+)\)", want_c["switches"][0]["deviceIndex"])
                 if match is None:
                     # If we get here this is typically because the device was pre-provisioned
-                    # and it does the regex expression above will not match in this case.
+                    # and the regex expression above will not match in this case.
                     # We need to make an additionl check using ipaddr to see if the device
                     # is already part of the fabric.
                     if have_c["switches"][0]["ipaddr"] == want_c["switches"][0]["ipaddr"]:


### PR DESCRIPTION
**Summary:**

The dcnm_inventory module does not currently handle cases where a device is unreachable.

This could be for any of the following reasons:
  * Device has been pre-provisioned
  * Device is in POAP mode
  * Device is not reachable due to some other network issue

**Adding devices to the fabric:**

When a device needs to be added to the fabric but is unreachable the following error message is generated and execution stops which is appropriate.

```python
msg = "Switch with IP {0} is not reachable or is not a valid IP".format(want_c["seedIP"])
```

If a device has already been added to the fabric but is currently unreachable it should still be managed because it's already part of the fabric.

This update makes an additional check to see if the device has already been added but is not reachable and does not error in this case.  The error message will still be generated for discovery when the device is not already part of the fabric.

**Removing devices from the fabric:**

Devices that have been pre-provisioned are not being removed properly so this also fixes that case.