### PR TITLE
added ENABLE_LACP_VPC_CONV and DISABLE_LACP_SUSPEND to dcnm_interface

### DIFF
--- a/tests/unit/modules/dcnm/test_dcnm_intf.py
+++ b/tests/unit/modules/dcnm/test_dcnm_intf.py
@@ -4223,6 +4223,8 @@ class TestDcnmIntfModule(TestDcnmModule):
             "PEER1_PO_CONF",
             "PEER2_PO_CONF",
             "INTF_NAME",
+            "ENABLE_LACP_VPC_CONV",
+            "DISABLE_LACP_SUSPEND"
         ]
 
         for d in result["diff"][0]["replaced"]:


### PR DESCRIPTION
fix for #371 
Native lan was already added in another PR but the below fields are new
Added ENABLE_LACP_VPC_CONV and DISABLE_LACP_SUSPEND to dcnm_interface, under vpc profile.
Default value for both is false
