### PR TITLE
dcnm_network: Fix TOR port handling

### DIFF
--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -668,9 +668,10 @@ class DcnmNetwork:
                                     else:
                                         # Dont update torports_configured to True.
                                         # If at all there is any other config change, this attach to will be appended attach_list there
+                                        torconfig_list = []
                                         for tor_h in have.get("torports"):
-                                            torconfig = tor_h["switch"] + "(" + tor_h["torPorts"] + ")"
-                                            want.update({"torPorts": torconfig})
+                                            torconfig_list.append(tor_h["switch"] + "(" + tor_h["torPorts"] + ")")
+                                        want.update({"torPorts": " ".join(torconfig_list)})
 
                                     del have["torports"]
 
@@ -750,9 +751,10 @@ class DcnmNetwork:
                                     continue
                                 del want["isAttached"]
                                 if want.get("torports"):
+                                    torconfig_list = []
                                     for tor_w in want["torports"]:
-                                        torconfig = tor_w["switch"] + "(" + tor_w["torPorts"] + ")"
-                                        want.update({"torPorts": torconfig})
+                                        torconfig_list.append(tor_w["switch"] + "(" + tor_w["torPorts"] + ")")
+                                    want.update({"torPorts": " ".join(torconfig_list)})
                                 del want["torports"]
                                 want.update({"deployment": True})
                                 attach_list.append(want)
@@ -774,9 +776,10 @@ class DcnmNetwork:
             if not found:
                 if bool(want["isAttached"]):
                     if want.get("torports"):
+                        torconfig_list = []
                         for tor_w in want["torports"]:
-                            torconfig = tor_w["switch"] + "(" + tor_w["torPorts"] + ")"
-                            want.update({"torPorts": torconfig})
+                            torconfig_list.append(tor_w["switch"] + "(" + tor_w["torPorts"] + ")")
+                        want.update({"torPorts": " ".join(torconfig_list)})
                     del want["torports"]
                     del want["isAttached"]
                     want["deployment"] = True
@@ -848,11 +851,11 @@ class DcnmNetwork:
         attach.update({"freeformConfig": ""})
         attach.update({"is_deploy": deploy})
         if attach.get("tor_ports"):
-            torports = {}
             if role.lower() != "leaf":
                 msg = "tor_ports for Networks cannot be attached to switch {0} with role {1}".format(attach["ip_address"], role)
                 self.module.fail_json(msg=msg)
             for tor in attach.get("tor_ports"):
+                torports = {}
                 torports.update({"switch": self.inventory_data[tor["ip_address"]].get("logicalName")})
                 torports.update({"torPorts": ",".join(tor["ports"])})
                 torlist.append(torports)
@@ -2062,9 +2065,10 @@ class DcnmNetwork:
                     # Saftey check
                     if attach.get("isAttached"):
                         if attach.get("torports"):
+                            torconfig_list = []
                             for tor_w in attach["torports"]:
-                                torconfig = tor_w["switch"] + "(" + tor_w["torPorts"] + ")"
-                                attach.update({"torPorts": torconfig})
+                                torconfig_list.append(tor_w["switch"] + "(" + tor_w["torPorts"] + ")")
+                            attach.update({"torPorts": " ".join(torconfig_list)})
                         del attach["torports"]
                         del attach["isAttached"]
                         atch_list.append(attach)

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright (c) 2020-2023 Cisco and/or its affiliates.
+# Copyright (c) 2020-2025 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -605,6 +605,7 @@ class DcnmNetwork:
     def diff_for_attach_deploy(self, want_a, have_a, replace=False):
 
         attach_list = []
+        atch_tor_ports = []
 
         if not want_a:
             return attach_list
@@ -628,7 +629,6 @@ class DcnmNetwork:
                                         if have.get("torports"):
                                             for tor_h in have["torports"]:
                                                 if tor_w["switch"] == tor_h["switch"]:
-                                                    atch_tor_ports = []
                                                     torports_present = True
                                                     h_tor_ports = tor_h["torPorts"].split(",") if tor_h["torPorts"] else []
                                                     w_tor_ports = tor_w["torPorts"].split(",") if tor_w["torPorts"] else []


### PR DESCRIPTION
This is a fix in `dcnm_network` for TOR ports being overwritten such that only the last TOR port is deployed.

The issue here is that tor_ports is being overwritten in a dict.update() of the torPorts key in four places.

The fix is to create a list to which each dict.update() is appended.   Then update torPorts with the resulting list.join()
