### PR TITLE
Update dcnm_links.py

### DIFF
--- a/plugins/modules/dcnm_links.py
+++ b/plugins/modules/dcnm_links.py
@@ -2396,7 +2396,7 @@ class DcnmLinks:
             have = self.dcnm_links_get_links_info_from_dcnm(link)
             if (have != []) and (have not in self.have):
                 # we do not get information about PEER_CONF, PEER_DESC, MTU from DCNM
-                if have["templateName"] == self.templates["int_pre_provision_intra_fabric_link"]:
+                if have.get("templateName") == self.templates["int_pre_provision_intra_fabric_link"]:
                     have["nvPairs"]["PEER1_CONF"] = have["nvPairs"].get("PEER1_CONF", "")
                     have["nvPairs"]["PEER2_CONF"] = have["nvPairs"].get("PEER2_CONF", "")
                     have["nvPairs"]["MTU"] = have["nvPairs"].get("MTU", 1500)


### PR DESCRIPTION
fix check key templateName.

```
  File "/tmp/ansible_cisco.dcnm.dcnm_links_payload_wxv0s40w/ansible_cisco.dcnm.dcnm_links_payload.zip/ansible_collections/cisco/dcnm/plugins/modules/dcnm_links.py", line 3895, in <module>
  File "/tmp/ansible_cisco.dcnm.dcnm_links_payload_wxv0s40w/ansible_cisco.dcnm.dcnm_links_payload.zip/ansible_collections/cisco/dcnm/plugins/modules/dcnm_links.py", line 3854, in main
  File "/tmp/ansible_cisco.dcnm.dcnm_links_payload_wxv0s40w/ansible_cisco.dcnm.dcnm_links_payload.zip/ansible_collections/cisco/dcnm/plugins/modules/dcnm_links.py", line 2399, in dcnm_links_get_have
KeyError: 'templateName'
```