### PR TITLE
fix key issue: 'ENABLE_MACSEC' on dcnm_links.py 

### DIFF
--- a/plugins/modules/dcnm_links.py
+++ b/plugins/modules/dcnm_links.py
@@ -3075,8 +3075,9 @@ class DcnmLinks:
                 == self.templates["int_intra_fabric_unnum_link"]
             )
         ):
-            if (
-                str(wlink["nvPairs"]["ENABLE_MACSEC"]).lower()
+            if ( 
+                hlink["nvPairs"].get("ENABLE_MACSEC") and
+                str(wlink["nvPairs"].get("ENABLE_MACSEC")).lower()
                 != str(hlink["nvPairs"].get("ENABLE_MACSEC")).lower()
             ):
                 mismatch_reasons.append(


### PR DESCRIPTION
Add safe.get for ENABLE_MACSEC, as the key is not always returned by ND.