### PR TITLE
update breakout part

### DIFF
--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -5080,12 +5080,22 @@ class DcnmIntf:
 
                     for have in self.have_all:
                         have_intf = have['ifName']
+                        deletable = have['deletable']
                         if re.search(r"\d+\/\d+\/\d+", have_intf):
                             found, parent_type = self.dcnm_intf_get_parent(have_intf, have['mgmtIpAddress'])
                             # If have in want breakout and if match to E1/x/1 add to dict
                             # Else if match E1/x/2, etc. silently ignore, because we delete the breakout
                             # with the first sub if.
                             if re.search(r"\d+\/\d+\/1$", have_intf) and found:
+                                if deletable is False:
+                                    self.changed_dict[0]["skipped"].append(
+                                        {
+                                            "Name": have_intf,
+                                            "Alias": have.get("alias"),
+                                            "Delete Reason": have["deleteReason"],
+                                        }
+                                    )
+                                    continue
                                 payload = {'serialNumber': have['serialNo'],
                                            'ifName': have['ifName']}
                                 self.diff_delete_breakout.append(payload)


### PR DESCRIPTION
Check if breakout is a deletable. When interface is used a fabric_link, we cannot delete breakout. Interface must be skipped.

Error message:

```
TASK [Delete interface] ********************************************************************************************************************************************************************************************************************************************
task path: /home/cisco/nac-vxlan/nac-vxlan/play-delete-fablink.yml:9
Friday 14 November 2025  09:49:09 +0100 (0:00:00.067)       0:00:00.067 *******
Friday 14 November 2025  09:49:09 +0100 (0:00:00.066)       0:00:00.066 *******
fatal: [fab-tsc]: FAILED! => changed=false
  invocation:
    module_args:
      check_deploy: false
      config:
      - deploy: true
        name: Ethernet1/51
        profile:
          map: 10g-4x
        switch:
        - 172.20.6.2
        type: breakout
      deploy: true
      fabric: fab-tsc
      override_intf_types: []
      state: deleted
  msg:
    CHANGED:
    - debugs: []
      deferred: []
      delete_deploy: []
      deleted: []
      deploy: []
      merged: []
      overridden: []
      query: []
      replaced: []
      skipped: []
    DATA:
    - column: 0
      entity: FDO21160ZQD~Ethernet1/51/1
      impact: null
      line: 0
      message: Ethernet1/51/1:<br>[Ethernet1/51/2, Ethernet1/51/3, Ethernet1/51/4, Ethernet1/51/1] have policy attached from a different source. Interface cannot be deleted!!!
      recommendation: null
      reportItemType: ERROR
      trigger: null
    MESSAGE: Internal Server Error
    METHOD: DELETE
    REQUEST_PATH: https://172.21.129.1:443/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/interface
    RETURN_CODE: 500

PLAY RECAP *********************************************************************************************************************************************************************************************************************************************************
fab-tsc                    : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0 
``` 

With fix we add in the skipped list.

```
TASK [Delete interface] *****************************************************************************************************************************************************************
task path: /home/cisco/nac-vxlan/nac-vxlan/play-delete-fablink.yml:9
Friday 14 November 2025  11:25:55 +0100 (0:00:00.067)       0:00:00.067 *******
Friday 14 November 2025  11:25:55 +0100 (0:00:00.066)       0:00:00.066 *******
ok: [fab-tsc] => changed=false
  diff:
  - debugs: []
    deferred: []
    delete_deploy: []
    deleted: []
    deploy: []
    merged: []
    overridden: []
    query: []
    replaced: []
    skipped:
    - Alias: connected-to-tsc-leaf1-Ethernet1/49
      Delete Reason: <br>[Ethernet1/51/2, Ethernet1/51/3, Ethernet1/51/4, Ethernet1/51/1] have policy attached from a different source.
      Name: Ethernet1/51/1
  invocation:
    module_args:
      check_deploy: false
      config:
      - deploy: true
        name: Ethernet1/51
        profile:
          map: 10g-4x
        switch:
        - 172.20.6.2
        type: breakout
      deploy: true
      fabric: fab-tsc
      override_intf_types: []
      state: deleted
  response: [] 
```