### PR TITLE
535: dcnm_policy and dcnm_vrf changes in integ tests

### DIFF
--- a/tests/integration/targets/dcnm_policy/tests/dcnm/dcnm_policy_with_vars_merge.yaml
+++ b/tests/integration/targets/dcnm_policy/tests/dcnm/dcnm_policy_with_vars_merge.yaml
@@ -45,9 +45,9 @@
     # Assert for Create responses
     - assert:
         that:
-          - 'result["msg"]["RETURN_CODE"] != 200'
-          - '"OSPF_TAG" in result["msg"]["DATA"]["failureList"][0]["message"]'
-          - '"LOOPBACK_IP" in result["msg"]["DATA"]["failureList"][0]["message"]'
+          - 'result.failed == true'
+          - '"OSPF_TAG" in result["msg"] or (result["msg"]["DATA"] is defined and "OSPF_TAG" in result["msg"]["DATA"]["failureList"][0]["message"])'
+          - '"LOOPBACK_IP" in result["msg"] or (result["msg"]["DATA"] is defined and "LOOPBACK_IP" in result["msg"]["DATA"]["failureList"][0]["message"])'
 
     - name: Create multiple policies including required variables with the same template
       cisco.dcnm.dcnm_policy:

--- a/tests/integration/targets/dcnm_vrf/tests/dcnm/deleted.yaml
+++ b/tests/integration/targets/dcnm_vrf/tests/dcnm/deleted.yaml
@@ -27,11 +27,11 @@
 
 - set_fact:
     rest_path: "/rest/control/fabrics/{{ fabric_1 }}"
-  when: controller_version == "11"
+  when: controller_version == 11
 
 - set_fact:
     rest_path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ fabric_1 }}"
-  when: controller_version >= "12"
+  when: controller_version >= 12
 
 - name: SETUP.0 - DELETED - print vars
   ansible.builtin.debug:

--- a/tests/integration/targets/dcnm_vrf/tests/dcnm/merged.yaml
+++ b/tests/integration/targets/dcnm_vrf/tests/dcnm/merged.yaml
@@ -36,11 +36,11 @@
 
 - set_fact:
     rest_path: "/rest/control/fabrics/{{ fabric_1 }}"
-  when: controller_version == "11"
+  when: controller_version == 11
 
 - set_fact:
     rest_path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ fabric_1 }}"
-  when: controller_version >= "12"
+  when: controller_version >= 12
 
 - name: SETUP.0 - MERGED - [with_items] print vars
   ansible.builtin.debug:

--- a/tests/integration/targets/dcnm_vrf/tests/dcnm/overridden.yaml
+++ b/tests/integration/targets/dcnm_vrf/tests/dcnm/overridden.yaml
@@ -38,11 +38,11 @@
 
 - set_fact:
     rest_path: "/rest/control/fabrics/{{ fabric_1 }}"
-  when: controller_version == "11"
+  when: controller_version == 11
 
 - set_fact:
     rest_path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ fabric_1 }}"
-  when: controller_version >= "12"
+  when: controller_version >= 12
 
 - name: SETUP.0 - OVERRIDDEN - print vars
   ansible.builtin.debug:

--- a/tests/integration/targets/dcnm_vrf/tests/dcnm/query.yaml
+++ b/tests/integration/targets/dcnm_vrf/tests/dcnm/query.yaml
@@ -25,11 +25,11 @@
 
 - set_fact:
     rest_path: "/rest/control/fabrics/{{ fabric_1 }}"
-  when: controller_version == "11"
+  when: controller_version == 11
 
 - set_fact:
     rest_path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ fabric_1 }}"
-  when: controller_version >= "12"
+  when: controller_version >= 12
 
 - name: SETUP.0 - QUERY - [with_items] print vars
   ansible.builtin.debug:

--- a/tests/integration/targets/dcnm_vrf/tests/dcnm/replaced.yaml
+++ b/tests/integration/targets/dcnm_vrf/tests/dcnm/replaced.yaml
@@ -27,11 +27,11 @@
 
 - set_fact:
     rest_path: "/rest/control/fabrics/{{ fabric_1 }}"
-  when: controller_version == "11"
+  when: controller_version == 11
 
 - set_fact:
     rest_path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ fabric_1 }}"
-  when: controller_version >= "12"
+  when: controller_version >= 12
 
 - name: SETUP.0 - REPLACED - [with_items] print vars
   ansible.builtin.debug:

--- a/tests/integration/targets/dcnm_vrf/tests/dcnm/sanity.yaml
+++ b/tests/integration/targets/dcnm_vrf/tests/dcnm/sanity.yaml
@@ -23,13 +23,13 @@
 
 - set_fact:
     rest_path: "/rest/control/fabrics/{{ fabric_1 }}"
-  when: controller_version == "11"
+  when: controller_version == 11
   tags:
     - sanity
 
 - set_fact:
     rest_path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ fabric_1 }}"
-  when: controller_version >= "12"
+  when: controller_version >= 12
   tags:
     - sanity
 

--- a/tests/integration/targets/dcnm_vrf/tests/dcnm/self-contained-tests/deleted_vrf_all.yaml
+++ b/tests/integration/targets/dcnm_vrf/tests/dcnm/self-contained-tests/deleted_vrf_all.yaml
@@ -23,11 +23,11 @@
 
 - set_fact:
     rest_path: "/rest/control/fabrics/{{ fabric_1 }}"
-  when: controller_version == "11"
+  when: controller_version == 11
 
 - set_fact:
     rest_path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ fabric_1 }}"
-  when: controller_version >= "12"
+  when: controller_version >= 12
 
 - name: DELETE_ALL - Verify if fabric is deployed.
   cisco.dcnm.dcnm_rest:

--- a/tests/integration/targets/dcnm_vrf/tests/dcnm/self-contained-tests/merged_vrf_all.yaml
+++ b/tests/integration/targets/dcnm_vrf/tests/dcnm/self-contained-tests/merged_vrf_all.yaml
@@ -23,11 +23,11 @@
 
 - set_fact:
     rest_path: "/rest/control/fabrics/{{ fabric_1 }}"
-  when: controller_version == "11"
+  when: controller_version == 11
 
 - set_fact:
     rest_path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ fabric_1 }}"
-  when: controller_version >= "12"
+  when: controller_version >= 12
 
 - name: MERGED_ALL - Verify if fabric is deployed.
   cisco.dcnm.dcnm_rest:

--- a/tests/integration/targets/dcnm_vrf/tests/dcnm/self-contained-tests/overridden_vrf_all.yaml
+++ b/tests/integration/targets/dcnm_vrf/tests/dcnm/self-contained-tests/overridden_vrf_all.yaml
@@ -23,11 +23,11 @@
 
 - set_fact:
     rest_path: "/rest/control/fabrics/{{ fabric_1 }}"
-  when: controller_version == "11"
+  when: controller_version == 11
 
 - set_fact:
     rest_path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ fabric_1 }}"
-  when: controller_version >= "12"
+  when: controller_version >= 12
 
 - name: OVERRIDDEN_ALL - Verify if fabric is deployed.
   cisco.dcnm.dcnm_rest:

--- a/tests/integration/targets/dcnm_vrf/tests/dcnm/self-contained-tests/scale.yaml
+++ b/tests/integration/targets/dcnm_vrf/tests/dcnm/self-contained-tests/scale.yaml
@@ -13,11 +13,11 @@
 
 - set_fact:
     rest_path: "/rest/control/fabrics/{{ fabric_1 }}"
-  when: controller_version == "11"
+  when: controller_version == 11
 
 - set_fact:
     rest_path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ fabric_1 }}"
-  when: controller_version >= "12"
+  when: controller_version >= 12
 
 - name: SETUP.0 - SCALE - [with_items] print vars
   ansible.builtin.debug:

--- a/tests/integration/targets/dcnm_vrf/tests/dcnm/self-contained-tests/vrf_lite.yaml
+++ b/tests/integration/targets/dcnm_vrf/tests/dcnm/self-contained-tests/vrf_lite.yaml
@@ -37,11 +37,11 @@
 
 - set_fact:
     rest_path: "/rest/control/fabrics/{{ fabric_1 }}"
-  when: controller_version == "11"
+  when: controller_version == 11
 
 - set_fact:
     rest_path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ fabric_1 }}"
-  when: controller_version >= "12"
+  when: controller_version >= 12
 
 - name: MERGED - Verify if fabric is deployed.
   cisco.dcnm.dcnm_rest:


### PR DESCRIPTION
Problem Description: 

There were some failures seen in dcnm_policy tests and dcnm_vrf tests while running the nightly pipeline. 

Issue:
dcnm_policy test changes:
1) changes in assertion to check the result's failed flag rather than the return code
2) OSPF_TAG: check the error message in result[msg] and then check the OSPF_TAG in failure list
3) LOOPBACK_IP: check the error message in result[msg] and then check the LOOPBACK_IP in failure list

dcnm_vrf test changes:
The controller_version is defined as an integer hence the string needs to be modified as numeric