### PR TITLE
dcnm_bootflash: IT: update switchX to switch_X

### DIFF
--- a/tests/integration/targets/dcnm_bootflash/tests/dcnm_bootflash_deleted_specific.yaml
+++ b/tests/integration/targets/dcnm_bootflash/tests/dcnm_bootflash_deleted_specific.yaml
@@ -15,17 +15,17 @@
 # SETUP
 ################################################################################
 #
-# 1. Two switches are required for this test; switch1 and switch2.
+# 1. Two switches are required for this test; switch_1 and switch_2.
 # 2. Files must be created on bootflash manually as NDFC does not
 #    provide a quick way to create files on bootflash. To create
 #    the files manually, we have two choices.
 #    A. Do the following directly on the switches:
-#       - On switch1, create a file named foo.txt
+#       - On switch_1, create files
 #         switch# echo 1 > air.ndfc_ut
 #         switch# echo 1 > earth.ndfc_ut
 #         switch# echo 1 > fire.ndfc_ut
 #         switch# echo 1 > water.ndfc_ut
-#       - On switch2, create a file named bar.txt
+#       - On switch_2, create files
 #         switch# echo 1 > black.ndfc_ut
 #         switch# echo 1 > blue.ndfc_ut
 #         switch# echo 1 > green.ndfc_ut
@@ -34,7 +34,7 @@
 #       ./playbooks/dcnm_bootflash/create_files.yaml
 #       This uses the cisco.nxos.nxos_command module to create the files.
 #       See the example inventory file in playbooks/roles/dcnm_bootflash/dcnm_hosts.yaml
-#       which includes inventory entries for switch1 and switch2 and change to
+#       which includes inventory entries for switch_1 and switch_2 and change to
 #       match your setup.
 # TEST
 # 3. Ensure dcnm_tests.yaml has uncommented the following:
@@ -198,7 +198,7 @@
       state: deleted
       config:
         switches:
-          - ip_address: "{{ switch1 }}"
+          - ip_address: "{{ switch_1 }}"
             targets:
               - filepath: "bootflash:/{{ switch1_file1 }}"
                 supervisor: active
@@ -208,7 +208,7 @@
                 supervisor: active
               - filepath: "bootflash:/{{ switch1_file4 }}"
                 supervisor: active
-          - ip_address: "{{ switch2 }}"
+          - ip_address: "{{ switch_2 }}"
             targets:
               - filepath: "bootflash:/{{ switch2_file1 }}"
                 supervisor: active
@@ -236,14 +236,14 @@
 
 - assert:
     that:
-    - result.diff[0][switch1][0].filepath == switch1_filepath1
-    - result.diff[0][switch1][1].filepath == switch1_filepath2
-    - result.diff[0][switch1][2].filepath == switch1_filepath3
-    - result.diff[0][switch1][3].filepath == switch1_filepath4
-    - result.diff[0][switch2][0].filepath == switch2_filepath1
-    - result.diff[0][switch2][1].filepath == switch2_filepath2
-    - result.diff[0][switch2][2].filepath == switch2_filepath3
-    - result.diff[0][switch2][3].filepath == switch2_filepath4
+    - result.diff[0][switch_1][0].filepath == switch1_filepath1
+    - result.diff[0][switch_1][1].filepath == switch1_filepath2
+    - result.diff[0][switch_1][2].filepath == switch1_filepath3
+    - result.diff[0][switch_1][3].filepath == switch1_filepath4
+    - result.diff[0][switch_2][0].filepath == switch2_filepath1
+    - result.diff[0][switch_2][1].filepath == switch2_filepath2
+    - result.diff[0][switch_2][2].filepath == switch2_filepath3
+    - result.diff[0][switch_2][3].filepath == switch2_filepath4
     - result.changed == true
     - result.failed == false
     - (result.diff | length) == 1
@@ -312,8 +312,8 @@
     - result.changed == false
     - result.failed == false
     - (result.diff | length) == 1
-    - switch1 not in result.diff[0]
-    - switch2 not in result.diff[0]
+    - switch_1 not in result.diff[0]
+    - switch_2 not in result.diff[0]
     - result.diff[0].sequence_number == 1
     - (result.metadata | length) == 1
     - result.metadata[0].action == "bootflash_delete"

