### PR TITLE
Updated IT: dcnm_network to be in parity with new changes to dcnm_network 

### DIFF
--- a/tests/integration/targets/dcnm_network/tasks/main.yaml
+++ b/tests/integration/targets/dcnm_network/tasks/main.yaml
@@ -11,47 +11,6 @@
   delegate_to: localhost
   tags: always
 
-# maintaining backward compatibility until all test cases are updated
-- set_fact:
-    controller_version: "Unable to determine controller version"
-  tags: always
-
-- name: Determine version of DCNM or NDFC
-  cisco.dcnm.dcnm_rest:
-    method: GET
-    path: /appcenter/cisco/ndfc/api/about/version
-  register: result
-  ignore_errors: yes
-  tags: always
-
-- set_fact:
-    controller_version: "{{ result.response['DATA']['version'][0:2] | int }}"
-  when: ( result.response['DATA']['version'] is search("\d\d.\d+") )
-  ignore_errors: yes
-  tags: always
-
-- name: Determine version of DCNM or NDFC
-  cisco.dcnm.dcnm_rest:
-    method: GET
-    path: /fm/fmrest/about/version
-  register: result
-  ignore_errors: yes
-  tags: always
-
-- set_fact:
-    controller_version: "{{ result.response['DATA']['version'][0:2] | int }}"
-  when: ( result.response['DATA']['version'] is search("\d\d.\d+") )
-  ignore_errors: yes
-  tags: always
-
-
-- assert:
-    that:
-    - 'controller_version != "Unable to determine controller version"'
-  tags: always
-
-# new version below
-
 - name: MAIN - QUERY - Verify Fabric Deployment
   cisco.dcnm.dcnm_fabric:
     state: query

--- a/tests/integration/targets/dcnm_network/templates/self-contained-tests/double_net_dhcp_changed_conf.j2
+++ b/tests/integration/targets/dcnm_network/templates/self-contained-tests/double_net_dhcp_changed_conf.j2
@@ -25,4 +25,4 @@
   attach:
   - ip_address: "{{ test_data_common.sw2 }}"
     ports: []
-  deploy: "{{ test_data_common.deploy }}"
+  deploy: {{ test_data_common.deploy | bool }}

--- a/tests/integration/targets/dcnm_network/templates/self-contained-tests/double_net_dhcp_conf.j2
+++ b/tests/integration/targets/dcnm_network/templates/self-contained-tests/double_net_dhcp_conf.j2
@@ -26,7 +26,7 @@
   attach:
   - ip_address: "{{ test_data_common.sw1 }}"
     ports: []
-  deploy: "{{ test_data_common.deploy }}"
+  deploy: {{ test_data_common.deploy | bool }}
 
 - net_name: "{{ test_data_common.net2 }}"
   vrf_name: "{{ test_data_common.net2_vrf }}"
@@ -50,4 +50,4 @@
   attach:
   - ip_address: "{{ test_data_common.sw2 }}"
     ports: []
-  deploy: "{{ test_data_common.deploy }}"
+  deploy: {{ test_data_common.deploy | bool }}

--- a/tests/integration/targets/dcnm_network/templates/self-contained-tests/double_net_mcast_changed_conf.j2
+++ b/tests/integration/targets/dcnm_network/templates/self-contained-tests/double_net_mcast_changed_conf.j2
@@ -20,4 +20,4 @@
   attach:
   - ip_address: "{{ test_data_common.sw1 }}"
     ports: []
-  deploy: "{{ test_data_common.deploy | bool }}"
+  deploy: {{ test_data_common.deploy | bool }}

--- a/tests/integration/targets/dcnm_network/templates/self-contained-tests/double_net_mcast_conf.j2
+++ b/tests/integration/targets/dcnm_network/templates/self-contained-tests/double_net_mcast_conf.j2
@@ -20,7 +20,7 @@
   attach:
   - ip_address: "{{ test_data_common.sw1 }}"
     ports: []
-  deploy: "{{ test_data_common.deploy | bool }}"
+  deploy: {{ test_data_common.deploy | bool }}
 
 - net_name: "{{ test_data_common.net2 }}"
   vrf_name: "{{ test_data_common.net2_vrf }}"
@@ -38,4 +38,4 @@
   attach:
   - ip_address: "{{ test_data_common.sw1 }}"
     ports: []
-  deploy: "{{ test_data_common.deploy | bool }}"
+  deploy: {{ test_data_common.deploy | bool }}

