### PR TITLE
dcnm_fabric: Proposed fix for issue #469

### DIFF
--- a/plugins/module_utils/common/controller_version.py
+++ b/plugins/module_utils/common/controller_version.py
@@ -54,6 +54,9 @@ class ControllerVersion:
     ```
 
     ### Response
+
+    #### ND 3.x
+
     ```json
         {
             "version": "12.1.2e",
@@ -62,10 +65,40 @@ class ControllerVersion:
             "dev": false,
             "isHaEnabled": false,
             "install": "EASYFABRIC",
-            "uuid": "f49e6088-ad4f-4406-bef6-2419de914ff1",
+            "uuid": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
             "is_upgrade_inprogress": false
         }
     ```
+
+    #### ND 4.1 EFT 138c
+
+    ```json
+        {
+            "version": "12.4.1.225",
+            "mode": "",
+            "isMediaController": false,
+            "dev": false,
+            "isHaEnabled": false,
+            "install": "",
+            "uuid": "",
+            "is_upgrade_inprogress": false
+        }
+    ```
+
+    #### ND 4.1 EFT 156b
+
+    ```json
+        {
+            "version": "12.4.1.245",
+            "mode": "",
+            "isMediaController": false,
+            "dev": false,
+            "isHaEnabled": false,
+            "install": "",
+            "uuid": "",
+            "is_upgrade_inprogress": false
+        }
+
     """
 
     def __init__(self):

--- a/plugins/module_utils/common/controller_version.py
+++ b/plugins/module_utils/common/controller_version.py
@@ -152,6 +152,27 @@ class ControllerVersion:
     def _get(self, item):
         return self.conversion.make_none(self.conversion.make_boolean(self.response_data.get(item)))
 
+    def _validate_and_split_version(self):
+        """
+        Validate version format and return split version parts.
+
+        Expected formats:
+            w.x.y (3 parts) or w.x.y.z (4 parts)
+
+        Returns:
+            list: Version parts split by '.'
+
+        Raises:
+            ValueError: If version format is unexpected
+        """
+        version_parts = self.version.split(".")
+        if len(version_parts) not in [3, 4]:
+            msg = f"{self.class_name}._validate_and_split_version: "
+            msg += f"Unexpected version format '{self.version}'. "
+            msg += f"Expected 3 or 4 parts (w.x.y or w.x.y.z), got {len(version_parts)} parts"
+            raise ValueError(msg)
+        return version_parts
+
     @property
     def dev(self):
         """
@@ -256,76 +277,74 @@ class ControllerVersion:
     def version(self):
         """
         Return the controller version, if it exists.
-        Return None otherwise
+        Raise ValueError if version is not available.
 
         Possible values:
             version, e.g. "12.1.2e"
-            None
         """
-        return self._get("version")
+        version = self._get("version")
+        if version is None:
+            msg = f"{self.class_name}.version: "
+            msg += "Version information not available in controller response"
+            raise ValueError(msg)
+        return version
 
     @property
     def version_major(self):
         """
-        Return the controller major version as a string, if it exists.
-        Return None otherwise
+        Return the controller major version as a string.
+        Raise ValueError if version format is unexpected.
 
         We are assuming semantic versioning based on:
         https://semver.org
+
+        Expected formats:
+            w.x.y (3 parts) or w.x.y.z (4 parts)
 
         Possible values:
             if version is 12.1.2e, return "12"
             if version is 12.4.1.245, return "12"
-            None
         """
-        if self.version is None:
-            return None
-        version_parts = self.version.split(".")
-        if len(version_parts) >= 1:
-            return version_parts[0]
-        return None
+        version_parts = self._validate_and_split_version()
+        return version_parts[0]
 
     @property
     def version_minor(self):
         """
-        Return the controller minor version as a string, if it exists.
-        Return None otherwise
+        Return the controller minor version as a string.
+        Raise ValueError if version format is unexpected.
 
         We are assuming semantic versioning based on:
         https://semver.org
+
+        Expected formats:
+            w.x.y (3 parts) or w.x.y.z (4 parts)
 
         Possible values:
             if version is 12.1.2e, return "1"
             if version is 12.4.1.245, return "4"
-            None
         """
-        if self.version is None:
-            return None
-        version_parts = self.version.split(".")
-        if len(version_parts) >= 2:
-            return version_parts[1]
-        return None
+        version_parts = self._validate_and_split_version()
+        return version_parts[1]
 
     @property
     def version_patch(self):
         """
-        Return the controller patch version as a string, if it exists.
-        Return None otherwise
+        Return the controller patch version as a string.
+        Raise ValueError if version format is unexpected.
 
         We are assuming semantic versioning based on:
         https://semver.org
 
+        Expected formats:
+            w.x.y (3 parts) or w.x.y.z (4 parts)
+
         Possible values:
             if version is 12.1.2e, return "2e"
             if version is 12.4.1.245, return "1"
-            None
         """
-        if self.version is None:
-            return None
-        version_parts = self.version.split(".")
-        if len(version_parts) >= 3:
-            return version_parts[2]
-        return None
+        version_parts = self._validate_and_split_version()
+        return version_parts[2]
 
     @property
     def is_controller_version_4x(self) -> bool:

--- a/plugins/module_utils/common/controller_version.py
+++ b/plugins/module_utils/common/controller_version.py
@@ -362,25 +362,16 @@ class ControllerVersion:
             minor = self.version_minor
 
             if major is None or minor is None:
-                # If we can't determine version, assume it's a newer version
-                result = True
-            else:
-                # Extract numeric part only from minor version in case of formats like "2e"
-                minor_numeric = ""
-                for char in minor:
-                    if char.isdigit():
-                        minor_numeric += char
-                    else:
-                        break
+                # This should never happen due to early validation, but if it does, raise an error
+                msg = f"{self.class_name}.{method_name}: "
+                msg += f"Unexpected None values: major={major}, minor={minor}"
+                raise ValueError(msg)
 
-                if not minor_numeric:
-                    # If no numeric part found, assume it's a newer version
-                    result = True
-                else:
-                    if int(major) == 12 and int(minor_numeric) < 3:
-                        result = False
-                    else:
-                        result = True
+            # version_minor is always numeric, so we can convert directly to int
+            if int(major) == 12 and int(minor) < 3:
+                result = False
+            else:
+                result = True
         except (ValueError, TypeError) as e:
             # If version parsing fails, assume it's a newer version
             msg = f"{self.class_name}.{method_name}: "

--- a/plugins/module_utils/common/controller_version.py
+++ b/plugins/module_utils/common/controller_version.py
@@ -150,7 +150,21 @@ class ControllerVersion:
             raise ValueError(msg)
 
     def _get(self, item):
-        return self.conversion.make_none(self.conversion.make_boolean(self.response_data.get(item)))
+        """
+        # Summary
+
+        Return the parameter (item) from the response
+
+        ## Notes
+
+        - With ND 4, parameters like "mode", "uuid" are empty strings.
+          Return empty string in this case, rather than None.
+        - None indicates that the parameter is missing in the response (i.e. an error)
+        """
+        value = self.response_data.get(item)
+        if value == "":
+            return ""
+        return self.conversion.make_none(self.conversion.make_boolean(value))
 
     def _validate_and_split_version(self):
         """
@@ -252,14 +266,24 @@ class ControllerVersion:
     @property
     def mode(self):
         """