--- a/tests/integration/targets/dcnm_bootflash/tests/dcnm_bootflash_deleted_wildcard.yaml
+++ b/tests/integration/targets/dcnm_bootflash/tests/dcnm_bootflash_deleted_wildcard.yaml
@@ -15,17 +15,17 @@
 # SETUP
 ################################################################################
 #
-# 1. Two switches are required for this test; switch1 and switch2.
+# 1. Two switches are required for this test; switch_1 and switch_2.
 # 2. Files must be created on bootflash manually as NDFC does not
 #    provide a quick way to create files on bootflash. To create
 #    the files manually, we have two choices.
 #    A. Do the following directly on the switches:
-#       - On switch1, create a file named foo.txt
+#       - On switch_1, create files
 #         switch# echo 1 > air.ndfc_ut
 #         switch# echo 1 > earth.ndfc_ut
 #         switch# echo 1 > fire.ndfc_ut
 #         switch# echo 1 > water.ndfc_ut
-#       - On switch2, create a file named bar.txt
+#       - On switch_2, create files
 #         switch# echo 1 > black.ndfc_ut
 #         switch# echo 1 > blue.ndfc_ut
 #         switch# echo 1 > green.ndfc_ut
@@ -34,7 +34,7 @@
 #       ./playbooks/dcnm_bootflash/create_files.yaml
 #       This uses the cisco.nxos.nxos_command module to create the files.
 #       See the example inventory file in playbooks/roles/dcnm_bootflash/dcnm_hosts.yaml
-#       which includes inventory entries for switch1 and switch2 and change to
+#       which includes inventory entries for switch_1 and switch_2 and change to
 #       match your setup.
 # TEST
 # 3. Ensure dcnm_tests.yaml has uncommented the following:
@@ -201,8 +201,8 @@
           - filepath: "{{ wildcard_filepath }}"
             supervisor: active
         switches:
-          - ip_address: "{{ switch1 }}"
-          - ip_address: "{{ switch2 }}"
+          - ip_address: "{{ switch_1 }}"
+          - ip_address: "{{ switch_2 }}"
   register: result
 
 - debug:
@@ -219,12 +219,12 @@
 
 - assert:
     that:
-    - result.diff[0][switch1][0].filepath == switch1_filepath1
-    - result.diff[0][switch1][1].filepath == switch1_filepath2
-    - result.diff[0][switch1][2].filepath == switch1_filepath3
-    - result.diff[0][switch2][0].filepath == switch2_filepath1
-    - result.diff[0][switch2][1].filepath == switch2_filepath2
-    - result.diff[0][switch2][2].filepath == switch2_filepath3
+    - result.diff[0][switch_1][0].filepath == switch1_filepath1
+    - result.diff[0][switch_1][1].filepath == switch1_filepath2
+    - result.diff[0][switch_1][2].filepath == switch1_filepath3
+    - result.diff[0][switch_2][0].filepath == switch2_filepath1
+    - result.diff[0][switch_2][1].filepath == switch2_filepath2
+    - result.diff[0][switch_2][2].filepath == switch2_filepath3
     - result.changed == true
     - result.failed == false
     - (result.diff | length) == 1
@@ -293,8 +293,8 @@
     - result.changed == false
     - result.failed == false
     - (result.diff | length) == 1
-    - switch1 not in result.diff[0]
-    - switch2 not in result.diff[0]
+    - switch_1 not in result.diff[0]
+    - switch_2 not in result.diff[0]
     - result.diff[0].sequence_number == 1
     - (result.metadata | length) == 1
     - result.metadata[0].action == "bootflash_delete"

--- a/tests/integration/targets/dcnm_bootflash/tests/dcnm_bootflash_query_specific.yaml
+++ b/tests/integration/targets/dcnm_bootflash/tests/dcnm_bootflash_query_specific.yaml
@@ -9,17 +9,17 @@
 # SETUP
 ################################################################################
 #
-# 1. Two switches are required for this test; switch1 and switch2.
+# 1. Two switches are required for this test; switch_1 and switch_2.
 # 2. Files must be created on bootflash manually as NDFC does not
 #    provide a quick way to create files on bootflash. To create
 #    the files manually, we have two choices.
 #    A. Do the following directly on the switches:
-#       - On switch1, create a file named foo.txt
+#       - On switch_1, create a file named foo.txt
 #         switch# echo 1 > air.ndfc_ut
 #         switch# echo 1 > earth.ndfc_ut
 #         switch# echo 1 > fire.ndfc_ut
 #         switch# echo 1 > water.ndfc_ut
