### PR TITLE
Fixing Incorrect Diff Attach Comparison : dcnm_network

### DIFF
--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -1138,7 +1138,7 @@ class DcnmNetwork:
             found = False
             if have_a:
                 for have in have_a:
-                    if want["serialNumber"] == have["serialNumber"]:
+                    if want["serialNumber"] == have["serialNumber"] and want["networkName"] == have["networkName"]:
                         found = True
 
                         if want.get("isAttached") is not None:


### PR DESCRIPTION
Issue:
Idempotence overridden/replaced tests with multiple networks and switches throws "Entered Network VLAN ID is already in use" error.

Root Cause:
Diff attach being incorrectly generated in diff_for_attach_deploy, when multiple network attachments are present for the same switch. 
In function diff_for_attach_deploy, only switch serial numbers are compared for have and want attachments and not the network names, which results in a incorrect comparison for attachment ports leading to attachment diff being miscalculated.

Fix:
Adding network name check along with switch serial number while comparing have and want attachments in diff_for_attach_deploy. 