--- a/tests/integration/targets/dcnm_network/templates/self-contained-tests/net1_changed_conf.j2
+++ b/tests/integration/targets/dcnm_network/templates/self-contained-tests/net1_changed_conf.j2
@@ -21,4 +21,4 @@
   attach:
   - ip_address: "{{ test_data_common.sw1 }}"
     ports: ["{{ test_data_common.sw1_int3 }}", "{{ test_data_common.sw1_int4 }}"]
-  deploy: "{{ test_data_common.deploy | bool }}"
+  deploy: {{ test_data_common.deploy | bool }}

--- a/tests/integration/targets/dcnm_network/templates/self-contained-tests/net1_conf.j2
+++ b/tests/integration/targets/dcnm_network/templates/self-contained-tests/net1_conf.j2
@@ -21,4 +21,4 @@
   attach:
   - ip_address: "{{ test_data_common.sw1 }}"
     ports: ["{{ test_data_common.sw1_int1 }}", "{{ test_data_common.sw1_int2 }}"]
-  deploy: "{{ test_data_common.deploy | bool }}"
+  deploy: {{ test_data_common.deploy | bool }}

--- a/tests/integration/targets/dcnm_network/templates/self-contained-tests/net1_dhcp_changed_conf.j2
+++ b/tests/integration/targets/dcnm_network/templates/self-contained-tests/net1_dhcp_changed_conf.j2
@@ -26,4 +26,4 @@
   attach:
   - ip_address: "{{ test_data_common.sw1 }}"
     ports: []
-  deploy: "{{ test_data_common.deploy | bool }}"
+  deploy: {{ test_data_common.deploy | bool }}

--- a/tests/integration/targets/dcnm_network/templates/self-contained-tests/net1_mcast_changed_conf.j2
+++ b/tests/integration/targets/dcnm_network/templates/self-contained-tests/net1_mcast_changed_conf.j2
@@ -20,4 +20,4 @@
   attach:
   - ip_address: "{{ test_data_common.sw1 }}"
     ports: []
-  deploy: "{{ test_data_common.deploy | bool }}"
+  deploy: {{ test_data_common.deploy | bool }}

--- a/tests/integration/targets/dcnm_network/templates/self-contained-tests/net1_mcast_conf.j2
+++ b/tests/integration/targets/dcnm_network/templates/self-contained-tests/net1_mcast_conf.j2
@@ -20,4 +20,4 @@
   attach:
   - ip_address: "{{ test_data_common.sw1 }}"
     ports: []
-  deploy: "{{ test_data_common.deploy | bool }}"
+  deploy: {{ test_data_common.deploy | bool }}

--- a/tests/integration/targets/dcnm_network/templates/self-contained-tests/net2_conf.j2
+++ b/tests/integration/targets/dcnm_network/templates/self-contained-tests/net2_conf.j2
@@ -21,4 +21,4 @@
   attach:
   - ip_address: "{{ test_data_common.sw2 }}"
     ports: ["{{ test_data_common.sw2_int1 }}", "{{ test_data_common.sw2_int2 }}"]
-  deploy: "{{ test_data_common.deploy | bool }}"
+  deploy: {{ test_data_common.deploy | bool }}

--- a/tests/integration/targets/dcnm_network/tests/dcnm/merged.yaml
+++ b/tests/integration/targets/dcnm_network/tests/dcnm/merged.yaml
@@ -835,33 +835,6 @@
     - result.changed == false
   tags: merged
 
-- name: MERGED - TC12 - Create Network and deploy in switch with null interface
-  cisco.dcnm.dcnm_network:
-    fabric: "{{ test_data_common.fabric }}"
-    state: merged
-    config:
-    - net_name: ansible-net13
-      vrf_name: Tenant-1
-      net_id: 7005
-      net_template: Default_Network_Universal
-      net_extension_template: Default_Network_Extension_Universal
-      vlan_id: 1500
-      gw_ip_subnet: '192.168.30.1/24'
-      attach:
-      - ip_address: "{{ test_data_common.sw1 }}"
-        ports:
-      deploy: false
-  register: result
-  ignore_errors: yes
-  tags: merged
-
-- name: MERGED - TC12 - ASSERT - Check invalid switch
-  assert:
-    that:
-    - '"Invalid parameters in playbook: ports : Required parameter not found" in result.msg'
-    - result.changed == false
-  tags: merged
-
 - name: MERGED - TC12 - Create Network with out of range routing tag
   cisco.dcnm.dcnm_network:
     fabric: "{{ test_data_common.fabric }}"


### PR DESCRIPTION
dcnm_network is updated by #427 which makes ports an optional parameter with a default value.
A test case which still expects ports to be mandatory is removed and backward compatibility is removed as it is no longer needed