-#       - On switch2, create a file named bar.txt
+#       - On switch_2, create a file named bar.txt
 #         switch# echo 1 > black.ndfc_ut
 #         switch# echo 1 > blue.ndfc_ut
 #         switch# echo 1 > green.ndfc_ut
@@ -28,7 +28,7 @@
 #       ./playbooks/dcnm_bootflash/create_files.yaml
 #       This uses the cisco.nxos.nxos_command module to create the files.
 #       See the example inventory file in playbooks/roles/dcnm_bootflash/dcnm_hosts.yaml
-#       which includes inventory entries for switch1 and switch2 and change to
+#       which includes inventory entries for switch_1 and switch_2 and change to
 #       match your setup.
 # TEST
 # 3. Ensure dcnm_tests.yaml has uncommented the following:
@@ -219,7 +219,7 @@
       state: query
       config:
         switches:
-          - ip_address: "{{ switch1 }}"
+          - ip_address: "{{ switch_1 }}"
             targets:
               - filepath: "bootflash:/{{ switch1_file2 }}"
                 supervisor: active
@@ -227,7 +227,7 @@
                 supervisor: active
               - filepath: "bootflash:/{{ switch1_file4 }}"
                 supervisor: active
-          - ip_address: "{{ switch2 }}"
+          - ip_address: "{{ switch_2 }}"
             targets:
               - filepath: "bootflash:/{{ switch2_file2 }}"
                 supervisor: active
@@ -251,29 +251,29 @@
 
 - assert:
     that:
-    - result.diff[0][switch1][0].filepath == switch1_filepath1
-    - result.diff[0][switch1][1].filepath == switch1_filepath2
-    - result.diff[0][switch1][2].filepath == switch1_filepath3
-    - result.diff[0][switch2][0].filepath == switch2_filepath1
-    - result.diff[0][switch2][1].filepath == switch2_filepath2
-    - result.diff[0][switch2][2].filepath == switch2_filepath3
+    - result.diff[0][switch_1][0].filepath == switch1_filepath1
+    - result.diff[0][switch_1][1].filepath == switch1_filepath2
+    - result.diff[0][switch_1][2].filepath == switch1_filepath3
+    - result.diff[0][switch_2][0].filepath == switch2_filepath1
+    - result.diff[0][switch_2][1].filepath == switch2_filepath2
+    - result.diff[0][switch_2][2].filepath == switch2_filepath3
     - result.changed == false
     - result.failed == false
     - (result.diff | length) == 1
     - (result.response | length) == 1
-    - result.response[0][switch1].RETURN_CODE == 200
-    - result.response[0][switch2].RETURN_CODE == 200
-    - result.response[0][switch1].MESSAGE == "OK"
-    - result.response[0][switch2].MESSAGE == "OK"
-    - result.response[0][switch1].METHOD == "GET"
-    - result.response[0][switch2].METHOD == "GET"
+    - result.response[0][switch_1].RETURN_CODE == 200
+    - result.response[0][switch_2].RETURN_CODE == 200
+    - result.response[0][switch_1].MESSAGE == "OK"
+    - result.response[0][switch_2].MESSAGE == "OK"
+    - result.response[0][switch_1].METHOD == "GET"
+    - result.response[0][switch_2].METHOD == "GET"
     - (result.metadata | length) == 1
     - result.metadata[0].action == "bootflash_info"
     - result.metadata[0].check_mode == false
     - result.metadata[0].sequence_number == 1
     - result.metadata[0].state == "query"
     - (result.result | length) == 1
-    - result.result[0][switch1].found == true
-    - result.result[0][switch2].found == true
-    - result.result[0][switch1].success == true
-    - result.result[0][switch2].success == true
+    - result.result[0][switch_1].found == true
+    - result.result[0][switch_2].found == true
+    - result.result[0][switch_1].success == true
+    - result.result[0][switch_2].success == true

--- a/tests/integration/targets/dcnm_bootflash/tests/dcnm_bootflash_query_wildcard.yaml
+++ b/tests/integration/targets/dcnm_bootflash/tests/dcnm_bootflash_query_wildcard.yaml
@@ -9,17 +9,17 @@
 # SETUP
 ################################################################################
 #
