### PR TITLE
dcnm-policy-fix-issue-482

### DIFF
--- a/plugins/modules/dcnm_policy.py
+++ b/plugins/modules/dcnm_policy.py
@@ -524,10 +524,9 @@ class DcnmPolicy:
                 clist, policy_spec
             )
             if invalid_params:
-                mesg = 'Invalid parameters in playbook: while processing policy "{0}", Error: {1}'.format(
-                    cfg["name"], invalid_params
-                )
-                self.module.fail_json(msg=mesg)
+                policy_name = cfg.get("name", "unknown")
+                msg = f"Invalid parameters in playbook: while processing policy {policy_name}, Error: {invalid_params}"
+                self.module.fail_json(msg=msg)
             if self.use_desc_as_key:
                 # Fail the module when use_desc_as_key is True but description is not given or empty
                 if cfg.get("description", "") == "":


### PR DESCRIPTION
# Summary

closes #482 

Fixes KeyError in error message when "name" key is missing from cfg.

No functional changes to the dcnm-policy module.
