### PR TITLE
VRFs should never deploy when deploy flag is False

### DIFF
--- a/plugins/modules/dcnm_vrf.py
+++ b/plugins/modules/dcnm_vrf.py
@@ -2069,14 +2069,15 @@ class DcnmVrf:
         for vrf in all_vrfs:
             # If the playbook sets the deploy key to False, then we need to remove the vrf from the deploy list.
             want_vrf_data = find_dict_in_list_by_key_value(search=self.config, key="vrf_name", value=vrf)
-            if want_vrf_data['deploy'] is False:
+            if want_vrf_data.get('deploy',True) is False:
                 modified_all_vrfs.remove(vrf)
 
-        if not self.diff_deploy:
-            diff_deploy.update({"vrfNames": ",".join(modified_all_vrfs)})
-        else:
-            vrfs = self.diff_deploy["vrfNames"] + "," + ",".join(modified_all_vrfs)
-            diff_deploy.update({"vrfNames": vrfs})
+        if modified_all_vrfs:
+            if not diff_deploy:
+                diff_deploy.update({"vrfNames": ",".join(modified_all_vrfs)})
+            else:
+                vrfs = self.diff_deploy["vrfNames"] + "," + ",".join(modified_all_vrfs)
+                diff_deploy.update({"vrfNames": vrfs})
 
         self.diff_attach = copy.deepcopy(diff_attach)
         self.diff_deploy = copy.deepcopy(diff_deploy)
@@ -2380,11 +2381,15 @@ class DcnmVrf:
         for vrf in all_vrfs:
             # If the playbook sets the deploy key to False, then we need to remove the vrf from the deploy list.
             want_vrf_data = find_dict_in_list_by_key_value(search=self.config, key="vrf_name", value=vrf)
-            if want_vrf_data['deploy'] is False:
+            if want_vrf_data.get("deploy", True) is False:
                 modified_all_vrfs.remove(vrf)
 
-        if len(modified_all_vrfs) != 0:
-            diff_deploy.update({"vrfNames": ",".join(all_vrfs)})
+        if modified_all_vrfs:
+            if not diff_deploy:
+                diff_deploy.update({"vrfNames": ",".join(modified_all_vrfs)})
+            else:
+                vrfs = self.diff_deploy["vrfNames"] + "," + ",".join(modified_all_vrfs)
+                diff_deploy.update({"vrfNames": vrfs})
 
         self.diff_attach = diff_attach
         self.diff_deploy = diff_deploy

--- a/plugins/modules/dcnm_vrf.py
+++ b/plugins/modules/dcnm_vrf.py
@@ -2069,7 +2069,7 @@ class DcnmVrf:
         for vrf in all_vrfs:
             # If the playbook sets the deploy key to False, then we need to remove the vrf from the deploy list.
             want_vrf_data = find_dict_in_list_by_key_value(search=self.config, key="vrf_name", value=vrf)
-            if want_vrf_data.get('deploy',True) is False:
+            if want_vrf_data.get('deploy', True) is False:
                 modified_all_vrfs.remove(vrf)
 
         if modified_all_vrfs:


### PR DESCRIPTION
## Initial Playbook

```yaml
    - name: Configure VRFs
      cisco.dcnm.dcnm_vrf:
        fabric: nac-msd-fabric1
        state: deleted
        config:
        - vrf_name: NetAsCodeVrf1
          vrf_id: 150001
          vlan_id: 2001
          vrf_intf_desc: Configured by Ansible NetAsCode
          vrf_description: Configured by Ansible NetAsCode
          vrf_int_mtu: 9216
          loopback_route_tag: 12345
          max_bgp_paths: 1
          max_ibgp_paths: 2
          ipv6_linklocal_enable: True
          adv_host_routes: False
          adv_default_routes: True
          static_default_route: True
          disable_rt_auto: False
          netflow_enable: False
          no_rp: False
          trm_enable: False
          redist_direct_rmap: FABRIC-RMAP-REDIST-SUBNET
          attach:
            - ip_address: 10.15.34.13  ## Leaf1
            - ip_address: 10.15.34.14  ## Leaf2
            - ip_address: 10.15.34.15  ## Leaf3
            - ip_address: 10.15.34.16  ## Leaf4
          deploy: false
```

* Run the playbook above
    * Initially the VRF will be created and attached to each leaf device but NOT deployed as expected

* If the attach list is modified to remove or add attach devices there are cases where the VRF will be deployed even though the deploy flag is false which is not correct.

Fix for this issue should ensure the following
  * deploy flag is always honored
  * ensure all states will work (merged,replaced,overridden,deleted)
  * we should be able to attach and detach any devices in the list when deploy is false