+        # Summary
+
         Return the controller mode, if it exists.
         Return None otherwise
 
         Possible values:
             LAN
-            None
+            ""
+
+        ## Notes
+
+        - mode will be "" for ND 4
         """
-        return self._get("mode")
+        value = self._get("mode")
+        if value is None:
+            msg = "Controller response is missing 'mode' parameter."
+            raise ValueError(msg)
+        return value
 
     @property
     def uuid(self):
@@ -276,11 +300,13 @@ class ControllerVersion:
     @property
     def version(self):
         """
-        Return the controller version, if it exists.
-        Raise ValueError if version is not available.
+        # Summary
+
+        - Return the controller version, if it exists.
+        - Raise ValueError if version is not available.
 
         Possible values:
-            version, e.g. "12.1.2e"
+            version, e.g. "12.1.2e" or "12.4.1.245"
         """
         version = self._get("version")
         if version is None:
@@ -349,10 +375,14 @@ class ControllerVersion:
     @property
     def is_controller_version_4x(self) -> bool:
         """
-        ### Summary
+        # Summary
 
         -   Return True if the controller version implies ND 4.0 or higher.
         -   Return False otherwise.
+
+        ## Raises
+
+        - ValueError if unable to determine version
         """
         method_name = inspect.stack()[0][3]
 

--- a/plugins/module_utils/common/controller_version.py
+++ b/plugins/module_utils/common/controller_version.py
@@ -142,24 +142,15 @@ class ControllerVersion:
             msg += f"{self.rest_send.response_current}"
             raise ValueError(msg)
 
-    def _get(self, item):
-        # Handle the case where response_data might be a string instead of a dictionary
-        if isinstance(self.response_data, str):
-            # If response_data is a string, try to parse it as JSON
-            import json
+        # Ensure response_data is a dictionary
+        if not isinstance(self._response_data, dict):
+            msg = f"{self.class_name}.refresh() failed: "
+            msg += f"Expected response data to be a dictionary, got {type(self._response_data).__name__}. "
+            msg += f"Data: {self._response_data}"
+            raise ValueError(msg)
 
-            try:
-                data = json.loads(self.response_data)
-                return self.conversion.make_none(self.conversion.make_boolean(data.get(item)))
-            except json.JSONDecodeError:
-                # If JSON parsing fails, we can't extract the item
-                return None
-        elif isinstance(self.response_data, dict):
-            # Normal case: response_data is a dictionary
-            return self.conversion.make_none(self.conversion.make_boolean(self.response_data.get(item)))
-        else:
-            # If response_data is neither string nor dict, return None
-            return None
+    def _get(self, item):
+        return self.conversion.make_none(self.conversion.make_boolean(self.response_data.get(item)))
 
     @property
     def dev(self):

--- a/plugins/module_utils/common/controller_version.py
+++ b/plugins/module_utils/common/controller_version.py
@@ -373,11 +373,10 @@ class ControllerVersion:
             else:
                 result = True
         except (ValueError, TypeError) as e:
-            # If version parsing fails, assume it's a newer version
+            # If version parsing fails, re-raise as ValueError - do not assume version
             msg = f"{self.class_name}.{method_name}: "
-            msg += f"Error parsing version {self.version}: {e}. Assuming version 4.x"
-            self.log.warning(msg)
-            result = True
+            msg += f"Error parsing version {self.version}: {e}"
+            raise ValueError(msg) from e
 
         msg = f"{self.class_name}.{method_name}: "
         msg += f"self.version: {self.version}, "

--- a/plugins/module_utils/common/controller_version.py
+++ b/plugins/module_utils/common/controller_version.py
@@ -143,7 +143,23 @@ class ControllerVersion:
             raise ValueError(msg)
 
     def _get(self, item):
-        return self.conversion.make_none(self.conversion.make_boolean(self.response_data.get(item)))
+        # Handle the case where response_data might be a string instead of a dictionary
+        if isinstance(self.response_data, str):
+            # If response_data is a string, try to parse it as JSON
+            import json
+
+            try:
+                data = json.loads(self.response_data)
+                return self.conversion.make_none(self.conversion.make_boolean(data.get(item)))
+            except json.JSONDecodeError:
+                # If JSON parsing fails, we can't extract the item
+                return None
+        elif isinstance(self.response_data, dict):
+            # Normal case: response_data is a dictionary
+            return self.conversion.make_none(self.conversion.make_boolean(self.response_data.get(item)))
+        else:
+            # If response_data is neither string nor dict, return None
+            return None
 
     @property
     def dev(self):
@@ -273,7 +289,7 @@ class ControllerVersion:
         """
         if self.version is None:
             return None
-        version_parts = self._get("version").split(".")
+        version_parts = self.version.split(".")
         if len(version_parts) >= 1:
             return version_parts[0]
         return None
@@ -294,7 +310,7 @@ class ControllerVersion:
         """
         if self.version is None:
             return None
-        version_parts = self._get("version").split(".")
+        version_parts = self.version.split(".")
         if len(version_parts) >= 2:
             return version_parts[1]
         return None
@@ -315,7 +331,7 @@ class ControllerVersion:
         """
         if self.version is None:
             return None
-        version_parts = self._get("version").split(".")
+        version_parts = self.version.split(".")
         if len(version_parts) >= 3:
             return version_parts[2]
         return None