-# 1. Two switches are required for this test; switch1 and switch2.
+# 1. Two switches are required for this test; switch_1 and switch_2.
 # 2. Files must be created on bootflash manually as NDFC does not
 #    provide a quick way to create files on bootflash. To create
 #    the files manually, we have two choices.
 #    A. Do the following directly on the switches:
-#       - On switch1, create a file named foo.txt
+#       - On switch_1, create a file named foo.txt
 #         switch# echo 1 > air.ndfc_ut
 #         switch# echo 1 > earth.ndfc_ut
 #         switch# echo 1 > fire.ndfc_ut
 #         switch# echo 1 > water.ndfc_ut
-#       - On switch2, create a file named bar.txt
+#       - On switch_2, create a file named bar.txt
 #         switch# echo 1 > black.ndfc_ut
 #         switch# echo 1 > blue.ndfc_ut
 #         switch# echo 1 > green.ndfc_ut
@@ -28,7 +28,7 @@
 #       ./playbooks/dcnm_bootflash/create_files.yaml
 #       This uses the cisco.nxos.nxos_command module to create the files.
 #       See the example inventory file in playbooks/roles/dcnm_bootflash/dcnm_hosts.yaml
-#       which includes inventory entries for switch1 and switch2 and change to
+#       which includes inventory entries for switch_1 and switch_2 and change to
 #       match your setup.
 # TEST
 # 3. Ensure dcnm_tests.yaml has uncommented the following:
@@ -222,8 +222,8 @@
           - filepath: "{{ wildcard_filepath }}"
             supervisor: active
         switches:
-          - ip_address: "{{ switch1 }}"
-          - ip_address: "{{ switch2 }}"
+          - ip_address: "{{ switch_1 }}"
+          - ip_address: "{{ switch_2 }}"
   register: result
 
 - debug:
@@ -240,30 +240,30 @@
 
 - assert:
     that:
-    - result.diff[0][switch1][0].filepath == switch1_filepath1
-    - result.diff[0][switch1][1].filepath == switch1_filepath2
-    - result.diff[0][switch1][2].filepath == switch1_filepath3
-    - result.diff[0][switch2][0].filepath == switch2_filepath1
-    - result.diff[0][switch2][1].filepath == switch2_filepath2
-    - result.diff[0][switch2][2].filepath == switch2_filepath3
+    - result.diff[0][switch_1][0].filepath == switch1_filepath1
+    - result.diff[0][switch_1][1].filepath == switch1_filepath2
+    - result.diff[0][switch_1][2].filepath == switch1_filepath3
+    - result.diff[0][switch_2][0].filepath == switch2_filepath1
+    - result.diff[0][switch_2][1].filepath == switch2_filepath2
+    - result.diff[0][switch_2][2].filepath == switch2_filepath3
     - result.changed == false
     - result.failed == false
     - (result.diff | length) == 1
     - (result.diff[0] | length) == 3
     - (result.response | length) == 1
-    - result.response[0][switch1].RETURN_CODE == 200
-    - result.response[0][switch2].RETURN_CODE == 200
-    - result.response[0][switch1].MESSAGE == "OK"
-    - result.response[0][switch2].MESSAGE == "OK"
-    - result.response[0][switch1].METHOD == "GET"
-    - result.response[0][switch2].METHOD == "GET"
+    - result.response[0][switch_1].RETURN_CODE == 200
+    - result.response[0][switch_2].RETURN_CODE == 200
+    - result.response[0][switch_1].MESSAGE == "OK"
+    - result.response[0][switch_2].MESSAGE == "OK"
+    - result.response[0][switch_1].METHOD == "GET"
+    - result.response[0][switch_2].METHOD == "GET"
     - (result.metadata | length) == 1
     - result.metadata[0].action == "bootflash_info"
     - result.metadata[0].check_mode == false
     - result.metadata[0].sequence_number == 1
     - result.metadata[0].state == "query"
     - (result.result | length) == 1
-    - result.result[0][switch1].found == true
-    - result.result[0][switch2].found == true
-    - result.result[0][switch1].success == true
-    - result.result[0][switch2].success == true
+    - result.result[0][switch_1].found == true
+    - result.result[0][switch_2].found == true
+    - result.result[0][switch_1].success == true
+    - result.result[0][switch_2].success == true


### PR DESCRIPTION
This PR updates the following vars in all dcnm_bootflash integration tests to align with standardized switch naming.

switch1 -> switch_1
switch2 -> switch_2
