### PR TITLE
Add Transfer-Encoding chunked header

### DIFF
--- a/plugins/httpapi/dcnm.py
+++ b/plugins/httpapi/dcnm.py
@@ -65,7 +65,7 @@ DEFAULT_RETRY_COUNT = 5
 class HttpApi(HttpApiBase):
     def __init__(self, *args, **kwargs):
         super(HttpApi, self).__init__(*args, **kwargs)
-        self.headers = {"Content-Type": "application/json"}
+        self.headers = {"Content-Type": "application/json", 'Transfer-Encoding': 'chunked'}
         self.urlencoded_headers = {"Content-Type": "application/x-www-form-urlencoded"}
         self.txt_headers = {"Content-Type": "text/plain"}
         self.version = None

--- a/tests/unit/plugins/httpapi/test_dcnm.py
+++ b/tests/unit/plugins/httpapi/test_dcnm.py
@@ -54,7 +54,7 @@ class TestHttpApiInit:
         """Test that HttpApi initializes with correct default values."""
         http_api = HttpApi(mock_connection)
 
-        assert http_api.headers == {"Content-Type": "application/json"}
+        assert http_api.headers == {"Content-Type": "application/json", 'Transfer-Encoding': 'chunked'}
         assert http_api.txt_headers == {"Content-Type": "text/plain"}
         assert http_api.version is None
         assert http_api.retrycount == 5


### PR DESCRIPTION
We discovered a problem where onemanage API's are resulting in truncated output for various `GET` calls.  The same APIs work fine with postman or curl which led to a deeper investigation into our httpapi plugin.  Adding the new header appears to solve "chunking" or truncating issue.