### PR TITLE
Print Diff for DCNM_Inventory Results, Fix for Issue #90

### DIFF
--- a/plugins/modules/dcnm_inventory.py
+++ b/plugins/modules/dcnm_inventory.py
@@ -509,6 +509,7 @@ class DcnmInventory:
         self.node_migration = False
         self.nd_prefix = "/appcenter/cisco/ndfc/api/v1/lan-fabric"
         self.switch_snos = []
+        self.diff_input_format = []
 
         self.result = dict(changed=False, diff=[], response=[])
 
@@ -1811,6 +1812,121 @@ class DcnmInventory:
 
         self.module.fail_json(msg=res)
 
+    def format_diff(self):
+        """
+        Format the diff for inventory operations
+        """
+        diff = []
+        create_list = []
+        preprovision_list = []
+        bootstrap_list = []
+        rma_list = []
+        delete_list = []
+
+        # Add created switches to the diff
+        for create in self.diff_create:
+            if create.get("switches") and len(create["switches"]) > 0:
+                switch = create["switches"][0]
+                item = {
+                    "ip_address": switch.get("ipaddr"),
+                    "serial_number": switch.get("serialNumber"),
+                    "role": create.get("role"),
+                    "platform": switch.get("platform"),
+                    "version": switch.get("version"),
+                    "hostname": switch.get("sysName"),
+                    "preserve_config": create.get("preserveConfig", False)
+                }
+                create_list.append(item)
+
+        if create_list:
+            create_item = {
+                "action": "create",
+                "switches": create_list
+            }
+            diff.append(create_item)
+
+        # Add POAP switches to the diff
+        for poap in self.want_create_poap:
+            item = {
+                "ip_address": poap.get("ipAddress"),
+                "role": poap.get("role"),
+                "hostname": poap.get("hostname"),
+                "platform": poap.get("model"),
+                "version": poap.get("version")
+            }
+            if poap.get("serialNumber"):
+                item["serial_number"] = poap.get("serialNumber")
+                bootstrap_list.append(item)
+            if poap.get("preprovisionSerial"):
+                item["preprovision_serial"] = poap.get("preprovisionSerial")
+                preprovision_list.append(item)
+
+            diff.append(item)
+
+        if bootstrap_list:
+            diff.append({
+                "action": "bootstrap",
+                "bootstrap_switches": bootstrap_list
+            })
+        if preprovision_list:
+            diff.append({
+                "action": "preprovision",
+                "preprovision_switches": preprovision_list
+            })
+
+        # Add RMA switches to the diff
+        for rma in self.want_create_rma:
+            item = {
+                "ip_address": rma.get("ipAddress"),
+                "old_serial": rma.get("oldSerialNumber"),
+                "new_serial": rma.get("newSerialNumber"),
+                "platform": rma.get("model"),
+                "version": rma.get("version")
+            }
+            rma_list.append(item)
+
+        if rma_list:
+            diff.append({
+                "action": "rma",
+                "rma_switches": rma_list
+            })
+
+        # Add deleted switches to the diff
+        for serial in self.diff_delete:
+            ip_address = None
+            hostname = None
+            for have_c in self.have_create:
+                if have_c["switches"][0]["serialNumber"] == serial:
+                    ip_address = have_c["switches"][0]["ipaddr"]
+                    hostname = have_c["switches"][0]["sysName"]
+                    role = have_c["switches"][0]["role"]
+                    platform = have_c["switches"][0]["platform"]
+                    version = have_c["switches"][0]["version"]
+                    break
+
+            item = {
+                "serial_number": serial
+            }
+            if ip_address:
+                item["ip_address"] = ip_address
+            if hostname:
+                item["hostname"] = hostname
+            if role:
+                item["role"] = role
+            if platform:
+                item["platform"] = platform
+            if version:
+                item["version"] = version
+
+            delete_list.append(item)
+
+        if delete_list:
+            diff.append({
+                "action": "delete",
+                "switches": delete_list
+            })
+
+        self.diff_input_format = diff
 
 def main():
     """main entry point for module execution"""
@@ -1943,6 +2059,8 @@ def main():
             if module.params["deploy"]:
                 dcnm_inv.config_deploy()
 
+    dcnm_inv.format_diff()
+    dcnm_inv.result["diff"] = dcnm_inv.diff_input_format
     module.exit_json(**dcnm_inv.result)
 
 


### PR DESCRIPTION
Issue:
https://github.com/CiscoDevNet/ansible-dcnm/issues/90

Fix:
Add function to read through the create, delete, rma and poap diff and populate the list of dictionaries containing the switches that are modified in the operation corresponding to each type of operation.
