### PR TITLE
Fix for only last TOR switch included in NDFC network attachment API payload

### DIFF
--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -658,6 +658,7 @@ class DcnmNetwork:
 
                                 # Handle tor ports first if configured.
                                 if want.get("torports"):
+                                    torconfig_list = []
                                     for tor_w in want["torports"]:
                                         torports_present = False
                                         if have.get("torports"):
@@ -676,7 +677,7 @@ class DcnmNetwork:
                                                         atch_tor_ports.extend(h_tor_ports)
 
                                                     torconfig = tor_w["switch"] + "(" + ",".join(atch_tor_ports) + ")"
-                                                    want.update({"torPorts": torconfig})
+                                                    torconfig_list.append(torconfig)
                                                     # Update torports_configured to True. If there is no other config change for attach
                                                     # We will still append this attach to attach_list as there is tor port change
                                                     if sorted(atch_tor_ports) != sorted(h_tor_ports):
@@ -684,10 +685,12 @@ class DcnmNetwork:
 
                                         if not torports_present:
                                             torconfig = tor_w["switch"] + "(" + tor_w["torPorts"] + ")"
-                                            want.update({"torPorts": torconfig})
+                                            torconfig_list.append(torconfig)
                                             # Update torports_configured to True. If there is no other config change for attach
                                             # We will still append this attach to attach_list as there is tor port change
                                             torports_configured = True
+
+                                    want.update({"torPorts": " ".join(torconfig_list)})
 
                                     if have.get("torports"):
                                         del have["torports"]


### PR DESCRIPTION
Fix for #585

### Fix Description:
Update the loop in the DCNM network module to build a list of torPorts entries and join them after the loop, so all TOR switches are included in the API payload.

### Proposed Fix Solution:
Accumulate all TOR switch-port strings in a list during payload generation, then join them with a space before assigning to torPorts.

