### PR TITLE
PortChannels not removed when same PC name used across multiple switches

### DIFF
--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -4711,7 +4711,7 @@ class DcnmIntf:
                     self.dcnm_intf_get_if_name(mem, "eth")[0]
                     for mem in item["members"]
                 ]:
-                    # Compare have serial_number to item serial_number and continue if they don't match
+                    # Compare have serial_number to item serial_number return if they don't match
                     if have.get('serialNo') != item.get('sno'):
                         return True, None
                     else:


### PR DESCRIPTION
PortChannel interfaces don't get removed in cases where the same PC name is configured on multiple switches in the topology.  This was because the serial number was not factored into the decision and caused interfaces to be skipped in a delete request. 