### PR TITLE
Add dhcp servers list

### DIFF
--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -2856,12 +2856,6 @@ class DcnmNetwork:
                                 invalid_params.append("vrf_name is required for L3 Networks")
 
                         if (
-                            (net.get("dhcp_srvr1_ip") or net.get("dhcp_srvr2_ip") or net.get("dhcp_srvr3_ip"))
-                            and (net.get("dhcp_servers"))
-                        ):
-                            invalid_params.append("DHCP key-value pairs and DHCP servers list cannot be used together")
-
-                        if (
                             (net.get("dhcp_srvr1_ip") and not net.get("dhcp_srvr1_vrf"))
                             or (net.get("dhcp_srvr1_vrf") and not net.get("dhcp_srvr1_ip"))
                             or (net.get("dhcp_srvr2_ip") and not net.get("dhcp_srvr2_vrf"))


### PR DESCRIPTION
This PR adds a new key `dhcp_servers` that can be used as an alternative to the `dhcp_srvr1_ip`, `dhcp_srvr1_vrf`, `dhcp_srvr2_ip`, `dhcp_srvr2_vrf`, `dhcp_srvr3_ip` and `dhcp_srvr3_vrf`.  The main difference is that `dhcp_servers` can define up to 16 DHCP servers and their VRFs.

Verification for the states `merged`, `replaced` and `overriden` was successfull.

Fixes #506 