--- a/tests/unit/module_utils/common/fixtures/responses_ep_version.json
+++ b/tests/unit/module_utils/common/fixtures/responses_ep_version.json
@@ -1,555 +1,580 @@
 {
     "test_controller_version_00100a": {
-        "RETURN_CODE": 200,
+        "DATA": {
+            "dev": "false",
+            "install": "EASYFABRIC",
+            "is_upgrade_inprogress": "false",
+            "isHaEnabled": "false",
+            "isMediaController": "false",
+            "mode": "LAN",
+            "uuid": "",
+            "version": "12.1.3b"
+        },
+        "MESSAGE": "OK",
         "METHOD": "GET",
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
-        "MESSAGE": "OK",
-        "DATA": {
-            "version": "12.1.3b",
-            "mode": "LAN",
-            "isMediaController": "false",
-            "dev": "false",
-            "isHaEnabled": "false",
-            "install": "EASYFABRIC",
-            "uuid": "",
-            "is_upgrade_inprogress": "false"
-        }
+        "RETURN_CODE": 200
     },
     "test_controller_version_00100b": {
-        "RETURN_CODE": 200,
+        "DATA": {
+            "dev": "true",
+            "install": "EASYFABRIC",
+            "is_upgrade_inprogress": "false",
+            "isHaEnabled": "false",
+            "isMediaController": "false",
+            "mode": "LAN",
+            "uuid": "",
+            "version": "12.1.3b"
+        },
+        "MESSAGE": "OK",
         "METHOD": "GET",
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
-        "MESSAGE": "OK",
-        "DATA": {
-            "version": "12.1.3b",
-            "mode": "LAN",
-            "isMediaController": "false",
-            "dev": "true",
-            "isHaEnabled": "false",
-            "install": "EASYFABRIC",
-            "uuid": "",
-            "is_upgrade_inprogress": "false"
-        }
+        "RETURN_CODE": 200
     },
     "test_controller_version_00100c": {
-        "RETURN_CODE": 200,
+        "DATA": {
+            "install": "EASYFABRIC",
+            "is_upgrade_inprogress": "false",
+            "isHaEnabled": "false",
+            "isMediaController": "false",
+            "mode": "LAN",
+            "uuid": "",
+            "version": "12.1.3b"
+        },
+        "MESSAGE": "OK",
         "METHOD": "GET",
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
-        "MESSAGE": "OK",
-        "DATA": {
-            "version": "12.1.3b",
-            "mode": "LAN",
-            "isMediaController": "false",
-            "isHaEnabled": "false",
-            "install": "EASYFABRIC",
-            "uuid": "",
-            "is_upgrade_inprogress": "false"
-        }
+        "RETURN_CODE": 200
     },
     "test_controller_version_00110a": {
-        "RETURN_CODE": 200,
+        "DATA": {
+            "dev": "false",
+            "install": "EASYFABRIC",
+            "is_upgrade_inprogress": "false",
+            "isHaEnabled": "false",
+            "isMediaController": "false",
+            "mode": "LAN",
+            "uuid": "",
+            "version": "12.1.3b"
+        },
+        "MESSAGE": "OK",
         "METHOD": "GET",
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
-        "MESSAGE": "OK",
-        "DATA": {
-            "version": "12.1.3b",
-            "mode": "LAN",
-            "isMediaController": "false",
-            "dev": "false",
-            "isHaEnabled": "false",
-            "install": "EASYFABRIC",
-            "uuid": "",
-            "is_upgrade_inprogress": "false"
-        }
+        "RETURN_CODE": 200
     },
     "test_controller_version_00110b": {
-        "RETURN_CODE": 200,
+        "DATA": {
+            "dev": "false",
+            "is_upgrade_inprogress": "false",
+            "isHaEnabled": "false",
+            "isMediaController": "false",
+            "mode": "LAN",
+            "uuid": "",
+            "version": "12.1.3b"
+        },
+        "MESSAGE": "OK",
         "METHOD": "GET",
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
-        "MESSAGE": "OK",
-        "DATA": {
-            "version": "12.1.3b",
-            "mode": "LAN",
-            "isMediaController": "false",
-            "dev": "false",
-            "isHaEnabled": "false",
-            "uuid": "",
-            "is_upgrade_inprogress": "false"
-        }
+        "RETURN_CODE": 200
     },
     "test_controller_version_00120a": {
-        "RETURN_CODE": 200,
+        "DATA": {
+            "dev": "false",
+            "install": "EASYFABRIC",
+            "is_upgrade_inprogress": "false",
+            "isHaEnabled": "true",
+            "isMediaController": "false",
+            "mode": "LAN",
+            "uuid": "",
+            "version": "12.1.3b"
+        },
+        "MESSAGE": "OK",
         "METHOD": "GET",
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
-        "MESSAGE": "OK",
-        "DATA": {
-            "version": "12.1.3b",
-            "mode": "LAN",
-            "isMediaController": "false",
-            "dev": "false",
-            "isHaEnabled": "true",
-            "install": "EASYFABRIC",
-            "uuid": "",
-            "is_upgrade_inprogress": "false"
-        }
+        "RETURN_CODE": 200
     },
     "test_controller_version_00120b": {
-        "RETURN_CODE": 200,
+        "DATA": {
+            "dev": "false",
+            "install": "EASYFABRIC",
+            "is_upgrade_inprogress": "false",
+            "isHaEnabled": "false",
+            "isMediaController": "false",
+            "mode": "LAN",
+            "uuid": "",
+            "version": "12.1.3b"
+        },
+        "MESSAGE": "OK",
         "METHOD": "GET",
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
-        "MESSAGE": "OK",
-        "DATA": {
-            "version": "12.1.3b",
-            "mode": "LAN",
-            "isMediaController": "false",
-            "dev": "false",
-            "isHaEnabled": "false",
-            "install": "EASYFABRIC",
-            "uuid": "",
-            "is_upgrade_inprogress": "false"
-        }
+        "RETURN_CODE": 200
     },
     "test_controller_version_00120c": {
-        "RETURN_CODE": 200,
-        "METHOD": "GET",
-        "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
-        "MESSAGE": "OK",
         "DATA": {
-            "version": "12.1.3b",
-            "mode": "LAN",
-            "isMediaController": "false",
             "dev": "false",
             "install": "EASYFABRIC",
+            "is_upgrade_inprogress": "false",
+            "isMediaController": "false",
+            "mode": "LAN",
             "uuid": "",
-            "is_upgrade_inprogress": "false"
-        }
+            "version": "12.1.3b"
+        },
+        "MESSAGE": "OK",
+        "METHOD": "GET",
+        "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
+        "RETURN_CODE": 200
     },
     "test_controller_version_00130a": {
-        "RETURN_CODE": 200,
+        "DATA": {
+            "dev": "false",
+            "install": "EASYFABRIC",
+            "is_upgrade_inprogress": "false",
+            "isHaEnabled": "false",
+            "isMediaController": "true",
+            "mode": "LAN",
+            "uuid": "",
+            "version": "12.1.3b"
+        },
+        "MESSAGE": "OK",
         "METHOD": "GET",
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
-        "MESSAGE": "OK",
-        "DATA": {
-            "version": "12.1.3b",
-            "mode": "LAN",
-            "isMediaController": "true",
-            "dev": "false",
-            "isHaEnabled": "false",
-            "install": "EASYFABRIC",
-            "uuid": "",
-            "is_upgrade_inprogress": "false"
-        }
+        "RETURN_CODE": 200
     },
     "test_controller_version_00130b": {
-        "RETURN_CODE": 200,
+        "DATA": {
+            "dev": "false",
+            "install": "EASYFABRIC",
+            "is_upgrade_inprogress": "false",
+            "isHaEnabled": "false",
+            "isMediaController": "false",
+            "mode": "LAN",
+            "uuid": "",
+            "version": "12.1.3b"
+        },
+        "MESSAGE": "OK",
         "METHOD": "GET",
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
-        "MESSAGE": "OK",
-        "DATA": {
-            "version": "12.1.3b",
-            "mode": "LAN",
-            "isMediaController": "false",
-            "dev": "false",
-            "isHaEnabled": "false",
-            "install": "EASYFABRIC",
-            "uuid": "",
-            "is_upgrade_inprogress": "false"
-        }
+        "RETURN_CODE": 200
     },
     "test_controller_version_00130c": {
-        "RETURN_CODE": 200,
+        "DATA": {
+            "dev": "false",
+            "install": "EASYFABRIC",
+            "is_upgrade_inprogress": "false",
+            "isHaEnabled": "false",
+            "mode": "LAN",
+            "uuid": "",
+            "version": "12.1.3b"
+        },
+        "MESSAGE": "OK",
         "METHOD": "GET",
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
-        "MESSAGE": "OK",
-        "DATA": {
-            "version": "12.1.3b",
-            "mode": "LAN",
-            "dev": "false",
-            "isHaEnabled": "false",
-            "install": "EASYFABRIC",
-            "uuid": "",
-            "is_upgrade_inprogress": "false"
-        }
+        "RETURN_CODE": 200
     },
     "test_controller_version_00140a": {
-        "RETURN_CODE": 200,
+        "DATA": {
+            "dev": "false",
+            "install": "EASYFABRIC",
+            "is_upgrade_inprogress": "true",
+            "isHaEnabled": "false",
+            "isMediaController": "false",
+            "mode": "LAN",
+            "uuid": "",
+            "version": "12.1.3b"
+        },
+        "MESSAGE": "OK",
         "METHOD": "GET",
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
-        "MESSAGE": "OK",
-        "DATA": {
-            "version": "12.1.3b",
-            "mode": "LAN",
-            "isMediaController": "false",
-            "dev": "false",
-            "isHaEnabled": "false",
-            "install": "EASYFABRIC",
-            "uuid": "",
-            "is_upgrade_inprogress": "true"
-        }
+        "RETURN_CODE": 200
     },
     "test_controller_version_00140b": {
-        "RETURN_CODE": 200,
+        "DATA": {
+            "dev": "false",
+            "install": "EASYFABRIC",
+            "is_upgrade_inprogress": "false",
+            "isHaEnabled": "false",
+            "isMediaController": "false",
+            "mode": "LAN",
+            "uuid": "",
+            "version": "12.1.3b"
+        },
+        "MESSAGE": "OK",
         "METHOD": "GET",
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
-        "MESSAGE": "OK",
-        "DATA": {
-            "version": "12.1.3b",
-            "mode": "LAN",
-            "isMediaController": "false",
-            "dev": "false",
-            "isHaEnabled": "false",
-            "install": "EASYFABRIC",
-            "uuid": "",
-            "is_upgrade_inprogress": "false"
-        }
+        "RETURN_CODE": 200
     },
     "test_controller_version_00140c": {
-        "RETURN_CODE": 200,
+        "DATA": {
+            "dev": "false",
+            "install": "EASYFABRIC",
+            "isHaEnabled": "false",
+            "isMediaController": "false",
+            "mode": "LAN",
+            "uuid": "",
+            "version": "12.1.3b"
+        },
+        "MESSAGE": "OK",
         "METHOD": "GET",
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
-        "MESSAGE": "OK",
-        "DATA": {
-            "version": "12.1.3b",
-            "mode": "LAN",
-            "isMediaController": "false",
-            "dev": "false",
-            "isHaEnabled": "false",
-            "install": "EASYFABRIC",
-            "uuid": ""
-        }
+        "RETURN_CODE": 200
     },
     "test_controller_version_00150a": {
-        "RETURN_CODE": 200,
+        "DATA": {
+            "dev": "false",
+            "install": "EASYFABRIC",
+            "is_upgrade_inprogress": "false",
+            "isHaEnabled": "false",
+            "isMediaController": "false",
+            "mode": "LAN",
+            "uuid": "",
+            "version": "12.1.3b"
+        },
+        "MESSAGE": "OK",
         "METHOD": "GET",
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
-        "MESSAGE": "OK",
-        "DATA": {
-            "version": "12.1.3b",
-            "mode": "LAN",
-            "isMediaController": "false",
-            "dev": "false",
-            "isHaEnabled": "false",
-            "install": "EASYFABRIC",
-            "uuid": "",
-            "is_upgrade_inprogress": "false"
-        }
+        "RETURN_CODE": 200
     },
     "test_controller_version_00160a": {
-        "RETURN_CODE": 200,
+        "MESSAGE": "OK",
         "METHOD": "GET",
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
-        "MESSAGE": "OK"
+        "RETURN_CODE": 200
     },
     "test_controller_version_00170a": {
-        "RETURN_CODE": 200,
+        "DATA": {
+            "dev": "false",
+            "install": "EASYFABRIC",
+            "is_upgrade_inprogress": "false",
+            "isHaEnabled": "false",
+            "isMediaController": "false",
+            "mode": "LAN",
+            "uuid": "",
+            "version": "12.1.3b"
+        },
+        "MESSAGE": "OK",
         "METHOD": "GET",
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
-        "MESSAGE": "OK",
-        "DATA": {
-            "version": "12.1.3b",
-            "mode": "LAN",
-            "isMediaController": "false",
-            "dev": "false",
-            "isHaEnabled": "false",
-            "install": "EASYFABRIC",
-            "uuid": "",
-            "is_upgrade_inprogress": "false"
-        }
+        "RETURN_CODE": 200
     },
     "test_controller_version_00180a": {
-        "RETURN_CODE": 404,
+        "DATA": {},
+        "MESSAGE": "Not Found",
         "METHOD": "GET",
         "REQUEST_PATH": "https://foo/noop",
-        "MESSAGE": "Not Found",
-        "DATA": {}
+        "RETURN_CODE": 404
     },
     "test_controller_version_00190a": {
-        "RETURN_CODE": 500,
+        "DATA": {},
+        "MESSAGE": "Internal Server Error",
         "METHOD": "GET",
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
-        "MESSAGE": "Internal Server Error",
-        "DATA": {}
+        "RETURN_CODE": 500
     },
     "test_controller_version_00200a": {
-        "RETURN_CODE": 200,
+        "TEST_NOTES": [
+            "mode key is populated.  ND 3."
+        ],
+        "DATA": {
+            "dev": "false",
+            "install": "EASYFABRIC",
+            "is_upgrade_inprogress": "false",
+            "isHaEnabled": "false",
+            "isMediaController": "false",
+            "mode": "LAN",
+            "uuid": "",
+            "version": "12.1.3b"
+        },
+        "MESSAGE": "OK",
         "METHOD": "GET",
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
-        "MESSAGE": "OK",
-        "DATA": {
-            "version": "12.1.3b",
-            "mode": "LAN",
-            "isMediaController": "false",
-            "dev": "false",
-            "isHaEnabled": "false",
-            "install": "EASYFABRIC",
-            "uuid": "",
-            "is_upgrade_inprogress": "false"
-        }
+        "RETURN_CODE": 200
     },
     "test_controller_version_00200b": {
-        "RETURN_CODE": 200,
+        "TEST_NOTES": [
+            "mode key is empty.  ND 4."
+        ],
+        "DATA": {
+            "dev": false,
+            "install": "",
+            "is_upgrade_inprogress": false,
+            "isHaEnabled": false,
+            "isMediaController": false,
+            "mode": "",
+            "uuid": "",
+            "version": "12.4.1.245"
+        },
+        "MESSAGE": "OK",
         "METHOD": "GET",
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
-        "MESSAGE": "OK",
+        "RETURN_CODE": 200
+    },
+    "test_controller_version_00200c": {
+        "TEST_NOTES": [
+            "mode key is missing.  Negative test."
+        ],
         "DATA": {
-            "version": "12.1.3b",
-            "isMediaController": "false",
             "dev": "false",
+            "is_upgrade_inprogress": "false",
             "isHaEnabled": "false",
+            "isMediaController": "false",
             "uuid": "",
-            "is_upgrade_inprogress": "false"
-        }
+            "version": "12.1.3b"
+        },
+        "MESSAGE": "OK",
+        "METHOD": "GET",
+        "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
+        "RETURN_CODE": 200
     },
     "test_controller_version_00210a": {
-        "RETURN_CODE": 200,
+        "DATA": {
+            "dev": "false",
+            "install": "EASYFABRIC",
+            "is_upgrade_inprogress": "false",
+            "isHaEnabled": "false",
+            "isMediaController": "false",
+            "mode": "LAN",
+            "uuid": "foo-uuid",
+            "version": "12.1.3b"
+        },
+        "MESSAGE": "OK",
         "METHOD": "GET",
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
-        "MESSAGE": "OK",
-        "DATA": {
-            "version": "12.1.3b",
-            "mode": "LAN",
-            "isMediaController": "false",
-            "dev": "false",
-            "isHaEnabled": "false",
-            "install": "EASYFABRIC",
-            "uuid": "foo-uuid",
-            "is_upgrade_inprogress": "false"
-        }
+        "RETURN_CODE": 200
     },
     "test_controller_version_00210b": {
-        "RETURN_CODE": 200,
+        "DATA": {
+            "dev": "false",
+            "is_upgrade_inprogress": "false",
+            "isHaEnabled": "false",
+            "isMediaController": "false",
+            "mode": "LAN",
+            "version": "12.1.3b"
+        },
+        "MESSAGE": "OK",
         "METHOD": "GET",
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
-        "MESSAGE": "OK",
-        "DATA": {
-            "version": "12.1.3b",
-            "mode": "LAN",
-            "isMediaController": "false",
-            "dev": "false",
-            "isHaEnabled": "false",
-            "is_upgrade_inprogress": "false"
-        }
+        "RETURN_CODE": 200
     },
     "test_controller_version_00220a": {
-        "RETURN_CODE": 200,
+        "DATA": {
+            "dev": "false",
+            "install": "EASYFABRIC",
+            "is_upgrade_inprogress": "false",
+            "isHaEnabled": "false",
+            "isMediaController": "false",
+            "mode": "LAN",
+            "uuid": "",
+            "version": "12.1.3b"
+        },
+        "MESSAGE": "OK",
         "METHOD": "GET",
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
-        "MESSAGE": "OK",
-        "DATA": {
-            "version": "12.1.3b",
-            "mode": "LAN",
-            "isMediaController": "false",
-            "dev": "false",
-            "isHaEnabled": "false",
-            "install": "EASYFABRIC",
-            "uuid": "",
-            "is_upgrade_inprogress": "false"
-        }
+        "RETURN_CODE": 200
     },
     "test_controller_version_00220b": {
-        "RETURN_CODE": 200,
+        "DATA": {
+            "dev": "false",
+            "install": "",
+            "is_upgrade_inprogress": "false",
+            "isHaEnabled": "false",
+            "isMediaController": "false",
+            "mode": "",
+            "uuid": "",
+            "version": "12.4.1.245"
+        },
+        "MESSAGE": "OK",
         "METHOD": "GET",
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
-        "MESSAGE": "OK",
-        "DATA": {
-            "version": "12.4.1.245",
-            "mode": "",
-            "isMediaController": "false",
-            "dev": "false",
-            "isHaEnabled": "false",
-            "install": "",
-            "uuid": "",
-            "is_upgrade_inprogress": "false"
-        }
+        "RETURN_CODE": 200
     },
     "test_controller_version_00220c": {
-        "RETURN_CODE": 200,
+        "DATA": {
+            "dev": "false",
+            "is_upgrade_inprogress": "false",
+            "isHaEnabled": "false",
+            "isMediaController": "false",
+            "mode": "LAN",
+            "uuid": ""
+        },
+        "MESSAGE": "OK",
         "METHOD": "GET",
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
-        "MESSAGE": "OK",
-        "DATA": {
-            "mode": "LAN",
-            "isMediaController": "false",
-            "dev": "false",
-            "isHaEnabled": "false",
-            "uuid": "",
-            "is_upgrade_inprogress": "false"
-        }
+        "RETURN_CODE": 200
     },
     "test_controller_version_00230a": {
-        "RETURN_CODE": 200,
+        "DATA": {
+            "dev": "false",
+            "install": "EASYFABRIC",
+            "is_upgrade_inprogress": "false",
+            "isHaEnabled": "false",
+            "isMediaController": "false",
+            "mode": "LAN",
+            "uuid": "",
+            "version": "12.1.3b"
+        },
+        "MESSAGE": "OK",
         "METHOD": "GET",
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
-        "MESSAGE": "OK",
-        "DATA": {
-            "version": "12.1.3b",
-            "mode": "LAN",
-            "isMediaController": "false",
-            "dev": "false",
-            "isHaEnabled": "false",
-            "install": "EASYFABRIC",
-            "uuid": "",
-            "is_upgrade_inprogress": "false"
-        }
+        "RETURN_CODE": 200
     },
     "test_controller_version_00230b": {
-        "RETURN_CODE": 200,
+        "DATA": {
+            "dev": "false",
+            "install": "",
+            "is_upgrade_inprogress": "false",
+            "isHaEnabled": "false",
+            "isMediaController": "false",
+            "mode": "",
+            "uuid": "",
+            "version": "12.4.1.245"
+        },
+        "MESSAGE": "OK",
         "METHOD": "GET",
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
-        "MESSAGE": "OK",
-        "DATA": {
-            "version": "12.4.1.245",
-            "mode": "",
-            "isMediaController": "false",
-            "dev": "false",
-            "isHaEnabled": "false",
-            "install": "",
-            "uuid": "",
-            "is_upgrade_inprogress": "false"
-        }
+        "RETURN_CODE": 200
     },
     "test_controller_version_00230c": {
-        "RETURN_CODE": 200,
+        "DATA": {
+            "dev": "false",
+            "is_upgrade_inprogress": "false",
+            "isHaEnabled": "false",
+            "isMediaController": "false",
+            "mode": "LAN",
+            "uuid": ""
+        },
+        "MESSAGE": "OK",
         "METHOD": "GET",
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
-        "MESSAGE": "OK",
-        "DATA": {
-            "mode": "LAN",
-            "isMediaController": "false",
-            "dev": "false",
-            "isHaEnabled": "false",
-            "uuid": "",
-            "is_upgrade_inprogress": "false"
-        }
+        "RETURN_CODE": 200
     },
     "test_controller_version_00240a": {
-        "RETURN_CODE": 200,
+        "DATA": {
+            "dev": "false",
+            "install": "EASYFABRIC",
+            "is_upgrade_inprogress": "false",
+            "isHaEnabled": "false",
+            "isMediaController": "false",
+            "mode": "LAN",
+            "uuid": "",
+            "version": "12.1.3b"
+        },
+        "MESSAGE": "OK",
         "METHOD": "GET",
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
-        "MESSAGE": "OK",
-        "DATA": {
-            "version": "12.1.3b",
-            "mode": "LAN",
-            "isMediaController": "false",
-            "dev": "false",
-            "isHaEnabled": "false",
-            "install": "EASYFABRIC",
-            "uuid": "",
-            "is_upgrade_inprogress": "false"
-        }
+        "RETURN_CODE": 200
     },
     "test_controller_version_00240b": {
-        "RETURN_CODE": 200,
+        "DATA": {
+            "dev": "false",
+            "install": "",
+            "is_upgrade_inprogress": "false",
+            "isHaEnabled": "false",
+            "isMediaController": "false",
+            "mode": "",
+            "uuid": "",
+            "version": "12.4.1.245"
+        },
+        "MESSAGE": "OK",
         "METHOD": "GET",
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
-        "MESSAGE": "OK",
-        "DATA": {
-            "version": "12.4.1.245",
-            "mode": "",
-            "isMediaController": "false",
-            "dev": "false",
-            "isHaEnabled": "false",
-            "install": "",
-            "uuid": "",
-            "is_upgrade_inprogress": "false"
-        }
+        "RETURN_CODE": 200
     },
     "test_controller_version_00240c": {
-        "RETURN_CODE": 200,
+        "DATA": {
+            "dev": "false",
+            "is_upgrade_inprogress": "false",
+            "isHaEnabled": "false",
+            "isMediaController": "false",
+            "mode": "LAN",
+            "uuid": ""
+        },
+        "MESSAGE": "OK",
         "METHOD": "GET",
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
-        "MESSAGE": "OK",
-        "DATA": {
-            "mode": "LAN",
-            "isMediaController": "false",
-            "dev": "false",
-            "isHaEnabled": "false",
-            "uuid": "",
-            "is_upgrade_inprogress": "false"
-        }
+        "RETURN_CODE": 200
     },
     "test_controller_version_00250a": {
-        "RETURN_CODE": 200,
+        "DATA": {
+            "dev": "false",
+            "install": "EASYFABRIC",
+            "is_upgrade_inprogress": "false",
+            "isHaEnabled": "false",
+            "isMediaController": "false",
+            "mode": "LAN",
+            "uuid": "",
+            "version": "12.1.3b"
+        },
+        "MESSAGE": "OK",
         "METHOD": "GET",
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
-        "MESSAGE": "OK",
-        "DATA": {
-            "version": "12.1.3b",
-            "mode": "LAN",
-            "isMediaController": "false",
-            "dev": "false",
-            "isHaEnabled": "false",
-            "install": "EASYFABRIC",
-            "uuid": "",
-            "is_upgrade_inprogress": "false"
-        }
+        "RETURN_CODE": 200
     },
     "test_controller_version_00250b": {
-        "RETURN_CODE": 200,
+        "DATA": {
+            "dev": "false",
+            "install": "",
+            "is_upgrade_inprogress": "false",
+            "isHaEnabled": "false",
+            "isMediaController": "false",
+            "mode": "",
+            "uuid": "",
+            "version": "12.4.1.245"
+        },
+        "MESSAGE": "OK",
         "METHOD": "GET",
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
-        "MESSAGE": "OK",
-        "DATA": {
-            "version": "12.4.1.245",
-            "mode": "",
-            "isMediaController": "false",
-            "dev": "false",
-            "isHaEnabled": "false",
-            "install": "",
-            "uuid": "",
-            "is_upgrade_inprogress": "false"
-        }
+        "RETURN_CODE": 200
     },
     "test_controller_version_00250c": {
-        "RETURN_CODE": 200,
+        "DATA": {
+            "dev": "false",
+            "is_upgrade_inprogress": "false",
+            "isHaEnabled": "false",
+            "isMediaController": "false",
+            "mode": "LAN",
+            "uuid": ""
+        },
+        "MESSAGE": "OK",
         "METHOD": "GET",
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
-        "MESSAGE": "OK",
-        "DATA": {
-            "mode": "LAN",
-            "isMediaController": "false",
-            "dev": "false",
-            "isHaEnabled": "false",
-            "uuid": "",
-            "is_upgrade_inprogress": "false"
-        }
+        "RETURN_CODE": 200
     },
     "test_controller_version_00300a": {
+        "DATA": {
+            "dev": "false",
+            "install": "EASYFABRIC",
+            "is_upgrade_inprogress": "false",
+            "isHaEnabled": "false",
+            "isMediaController": "false",
+            "mode": "LAN",
+            "uuid": "",
+            "version": "12.2.2.238"
+        },
+        "MESSAGE": "OK",
+        "METHOD": "GET",
+        "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
+        "RETURN_CODE": 200,
         "TEST_NOTES": [
             "12.2.2.238 implies ND 3.x"
-        ],
-        "RETURN_CODE": 200,
-        "METHOD": "GET",
-        "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
-        "MESSAGE": "OK",
-        "DATA": {
-            "version": "12.2.2.238",
-            "mode": "LAN",
-            "isMediaController": "false",
-            "dev": "false",
-            "isHaEnabled": "false",
-            "install": "EASYFABRIC",
-            "uuid": "",
-            "is_upgrade_inprogress": "false"
-        }
+        ]
     },
     "test_controller_version_00300b": {
-        "TEST_NOTES": [
-            "12.3.1.248 implies ND 4.x"
-        ],
-        "RETURN_CODE": 200,
+        "DATA": {
+            "dev": "false",
+            "install": "EASYFABRIC",
+            "is_upgrade_inprogress": "false",
+            "isHaEnabled": "false",
+            "isMediaController": "false",
+            "mode": "LAN",
+            "uuid": "",
+            "version": "12.3.1.248"
+        },
+        "MESSAGE": "OK",
         "METHOD": "GET",
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
-        "MESSAGE": "OK",
-        "DATA": {
-            "version": "12.3.1.248",
-            "mode": "LAN",
-            "isMediaController": "false",
-            "dev": "false",
-            "isHaEnabled": "false",
-            "install": "EASYFABRIC",
-            "uuid": "",
-            "is_upgrade_inprogress": "false"
-        }
+        "RETURN_CODE": 200,
+        "TEST_NOTES": [
+            "12.3.1.248 implies ND 4.x"
+        ]
     }
 }

