### PR TITLE
Handling of '' InstanceValues in DCNM_VRF (4.1)

### DIFF
--- a/plugins/modules/dcnm_vrf.py
+++ b/plugins/modules/dcnm_vrf.py
@@ -892,8 +892,9 @@ class DcnmVrf:
                         want_inst_values = {}
                         have_inst_values = {}
                         if (
-                            want["instanceValues"] is not None
-                            and have["instanceValues"] is not None
+                            (want["instanceValues"] is not None and want["instanceValues"] != "")
+                            and
+                            (have["instanceValues"] is not None and have["instanceValues"] != "")
                         ):
                             want_inst_values = ast.literal_eval(want["instanceValues"])
                             have_inst_values = ast.literal_eval(have["instanceValues"])


### PR DESCRIPTION
Issue:
"invalid syntax ("unknown", line 0)" error thrown, while trying to run replaced task on ND 4.1.

RCA:
Trying to parse instanceValues which is '' (empty string). These are in the VRF attachment objects for switches, which are not attached yet and in the "NA" state. 
Due to 4.1 response value differences.

Fix:
Adding a null string check.