### PR TITLE
DCNM_VRF: VRF Deletion Failure Fix

### DIFF
--- a/plugins/modules/dcnm_vrf.py
+++ b/plugins/modules/dcnm_vrf.py
@@ -3730,6 +3730,10 @@ class DcnmVrf:
                 continue
             if item.get("id") is None:
                 continue
+            if not item.get("ipAddress"):
+                continue
+            if not item.get("switchName"):
+                continue
 
             msg = f"item {json.dumps(item, indent=4, sort_keys=True)}"
             self.log.debug(msg)


### PR DESCRIPTION
Fix for invalid TOP_DOWN_VRF_VLAN resource being attempted to get deleted.

Issue:
https://github.com/CiscoDevNet/ansible-dcnm/issues/450

Fix:
When TOP_DOWN_VRF_VLAN resources are being populated in delete_ids list (release_orphaned_resources function), some resources IDs with invalid IP, switch name are sent to the controller for deletion, causing failure. 


TOP_DOWN_VRF_VLAN Resources in NDFC. 
[
    {
        "id": 2553,
        "resourcePool": {
            "id": 0,
            "poolName": "TOP_DOWN_VRF_VLAN",
            "fabricName": "AK-Test",
            "vrfName": null,
            "poolType": "ID_POOL",
            "dynamicSubnetRange": null,
            "targetSubnet": 0,
            "overlapAllowed": false,
            "hierarchicalKey": "AK-Test"
        },
        "entityType": "Device",
        "entityName": "ansible-vrf-int1",
        "allocatedIp": "500",
        "allocatedOn": 1751290494585,
        "allocatedFlag": true,
        "allocatedScopeValue": "ABCDEFGGJJ",
        "ipAddress": "192.168.1.2",
        "switchName": "spine",
        "hierarchicalKey": "0"
    },
    {
        "id": 2555,
        "resourcePool": {
            "id": 0,
            "poolName": "TOP_DOWN_VRF_VLAN",
            "fabricName": "AK-Test",
            "vrfName": null,
            "poolType": "ID_POOL",
            "dynamicSubnetRange": null,
            "targetSubnet": 0,
            "overlapAllowed": false,
            "hierarchicalKey": "AK-Test"
        },
        "entityType": "Device",
        "entityName": "ansible-vrf-int1",
        "allocatedIp": "500",
        "allocatedOn": 1751290505463,
        "allocatedFlag": false,
        "allocatedScopeValue": "ABCDEFGGJJ",
        "ipAddress": "192.168.1.3",
        "switchName": "leaf2",
        "hierarchicalKey": "0"
    },
    {
        "id": 2554,
        "resourcePool": {
            "id": 0,
            "poolName": "TOP_DOWN_VRF_VLAN",
            "fabricName": "AK-Test",
            "vrfName": null,
            "poolType": "ID_POOL",
            "dynamicSubnetRange": null,
            "targetSubnet": 0,
            "overlapAllowed": false,
            "hierarchicalKey": "AK-Test"
        },
        "entityType": "Device",
        "entityName": "ansible-vrf-int1",
        "allocatedIp": "500",
        "allocatedOn": 1751290494655,
        "allocatedFlag": true,
        "allocatedScopeValue": "ABCDEFGGJT",
        "ipAddress": "192.168.1.4",
        "switchName": "leaf1",
        "hierarchicalKey": "0"
    },
    {
        "id": 1744,
        "resourcePool": {
            "id": 0,
            "poolName": "TOP_DOWN_VRF_VLAN",
            "fabricName": "AK-Test",
            "vrfName": null,
            "poolType": "ID_POOL",
            "dynamicSubnetRange": null,
            "targetSubnet": 0,
            "overlapAllowed": false,
            "hierarchicalKey": "AK-Test"
        },
        "entityType": "Device",
        "entityName": "Tenant-2",
        "allocatedIp": "502",
        "allocatedOn": 1736348121214,
        "allocatedFlag": false,
        "allocatedScopeValue": "AK-Test",
        "ipAddress": "",
        "switchName": "",
        "hierarchicalKey": "0"
    },
    {
        "id": 1746,
        "resourcePool": {
            "id": 0,
            "poolName": "TOP_DOWN_VRF_VLAN",
            "fabricName": "AK-Test",
            "vrfName": null,
            "poolType": "ID_POOL",
            "dynamicSubnetRange": null,
            "targetSubnet": 0,
            "overlapAllowed": false,
            "hierarchicalKey": "AK-Test"
        },
        "entityType": "Device",
        "entityName": "Tenant-1",
        "allocatedIp": "501",
        "allocatedOn": 1736348121789,
        "allocatedFlag": false,
        "allocatedScopeValue": "AK-Test",
        "ipAddress": "",
        "switchName": "",
        "hierarchicalKey": "0"
    },
    {
        "id": 1747,
        "resourcePool": {
            "id": 0,
            "poolName": "TOP_DOWN_VRF_VLAN",
            "fabricName": "AK-Test",
            "vrfName": null,
            "poolType": "ID_POOL",
            "dynamicSubnetRange": null,
            "targetSubnet": 0,
            "overlapAllowed": false,
            "hierarchicalKey": "AK-Test"
        },
        "entityType": "Device",
        "entityName": "ansible-vrf-int1",
        "allocatedIp": "500",
        "allocatedOn": 1736348121976,
        "allocatedFlag": false,
        "allocatedScopeValue": "AK-Test",
        "ipAddress": "",
        "switchName": "",
        "hierarchicalKey": "0"
    }
]


NDFC Response:
{'RETURN_CODE': 500, 'METHOD': 'DELETE', 'REQUEST_PATH': 'https://192.168.1.1:443/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/resource-manager/resources?id=2551,1747', 'MESSAGE': 'Internal Server Error', 'DATA': {'successList': [2551], 'invalidList': [1747]}}