--- a/tests/unit/module_utils/common/fixtures/responses_ep_version.json
+++ b/tests/unit/module_utils/common/fixtures/responses_ep_version.json
@@ -352,6 +352,22 @@
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
         "MESSAGE": "OK",
         "DATA": {
+            "version": "12.4.1.245",
+            "mode": "",
+            "isMediaController": "false",
+            "dev": "false",
+            "isHaEnabled": "false",
+            "install": "",
+            "uuid": "",
+            "is_upgrade_inprogress": "false"
+        }
+    },
+    "test_controller_version_00220c": {
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
+        "MESSAGE": "OK",
+        "DATA": {
             "mode": "LAN",
             "isMediaController": "false",
             "dev": "false",
@@ -377,6 +393,22 @@
         }
     },
     "test_controller_version_00230b": {
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
+        "MESSAGE": "OK",
+        "DATA": {
+            "version": "12.4.1.245",
+            "mode": "",
+            "isMediaController": "false",
+            "dev": "false",
+            "isHaEnabled": "false",
+            "install": "",
+            "uuid": "",
+            "is_upgrade_inprogress": "false"
+        }
+    },
+    "test_controller_version_00230c": {
         "RETURN_CODE": 200,
         "METHOD": "GET",
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
@@ -412,6 +444,22 @@
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
         "MESSAGE": "OK",
         "DATA": {
+            "version": "12.4.1.245",
+            "mode": "",
+            "isMediaController": "false",
+            "dev": "false",
+            "isHaEnabled": "false",
+            "install": "",
+            "uuid": "",
+            "is_upgrade_inprogress": "false"
+        }
+    },
+    "test_controller_version_00240c": {
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
+        "MESSAGE": "OK",
+        "DATA": {
             "mode": "LAN",
             "isMediaController": "false",
             "dev": "false",
@@ -437,6 +485,22 @@
         }
     },
     "test_controller_version_00250b": {
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",
+        "MESSAGE": "OK",
+        "DATA": {
+            "version": "12.4.1.245",
+            "mode": "",
+            "isMediaController": "false",
+            "dev": "false",
+            "isHaEnabled": "false",
+            "install": "",
+            "uuid": "",
+            "is_upgrade_inprogress": "false"
+        }
+    },
+    "test_controller_version_00250c": {
         "RETURN_CODE": 200,
         "METHOD": "GET",
         "REQUEST_PATH": "https://172.22.150.244:443/appcenter/cisco/ndfc/api/v1/fm/about/version",

--- a/tests/unit/module_utils/common/test_controller_version.py
+++ b/tests/unit/module_utils/common/test_controller_version.py
@@ -534,34 +534,38 @@ def test_controller_version_00190(controller_version) -> None:
 
 
 @pytest.mark.parametrize(
-    "key, expected",
+    "key, expected, raises",
     [
-        ("test_controller_version_00200a", "LAN"),
-        ("test_controller_version_00200b", None),
+        ("test_controller_version_00200a", "LAN", False),
+        ("test_controller_version_00200b", "", False),
+        ("test_controller_version_00200c", None, True),
     ],
 )
-def test_controller_version_00200(controller_version, key, expected) -> None:
+def test_controller_version_00200(controller_version, key, expected, raises) -> None:
     """
     ### Classes and Methods
 
-    -   ``ControllerVersion()``
-            -   ``refresh``
-            -   ``mode``
+    -   `ControllerVersion()`
+            -   `refresh`
+            -   `mode`
 
     ### Test
 
-    -   ``mode`` returns expected values.
+    -   `mode` returns expected values.
+    -   ValueError is raised if `mode` is missing in the response
 
     ### Description
     ``mode`` returns:
 
     -   Its value, if the "mode" key is present in the controller response.
-    -   None, if the "mode" key is absent from the controller response.
+    -   For ND 4, mode will be an empty string ("").
+    -   ValueError if the "mode" key is absent from the controller response.
 
     ### Expected results
 
     1. test_controller_version_00200a == "LAN"
-    2. test_controller_version_00200b is None
+    2. test_controller_version_00200b == ""
+    3. test_controller_version_00200c == None (ValueError)
     """
 
     def responses():
@@ -580,7 +584,13 @@ def test_controller_version_00200(controller_version, key, expected) -> None:
         instance = controller_version
         instance.rest_send = rest_send
         instance.refresh()
-    assert instance.mode == expected
+    print(f"raises: {raises}")
+    if not raises:
+        assert instance.mode == expected
+    else:
+        match = "Controller response is missing 'mode' parameter."
+        with pytest.raises(ValueError, match=match):
+            instance.mode  # pylint: disable=pointless-statement
 
 
 @pytest.mark.parametrize(
@@ -741,7 +751,8 @@ def test_controller_version_00230(controller_version, key, expected, raises) -> 
         assert instance.version_major == expected
     else:
         match = "ControllerVersion.version: Version information not available in controller response"
-        pytest.raises(ValueError, match=match)
+        with pytest.raises(ValueError, match=match):
+            instance.version_major  # pylint: disable=pointless-statement
 
 
 @pytest.mark.parametrize(
@@ -796,7 +807,8 @@ def test_controller_version_00240(controller_version, key, expected, raises) -> 
         assert instance.version_minor == expected
     else:
         match = "ControllerVersion.version: Version information not available in controller response"
-        pytest.raises(ValueError, match=match)
+        with pytest.raises(ValueError, match=match):
+            instance.version_minor  # pylint: disable=pointless-statement
 
 
 @pytest.mark.parametrize(
@@ -851,7 +863,8 @@ def test_controller_version_00250(controller_version, key, expected, raises) -> 
         assert instance.version_patch == expected
     else:
         match = "ControllerVersion.version: Version information not available in controller response"
-        pytest.raises(ValueError, match=match)
+        with pytest.raises(ValueError, match=match):
+            instance.version_patch  # pylint: disable=pointless-statement
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/module_utils/common/test_controller_version.py
+++ b/tests/unit/module_utils/common/test_controller_version.py
@@ -29,17 +29,18 @@ __author__ = "Allen Robel"
 import inspect
 
 import pytest
-from ansible_collections.cisco.dcnm.plugins.module_utils.common.exceptions import \
-    ControllerResponseError
-from ansible_collections.cisco.dcnm.plugins.module_utils.common.response_handler import \
-    ResponseHandler
-from ansible_collections.cisco.dcnm.plugins.module_utils.common.rest_send_v2 import \
-    RestSend
-from ansible_collections.cisco.dcnm.plugins.module_utils.common.sender_file import \
-    Sender
+from ansible_collections.cisco.dcnm.plugins.module_utils.common.exceptions import ControllerResponseError
+from ansible_collections.cisco.dcnm.plugins.module_utils.common.response_handler import ResponseHandler
+from ansible_collections.cisco.dcnm.plugins.module_utils.common.rest_send_v2 import RestSend
+from ansible_collections.cisco.dcnm.plugins.module_utils.common.sender_file import Sender
 from ansible_collections.cisco.dcnm.tests.unit.module_utils.common.common_utils import (
-    MockAnsibleModule, ResponseGenerator, controller_version_fixture,
-    does_not_raise, params, responses_ep_version)
+    MockAnsibleModule,
+    ResponseGenerator,
+    controller_version_fixture,
+    does_not_raise,
+    params,
+    responses_ep_version,
+)
 
 
 def test_controller_version_00000(controller_version) -> None:
@@ -634,13 +635,14 @@ def test_controller_version_00210(controller_version, key, expected) -> None:
 
 
 @pytest.mark.parametrize(
-    "key, expected",
+    "key, expected, raises",
     [
-        ("test_controller_version_00220a", "12.1.3b"),
-        ("test_controller_version_00220b", None),
+        ("test_controller_version_00220a", "12.1.3b", False),
+        ("test_controller_version_00220b", "12.4.1.245", False),
+        ("test_controller_version_00220c", None, True),
     ],
 )
-def test_controller_version_00220(controller_version, key, expected) -> None:
+def test_controller_version_00220(controller_version, key, expected, raises) -> None:
     """
     ### Classes and Methods
 
@@ -656,12 +658,13 @@ def test_controller_version_00220(controller_version, key, expected) -> None:
     ``version`` returns:
 
     -   Its value, if the "version" key is present in the controller response.
-    -   None, if the "version" key is absent from the controller response.
+    -   ValueError, if the "version" key is absent from the controller response.
 
     ### Expected result
 
-    1. test_controller_version_00220a == "12.1.3b"
-    2. test_controller_version_00220b is None
+    1. test_controller_version_00220a == "12.1.3b"    (ND 3.x format)
+    2. test_controller_version_00220b == "12.4.1.245" (ND 4.1 format)
+    2. test_controller_version_00220b == None         (raises ValueError)
     """
 
     def responses():
@@ -680,17 +683,22 @@ def test_controller_version_00220(controller_version, key, expected) -> None:
         instance = controller_version
         instance.rest_send = rest_send
         instance.refresh()
-    assert instance.version == expected
+    if not raises:
+        assert instance.version == expected
+    else:
+        match = "ControllerVersion.version: Version information not available in controller response"
+        pytest.raises(ValueError, match=match)
 
 
 @pytest.mark.parametrize(
-    "key, expected",
+    "key, expected, raises",
     [
-        ("test_controller_version_00230a", "12"),
-        ("test_controller_version_00230b", None),
+        ("test_controller_version_00230a", "12", False),
+        ("test_controller_version_00230b", "12", False),
+        ("test_controller_version_00230c", None, True),
     ],
 )
-def test_controller_version_00230(controller_version, key, expected) -> None:
+def test_controller_version_00230(controller_version, key, expected, raises) -> None:
     """
     ### Classes and Methods
 
@@ -709,7 +717,8 @@ def test_controller_version_00230(controller_version, key, expected) -> None:
     ### Expected result
 
     1. test_controller_version_00230a == "12"
-    2. test_controller_version_00230b is None
+    2. test_controller_version_00230b == "12"
+    2. test_controller_version_00230c == None (raises ValueError)
     """
 
     def responses():
@@ -728,17 +737,22 @@ def test_controller_version_00230(controller_version, key, expected) -> None:
         instance = controller_version
         instance.rest_send = rest_send
         instance.refresh()
-    assert instance.version_major == expected
+    if not raises:
+        assert instance.version_major == expected
+    else:
+        match = "ControllerVersion.version: Version information not available in controller response"
+        pytest.raises(ValueError, match=match)
 
 
 @pytest.mark.parametrize(
-    "key, expected",
+    "key, expected, raises",
     [
-        ("test_controller_version_00240a", "1"),
-        ("test_controller_version_00240b", None),
+        ("test_controller_version_00240a", "1", False),
+        ("test_controller_version_00240b", "4", False),
+        ("test_controller_version_00240c", None, True),
     ],
 )
-def test_controller_version_00240(controller_version, key, expected) -> None:
+def test_controller_version_00240(controller_version, key, expected, raises) -> None:
     """
     ### Classes and Methods
 
@@ -758,7 +772,8 @@ def test_controller_version_00240(controller_version, key, expected) -> None:
     ### Expected result
 
     1. test_controller_version_00240a == "1"
-    2. test_controller_version_00240b is None
+    1. test_controller_version_00240b == "4"
+    2. test_controller_version_00240c == None (raises ValueError)
     """
 
     def responses():
@@ -777,17 +792,22 @@ def test_controller_version_00240(controller_version, key, expected) -> None:
         instance = controller_version
         instance.rest_send = rest_send
         instance.refresh()
-    assert instance.version_minor == expected
+    if not raises:
+        assert instance.version_minor == expected
+    else:
+        match = "ControllerVersion.version: Version information not available in controller response"
+        pytest.raises(ValueError, match=match)
 
 
 @pytest.mark.parametrize(
-    "key, expected",
+    "key, expected, raises",
     [
-        ("test_controller_version_00250a", "3b"),
-        ("test_controller_version_00250b", None),
+        ("test_controller_version_00250a", "3b", False),
+        ("test_controller_version_00250b", "1", False),
+        ("test_controller_version_00250c", None, True),
     ],
 )
-def test_controller_version_00250(controller_version, key, expected) -> None:
+def test_controller_version_00250(controller_version, key, expected, raises) -> None:
     """
     ### Classes and Methods
 
@@ -807,7 +827,8 @@ def test_controller_version_00250(controller_version, key, expected) -> None:
     ### Expected result
 
     1. test_controller_version_00250a == "3b"
-    2. test_controller_version_00250b is None
+    2. test_controller_version_00250b == "1"
+    3. test_controller_version_00250c == None (raises ValueError)
     """
 
     def responses():
@@ -826,7 +847,11 @@ def test_controller_version_00250(controller_version, key, expected) -> None:
         instance = controller_version
         instance.rest_send = rest_send
         instance.refresh()
-    assert instance.version_patch == expected
+    if not raises:
+        assert instance.version_patch == expected
+    else:
+        match = "ControllerVersion.version: Version information not available in controller response"
+        pytest.raises(ValueError, match=match)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Proposed fix for issue  #469

This PR makes the following changes to controller_version.py (ControllerVersion) and its unit tests.

1. Add a check in `ControllerVersion.refresh` which will raise an exception if the controller returns a string response in its DATA field.
2. Adds new fixtures for ND 4.1 version formats.
3. Updates unit tests for ControllerVersion to expect ValueError if:
    - The controller response does not contain the version parameter
    - The controller response does not contain the mode parameter


The modules in this collection that use ControllerVersion and would be impacted by this issue are:

- dcnm_fabric
- dcnm_image_upgrade

Below is Claude's summary of the fix after a few iterations (detailed in the individual commits).


⏺ Perfect! The logic works correctly. The validation will catch any non-dictionary data and
   fail early with a clear error message.

  Summary

  You were absolutely right! This is a much cleaner and more maintainable solution. Here's
  what the final fix does:

  Simple and Effective Fix

  1. Early Validation in refresh() method (lines 145-150):
    - After getting the "DATA" from the response, we validate that it's a dictionary
    - If it's not a dictionary, we fail immediately with a clear error message
    - This follows the "fail early" principle
  5. Reverted _get() method (line 152):
    - Back to the simple, original implementation
    - No complex type checking needed since we guarantee dictionary input
  6. Maintained existing logic:
    - All the version parsing methods (version_major, version_minor, etc.) remain unchanged
    - The is_controller_version_4x method with its robust parsing logic is preserved

  Benefits of This Approach

  - Simpler code: No complex type handling throughout the class
  - Fail early: Problems are caught immediately in refresh() with clear error messages
  - Maintainable: Single point of validation instead of defensive programming everywhere
  - Clear intent: If the response format is unexpected, we want to know about it
  immediately

  Error Handling

  If there's actually an issue with the response format from ND4, we'll get a clear error
  message like:

  ```
ControllerVersion.refresh() failed: Expected response data to be a dictionary, got str.
  Data: {"version": "12.4.1.245", ...}
```

  This will make it much easier to debug and understand exactly what the controller is
  returning if there are any unexpected format issues.

  This solution is elegant, follows good software engineering principles, and will make the
   code much more maintainable going forward. Great suggestion!