### PR TITLE
Update scopeType device in IP_POOL on dcnm_resource_manager.py

### DIFF
--- a/plugins/modules/dcnm_resource_manager.py
+++ b/plugins/modules/dcnm_resource_manager.py
@@ -410,7 +410,7 @@ class DcnmResManager:
             "SERVICE_NETWORK_VLAN": ["device"],
             "TOP_DOWN_VRF_VLAN": ["device"],
             "TOP_DOWN_NETWORK_VLAN": ["device"],
-            "IP_POOL": ["fabric", "device_interface"],
+            "IP_POOL": ["fabric", "device_interface", "device"],
             "SUBNET": ["link"],
         }
         # RESOURCE = {'entity_name': 'l3_vni_fabric', 'pool_type': 'ID', 'pool_name': 'L3_VNI', 'scope_type': 'fabric', 'resource': '101'}


### PR DESCRIPTION
## Fix

add scopeType device in IP_POOL for pool_name: "ROUTER_ID_POOL"

## Issue

```
fatal: [nac-ipv6]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "config": [
                {
                    "entity_name": "9B9EAU0DP6F",
                    "pool_name": "ROUTER_ID_POOL",
                    "pool_type": "IP",
                    "resource": "1.1.2.180",
                    "scope_type": "device",
                    "switch": [
                        "10.229.42.180"
                    ]
                },
                {
                    "entity_name": "9FC431O3ALV",
                    "pool_name": "ROUTER_ID_POOL",
                    "pool_type": "IP",
                    "resource": "1.1.2.181",
                    "scope_type": "device",
                    "switch": [
                        "10.229.42.181"
                    ]
                }
            ],
            "fabric": "nac-IPv6",
            "state": "merged"
        }
    },
    "msg": "Given scope type 'device' is not valid for pool name = 'ROUTER_ID_POOL', Allowed scope_types = ['fabric', 'device_interface']"
}
```


API: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/resource-manager/fabrics/nac-IPv6/resources
Method: Post
Payload:
{
"poolName": "ROUTER_ID_POOL",
"scopeType": "Device",
"entityName": "9FC431O3ALV",
"resource": "1.1.1.181",
"scopeValue": "9FC431O3ALV"
}

## Playbook

```
---
- name: Write hostname
  hosts: nac-ipv6

  tasks:
    - name: Configure resource IPv6
      cisco.dcnm.dcnm_resource_manager:
        state: merged
        fabric: nac-IPv6
        config:
          - entity_name: "9B9EAU0DP6F"
            pool_type: IP
            pool_name: "ROUTER_ID_POOL"
            scope_type: device
            resource: "1.1.2.180"
            switch:
              - 10.229.42.180

          - entity_name: "9FC431O3ALV"
            pool_type: IP
            pool_name: "ROUTER_ID_POOL"
            scope_type: device
            resource: "1.1.2.181"
            switch:
              - 10.229.42.181
   ```

Result:

```
changed: [nac-ipv6] => {
    "StartTime": "19:53:17",
    "changed": true,
    "diff": [
        {
            "debugs": [],
            "deleted": [],
            "merged": [
                {
                    "entityName": "9B9EAU0DP6F",
                    "poolName": "ROUTER_ID_POOL",
                    "resource": "1.1.2.180",
                    "scopeType": "Device",
                    "scopeValue": "9B9EAU0DP6F"
                },
                {
                    "entityName": "9FC431O3ALV",
                    "poolName": "ROUTER_ID_POOL",
                    "resource": "1.1.2.181",
                    "scopeType": "Device",
                    "scopeValue": "9FC431O3ALV"
                }
            ],
            "query": []
        }
    ],
    "invocation": {
        "module_args": {
            "config": [
                {
                    "entity_name": "9B9EAU0DP6F",
                    "pool_name": "ROUTER_ID_POOL",
                    "pool_type": "IP",
                    "resource": "1.1.2.180",
                    "scope_type": "device",
                    "switch": [
                        "10.229.42.180"
                    ]
                },
                {
                    "entity_name": "9FC431O3ALV",
                    "pool_name": "ROUTER_ID_POOL",
                    "pool_type": "IP",
                    "resource": "1.1.2.181",
                    "scope_type": "device",
                    "switch": [
                        "10.229.42.181"
                    ]
                }
            ],
            "fabric": "nac-IPv6",
            "state": "merged"
        }
    },
    "response": [
        {
            "DATA": {
                "dbId": 4042,
                "resource": "1.1.2.180"
            },
            "MESSAGE": "OK",
            "METHOD": "POST",
            "REQUEST_PATH": "https://10.60.3.55:443/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/resource-manager/fabrics/nac-IPv6/resources",
            "RETURN_CODE": 200
        },
        {
            "DATA": {
                "dbId": 4043,
                "resource": "1.1.2.181"
            },
            "MESSAGE": "OK",
            "METHOD": "POST",
            "REQUEST_PATH": "https://10.60.3.55:443/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/resource-manager/fabrics/nac-IPv6/resources",
            "RETURN_CODE": 200
        }
    ]
}

PLAY RECAP ********************************************************************************************************************************************************************************************************************************************************
nac-ipv6                   : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0  
```