### PR TITLE
Adding fixes for bgpPasswordKeyType, Unit Tests and Sanity

### DIFF
--- a/plugins/module_utils/network/dcnm/dcnm.py
+++ b/plugins/module_utils/network/dcnm/dcnm.py
@@ -1192,6 +1192,7 @@ def has_partial_dhcp_config(server):
     vrf = server.get("srvr_vrf")
     return bool(ip) != bool(vrf)
 
+
 def sanitize_lan_attach_list(attach_objects: list) -> list:
     """
     # Summary
@@ -1274,8 +1275,8 @@ def sanitize_lan_attach_list(attach_objects: list) -> list:
 
     return attach_objects
 
-# Action plugin utilities
 
+# Action plugin utilities
 def get_nd_version(action_module, task_vars, tmp):
     """
     Query NDFC and return the exact software version

--- a/plugins/modules/dcnm_vrf.py
+++ b/plugins/modules/dcnm_vrf.py
@@ -1859,6 +1859,18 @@ class DcnmVrf:
         if vrfSegmentId_want is None:
             skip_keys.append("vrfSegmentId")
 
+        # BGP password/key type special handling
+        bgp_password_want = json_to_dict_want.get("bgpPassword")
+        bgp_password_have = json_to_dict_have.get("bgpPassword")
+        bgp_key_type_have = json_to_dict_have.get("bgpPasswordKeyType")
+
+        # Some ND versions give empty bgpPasswordKeyType. Skip comparison if:
+        # 1. Have keytype is empty/None (ND has no password configured)
+        # 2. Both passwords are empty (no password in want or have)
+        if ((bgp_key_type_have == "") or
+           (bgp_password_want == "") and bgp_password_have == ""):
+            skip_keys.append("bgpPasswordKeyType")
+
         template_skip_keys = self.get_template_skip_keys()
         if template_skip_keys:
             skip_keys.extend(template_skip_keys)

--- a/tests/unit/modules/dcnm/fixtures/dcnm_vrf.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_vrf.json
@@ -769,8 +769,8 @@
       ],
       "child_fabric_config": [
         {
-          "adv_host_routes": true,
-          "adv_default_routes": true,
+          "adv_host_routes": false,
+          "adv_default_routes": false,
           "l3vni_wo_vlan": false,
           "fabric": "child_fabric"
         }
@@ -793,7 +793,7 @@
       "child_fabric_config": [
         {
           "fabric": "child_fabric",
-          "static_default_route": true,
+          "static_default_route": false,
           "l3vni_wo_vlan": true
         }
       ],
@@ -919,8 +919,8 @@
       "child_fabric_config": [
         {
           "fabric": "child_fabric",
-          "adv_host_routes": true,
-          "adv_default_routes": true,
+          "adv_host_routes": false,
+          "adv_default_routes": false,
           "l3vni_wo_vlan": false
         }
       ],
@@ -1177,8 +1177,16 @@
         "vrfName": "test_vrf_1",
         "lanAttachList": [
           {
+            "vrfName": "test_vrf_1",
+            "switchName": "n9kv_leaf1",
             "lanAttachState": "DEPLOYED",
-            "isLanAttached": false
+            "isLanAttached": true,
+            "switchSerialNo": "XYZKSJHSMK1",
+            "switchRole": "leaf",
+            "fabricName": "child_fabric",
+            "ipAddress": "10.10.10.224",
+            "vlanId": "2000",
+            "vrfId": "9008011"
           }
         ]
       }
@@ -1231,8 +1239,16 @@
         "vrfName": "test_vrf_1",
         "lanAttachList": [
           {
+            "vrfName": "test_vrf_1",
+            "switchName": "n9kv_leaf1",
             "lanAttachState": "NA",
-            "isLanAttached": false
+            "isLanAttached": false,
+            "switchSerialNo": "XYZKSJHSMK1",
+            "switchRole": "leaf",
+            "fabricName": "child_fabric",
+            "ipAddress": "10.10.10.224",
+            "vlanId": "2000",
+            "vrfId": "9008011"
           }
         ]
       }

