### PR TITLE
dcnm.py: dcnm_update_arg_specs(): implement without eval()

### DIFF
--- a/plugins/module_utils/network/dcnm/dcnm.py
+++ b/plugins/module_utils/network/dcnm/dcnm.py
@@ -673,6 +673,7 @@ def dcnm_get_template_details(module, version, name):
         else:
             return []
 
+
 def dcnm_update_arg_specs(mspec, arg_specs):
     """
     Update argument specifications based on module specification dependencies.


### PR DESCRIPTION
Rewrite dcnm_update_arg_specs() without eval.

dcnm_update_arg_specs() is used only by the dcnm_vpc_pairs module.

I’ve tested this against the original function using a test script that works with all of the data passed through these functions by the unit tests for dcnm_vpc_pairs.

We should probably move this function into the dcnm_vpc_pairs module since it's not used by anything else...