--- a/tests/unit/modules/dcnm/test_dcnm_vrf.py
+++ b/tests/unit/modules/dcnm/test_dcnm_vrf.py
@@ -1709,8 +1709,8 @@ class TestDcnmVrfModule(TestDcnmModule):
         self.assertTrue(result.get("parent_fabric").get("response")[1]["DATA"]["test-vrf-1--XYZKSJHSMK1(leaf1)"], "SUCCESS")
         self.assertEqual(result.get("parent_fabric").get("response")[2]["DATA"]["status"], "")
         self.assertEqual(result.get("parent_fabric").get("response")[2]["RETURN_CODE"], self.SUCCESS_RETURN_CODE)
-        self.assertTrue(result.get("child_fabrics")[0]["diff"][0]["adv_default_routes"])
-        self.assertTrue(result.get("child_fabrics")[0]["diff"][0]["adv_host_routes"])
+        self.assertFalse(result.get("child_fabrics")[0]["diff"][0]["adv_default_routes"])
+        self.assertFalse(result.get("child_fabrics")[0]["diff"][0]["adv_host_routes"])
         self.assertTrue(result.get("child_fabrics")[0]["response"][0]["MESSAGE"], "OK")
         self.assertEqual(result.get("child_fabrics")[0]["response"][1]["RETURN_CODE"], self.SUCCESS_RETURN_CODE)
 
@@ -1726,7 +1726,7 @@ class TestDcnmVrfModule(TestDcnmModule):
         self.assertEqual(result.get("parent_fabric").get("response")[1]["RETURN_CODE"], self.SUCCESS_RETURN_CODE)
         self.assertTrue(result.get("child_fabrics")[0]["diff"][0]["adv_default_routes"])
         self.assertFalse(result.get("child_fabrics")[0]["diff"][0]["adv_host_routes"])
-        self.assertTrue(result.get("child_fabrics")[0]["diff"][0]["static_default_route"])
+        self.assertFalse(result.get("child_fabrics")[0]["diff"][0]["static_default_route"])
         self.assertTrue(result.get("child_fabrics")[0]["response"][0]["MESSAGE"], "OK")
         self.assertEqual(result.get("child_fabrics")[0]["response"][1]["RETURN_CODE"], self.SUCCESS_RETURN_CODE)
 
@@ -1816,8 +1816,8 @@ class TestDcnmVrfModule(TestDcnmModule):
             result.get("parent_fabric").get("response")[6]["DATA"]["test-vrf-2--XYZKSJHSMK1(leaf1)"], "SUCCESS"
         )
         self.assertEqual(result.get("child_fabrics")[0]["diff"][0]["vrf_name"], "test_vrf_2")
-        self.assertTrue(result.get("child_fabrics")[0]["diff"][0]["adv_default_routes"])
-        self.assertTrue(result.get("child_fabrics")[0]["diff"][0]["adv_host_routes"])
+        self.assertFalse(result.get("child_fabrics")[0]["diff"][0]["adv_default_routes"])
+        self.assertFalse(result.get("child_fabrics")[0]["diff"][0]["adv_host_routes"])
         self.assertFalse(result.get("child_fabrics")[0]["diff"][0]["l3vni_wo_vlan"])
         self.assertEqual(result.get("child_fabrics")[0]["response"][1]["DATA"]["status"], "")
         self.assertEqual(result.get("child_fabrics")[0]["response"][1]["RETURN_CODE"], self.SUCCESS_RETURN_CODE)
@@ -1927,6 +1927,7 @@ class TestDcnmVrfModule(TestDcnmModule):
         self.assertTrue(result.get("child_fabrics")[0]["diff"][0]["adv_default_routes"])
         self.assertFalse(result.get("child_fabrics")[0]["diff"][0]["adv_host_routes"])
         self.assertTrue(result.get("child_fabrics")[0]["diff"][0]["static_default_route"])
+        self.assertTrue(result.get("child_fabrics")[0]["diff"][0]["l3vni_wo_vlan"])
         self.assertTrue(result.get("child_fabrics")[0]["response"][0]["MESSAGE"], "OK")
         self.assertEqual(result.get("child_fabrics")[0]["response"][1]["RETURN_CODE"], self.SUCCESS_RETURN_CODE)
 


### PR DESCRIPTION
1. Adding fix to handle vrf comparsion between have and want, when ND returns no value for "bgpPasswordKeyType".
2. Fix UT, UT Fixtures and Sanity.