### PR TITLE
Add xconnect dcnm network

### DIFF
--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -306,6 +306,12 @@ options:
         - Not applicable at Multisite parent fabric level
         type: str
         required: false
+      xconnect:
+        description:
+        - Enable XConnect feature. Only available for ND version > 4.1.
+        type: bool
+        default: false
+        required: false
       attach:
         description:
         - List of network attachment details
@@ -1001,6 +1007,11 @@ from ansible_collections.cisco.dcnm.plugins.module_utils.network.dcnm.dcnm impor
     validate_list_of_dicts,
     sanitize_lan_attach_list
 )
+from ..module_utils.common.controller_version_v2 import ControllerVersion
+from ..module_utils.common.rest_send_v2 import RestSend
+from ..module_utils.common.response_handler import ResponseHandler
+from ..module_utils.common.sender_dcnm import Sender
+from ..module_utils.common.exceptions import ControllerResponseError
 
 
 class DcnmNetwork:
@@ -1102,6 +1113,8 @@ class DcnmNetwork:
 
         msg = f"self.dcnm_version: {self.dcnm_version}"
         self.log.debug(msg)
+
+        self.ndfc_version = self._get_ndfc_version()
 
         self.inventory_data = get_nd_fabric_inventory_details(self.module, self.dcnm_version, self.fabric, self.fabric_details)
 
@@ -1622,6 +1635,7 @@ class DcnmNetwork:
         nf_en_changed = False
         intvlan_nfmon_changed = False
         vlan_nfmon_changed = False
+        xconnect_changed = False
 
         if want.get("networkId") and want["networkId"] != have["networkId"]:
             self.module.fail_json(msg="networkId can not be updated on existing network: {0}".format(want["networkName"]))
@@ -1679,6 +1693,8 @@ class DcnmNetwork:
         intvlan_nfen_have = json_to_dict_have.get("SVI_NETFLOW_MONITOR", "")
         vlan_nfen_want = json_to_dict_want.get("VLAN_NETFLOW_MONITOR", "")
         vlan_nfen_have = json_to_dict_have.get("VLAN_NETFLOW_MONITOR", "")
+        xconnect_want = str(json_to_dict_want.get("xconnect", "")).lower()
+        xconnect_have = str(json_to_dict_have.get("xconnect", "")).lower()
 
         if vlanId_have != "":
             vlanId_have = int(vlanId_have)
@@ -1796,6 +1812,10 @@ class DcnmNetwork:
                 net_name_diff = net_name_have != net_name_want
                 comparisons.append(net_name_diff)
 
+            if "xconnect" not in skipped_template_keys:
+                xconnect_diff = xconnect_have != xconnect_want
+                comparisons.append(xconnect_diff)
+
             if any(comparisons):
                 # The network updates with missing networkId will have to use existing
                 # networkId from the instance of the same network on DCNM.
@@ -1848,6 +1868,9 @@ class DcnmNetwork:
                         intvlan_nfmon_changed = True
                     if vlan_nfen_have != vlan_nfen_want:
                         vlan_nfmon_changed = True
+                if self._ndfc_version_gte("12.4.1"):
+                    if xconnect_have != xconnect_want:
+                        xconnect_changed = True
 
                 want.update({"networkId": have["networkId"]})
                 create = want
@@ -1957,6 +1980,10 @@ class DcnmNetwork:
                 net_name_diff = net_name_have != net_name_want
                 comparisons.append(net_name_diff)
 
+            if "xconnect" not in skipped_template_keys:
+                xconnect_diff = xconnect_have != xconnect_want
+                comparisons.append(xconnect_diff)
+
             if any(comparisons):
                 # The network updates with missing networkId will have to use existing
                 # networkId from the instance of the same network on DCNM.
@@ -2006,6 +2033,9 @@ class DcnmNetwork:
                         intvlan_nfmon_changed = True
                     if vlan_nfen_have != vlan_nfen_want:
                         vlan_nfmon_changed = True
+                if self._ndfc_version_gte("12.4.1"):
+                    if xconnect_have != xconnect_want:
+                        xconnect_changed = True
 
                 want.update({"networkId": have["networkId"]})
                 create = want
@@ -2035,6 +2065,7 @@ class DcnmNetwork:
             nf_en_changed,
             intvlan_nfmon_changed,
             vlan_nfmon_changed,
+            xconnect_changed,
         )
 
     def update_create_params(self, net):
@@ -2111,6 +2142,8 @@ class DcnmNetwork:
             template_conf.update(ENABLE_NETFLOW=net.get("netflow_enable", False))
             template_conf.update(SVI_NETFLOW_MONITOR=net.get("intfvlan_nf_monitor", ""))
             template_conf.update(VLAN_NETFLOW_MONITOR=net.get("vlan_nf_monitor", ""))
+        if self._ndfc_version_gte("12.4.1"):
+            template_conf.update(xconnect=net.get("xconnect", False))
 
         if template_conf["vlanId"] is None:
             template_conf["vlanId"] = ""
@@ -2264,6 +2297,8 @@ class DcnmNetwork:
                     t_conf.update(ENABLE_NETFLOW=json_to_dict.get("ENABLE_NETFLOW", False))
                     t_conf.update(SVI_NETFLOW_MONITOR=json_to_dict.get("SVI_NETFLOW_MONITOR", ""))
                     t_conf.update(VLAN_NETFLOW_MONITOR=json_to_dict.get("VLAN_NETFLOW_MONITOR", ""))
+                if self._ndfc_version_gte("12.4.1"):
+                    t_conf.update(xconnect=json_to_dict.get("xconnect", False))
 
                 # Remove mcastGroup when Fabric is MSD
                 if "mcastGroup" not in json_to_dict:
@@ -2319,6 +2354,8 @@ class DcnmNetwork:
                             t_conf.update(ENABLE_NETFLOW=json_to_dict.get("ENABLE_NETFLOW", False))
                             t_conf.update(SVI_NETFLOW_MONITOR=json_to_dict.get("SVI_NETFLOW_MONITOR", ""))
                             t_conf.update(VLAN_NETFLOW_MONITOR=json_to_dict.get("VLAN_NETFLOW_MONITOR", ""))
+                        if self._ndfc_version_gte("12.4.1"):
+                            t_conf.update(xconnect=json_to_dict.get("xconnect", False))
 
                         l2net.update({"networkTemplateConfig": json.dumps(t_conf)})
                         del l2net["displayName"]
@@ -2845,6 +2882,7 @@ class DcnmNetwork:
         nf_en_changed = {}
         intvlan_nfmon_changed = {}
         vlan_nfmon_changed = {}
+        xconnect_changed = {}
 
         for want_c in self.want_create:
             found = False
@@ -2877,6 +2915,7 @@ class DcnmNetwork:
                         nf_en_chg,
                         intvlan_nfmon_chg,
                         vlan_nfmon_chg,
+                        xconnect_chg,
                     ) = self.diff_for_create(want_c, have_c)
 
                     gw_changed.update({want_c["networkName"]: gw_chg})
@@ -2902,6 +2941,7 @@ class DcnmNetwork:
                     nf_en_changed.update({want_c["networkName"]: nf_en_chg})
                     intvlan_nfmon_changed.update({want_c["networkName"]: intvlan_nfmon_chg})
                     vlan_nfmon_changed.update({want_c["networkName"]: vlan_nfmon_chg})
+                    xconnect_changed.update({want_c["networkName"]: xconnect_chg})
                     if diff:
                         diff_create_update.append(diff)
                     break
@@ -3013,6 +3053,7 @@ class DcnmNetwork:
                             or nf_en_changed.get(want_a["networkName"], False)
                             or intvlan_nfmon_changed.get(want_a["networkName"], False)
                             or vlan_nfmon_changed.get(want_a["networkName"], False)
+                            or xconnect_changed.get(want_a["networkName"], False)
                         ):
                             dep_net = want_a["networkName"]
 
@@ -3119,6 +3160,8 @@ class DcnmNetwork:
                 found_c.update({"netflow_enable": json_to_dict.get("ENABLE_NETFLOW", False)})
                 found_c.update({"intfvlan_nf_monitor": json_to_dict.get("SVI_NETFLOW_MONITOR", "")})
                 found_c.update({"vlan_nf_monitor": json_to_dict.get("VLAN_NETFLOW_MONITOR", "")})
+            if self._ndfc_version_gte("12.4.1"):
+                found_c.update({"xconnect": json_to_dict.get("xconnect", False)})
             found_c.update({"attach": []})
 
             del found_c["fabric"]
@@ -3656,6 +3699,8 @@ class DcnmNetwork:
                     t_conf.update(ENABLE_NETFLOW=json_to_dict.get("ENABLE_NETFLOW", False))
                     t_conf.update(SVI_NETFLOW_MONITOR=json_to_dict.get("SVI_NETFLOW_MONITOR", ""))
                     t_conf.update(VLAN_NETFLOW_MONITOR=json_to_dict.get("VLAN_NETFLOW_MONITOR", ""))
+                if self._ndfc_version_gte("12.4.1"):
+                    t_conf.update(xconnect=json_to_dict.get("xconnect", False))
 
                 # Remove skipped attributes from template config for parent fabrics
                 for key in list(t_conf.keys()):
@@ -3811,6 +3856,35 @@ class DcnmNetwork:
 
         return skipped_attrs
 
+    def _get_ndfc_version(self):
+        """Return the full NDFC version string (e.g. '12.4.1.245') using ControllerVersion, or None on failure."""
+        try:
+            sender = Sender()
+            sender.ansible_module = self.module
+            rest_send = RestSend(self.module.params)
+            rest_send.response_handler = ResponseHandler()
+            rest_send.sender = sender
+            controller_version = ControllerVersion()
+            controller_version.rest_send = rest_send
+            controller_version.refresh()
+            raw_version = controller_version.version
+            if raw_version:
+                return re.sub(r'[a-zA-Z]+$', '', raw_version)
+        except (ControllerResponseError, ValueError):
+            pass
+        return None
+
+    def _ndfc_version_gte(self, target):
+        """Check if NDFC version >= target. Uses tuple comparison on version segments."""
+        if not self.ndfc_version:
+            return False
+        try:
+            current = tuple(int(x) for x in self.ndfc_version.split(".")[:3])
+            required = tuple(int(x) for x in target.split(".")[:3])
+            return current >= required
+        except (ValueError, AttributeError):
+            return False
+
     def get_template_config_mapping(self):
         """
         Get mapping from network spec attributes to template config keys.
@@ -3846,8 +3920,10 @@ class DcnmNetwork:
             "l3gw_on_border": "enableL3OnBorder",
             "netflow_enable": "ENABLE_NETFLOW",
             "intfvlan_nf_monitor": "SVI_NETFLOW_MONITOR",
-            "vlan_nf_monitor": "VLAN_NETFLOW_MONITOR"
+            "vlan_nf_monitor": "VLAN_NETFLOW_MONITOR",
         }
+        if self._ndfc_version_gte("12.4.1"):
+            mapping["xconnect"] = "xconnect"
         return mapping
 
     def get_network_spec(self, fabric_type=None):
@@ -3956,6 +4032,9 @@ class DcnmNetwork:
                 intfvlan_nf_monitor=dict(type="str"),
                 vlan_nf_monitor=dict(type="str"),
             )
+
+            if self._ndfc_version_gte("12.4.1"):
+                net_spec["xconnect"] = dict(type="bool", default=False)
 
             # Adjust deploy field for query state
             if is_query_state:
@@ -4432,6 +4511,14 @@ class DcnmNetwork:
         # NetFlow SVI monitor configuration (common for all fabric types, version 12+ only)
         if self.dcnm_version > 11 and cfg.get("intfvlan_nf_monitor", None) is None:
             json_to_dict_want["SVI_NETFLOW_MONITOR"] = json_to_dict_have["SVI_NETFLOW_MONITOR"]
+
+        # XConnect configuration (NDFC >= 12.4.1 only)
+        if self._ndfc_version_gte("12.4.1") and cfg.get("xconnect", None) is None:
+            json_to_dict_want["xconnect"] = json_to_dict_have.get("xconnect", False)
+            if str(json_to_dict_want["xconnect"]).lower() == "true":
+                json_to_dict_want["xconnect"] = True
+            else:
+                json_to_dict_want["xconnect"] = False
 
         want.update({"networkTemplateConfig": json.dumps(json_to_dict_want)})
 

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -5064,13 +5064,13 @@ class DcnmNetwork:
             raw_version = controller_version.version
             if raw_version:
                 return re.sub(r'[a-zA-Z]+$', '', raw_version)
-        except (ControllerResponseError, ValueError):
+        except (ControllerResponseError, ValueError, AssertionError, Exception):
             pass
         return None
 
     def _ndfc_version_gte(self, target):
         """Check if NDFC version >= target. Uses tuple comparison on version segments."""
-        if not self.ndfc_version:
+        if not getattr(self, 'ndfc_version', None):
             return False
         try:
             current = tuple(int(x) for x in self.ndfc_version.split(".")[:3])

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -319,6 +319,12 @@ options:
         - Not applicable at Multisite parent fabric level
         type: str
         required: false
+      xconnect:
+        description:
+        - Enable XConnect feature. Only available for ND version > 4.1.
+        type: bool
+        default: false
+        required: false
       attach:
         description:
         - List of network attachment details
@@ -1016,6 +1022,11 @@ from ansible_collections.cisco.dcnm.plugins.module_utils.network.dcnm.dcnm impor
     sanitize_lan_attach_list
 )
 from ..module_utils.common.log_v2 import Log
+from ..module_utils.common.controller_version_v2 import ControllerVersion
+from ..module_utils.common.rest_send_v2 import RestSend
+from ..module_utils.common.response_handler import ResponseHandler
+from ..module_utils.common.sender_dcnm import Sender
+from ..module_utils.common.exceptions import ControllerResponseError
 
 
 class DcnmNetwork:
@@ -1131,6 +1142,9 @@ class DcnmNetwork:
 
         msg = f"self.dcnm_version: {self.dcnm_version}"
         self.log.debug(msg)
+
+        self.ndfc_version = self._get_ndfc_version()
+
         # Check for bulk API support
         self.has_bulk_api = dcnm_get_bulk_api_support(self.module)
         msg = f"Bulk API support detected: {self.has_bulk_api}"
@@ -1972,6 +1986,7 @@ class DcnmNetwork:
         nf_en_changed = False
         intvlan_nfmon_changed = False
         vlan_nfmon_changed = False
+        xconnect_changed = False
 
         if want.get("networkId") and want["networkId"] != have["networkId"]:
             self.module.fail_json(msg="networkId can not be updated on existing network: {0}".format(want["networkName"]))
@@ -2029,6 +2044,8 @@ class DcnmNetwork:
         intvlan_nfen_have = json_to_dict_have.get("SVI_NETFLOW_MONITOR", "")
         vlan_nfen_want = json_to_dict_want.get("VLAN_NETFLOW_MONITOR", "")
         vlan_nfen_have = json_to_dict_have.get("VLAN_NETFLOW_MONITOR", "")
+        xconnect_want = str(json_to_dict_want.get("xconnect", "")).lower()
+        xconnect_have = str(json_to_dict_have.get("xconnect", "")).lower()
 
         if vlanId_have != "":
             vlanId_have = int(vlanId_have)
@@ -2146,6 +2163,10 @@ class DcnmNetwork:
                 net_name_diff = net_name_have != net_name_want
                 comparisons.append(net_name_diff)
 
+            if "xconnect" not in skipped_template_keys:
+                xconnect_diff = xconnect_have != xconnect_want
+                comparisons.append(xconnect_diff)
+
             if any(comparisons):
                 # The network updates with missing networkId will have to use existing
                 # networkId from the instance of the same network on DCNM.
@@ -2198,6 +2219,9 @@ class DcnmNetwork:
                         intvlan_nfmon_changed = True
                     if vlan_nfen_have != vlan_nfen_want:
                         vlan_nfmon_changed = True
+                if self._ndfc_version_gte("12.4.1"):
+                    if xconnect_have != xconnect_want:
+                        xconnect_changed = True
 
                 want.update({"networkId": have["networkId"]})
                 create = want
@@ -2307,6 +2331,10 @@ class DcnmNetwork:
                 net_name_diff = net_name_have != net_name_want
                 comparisons.append(net_name_diff)
 
+            if "xconnect" not in skipped_template_keys:
+                xconnect_diff = xconnect_have != xconnect_want
+                comparisons.append(xconnect_diff)
+
             if any(comparisons):
                 # The network updates with missing networkId will have to use existing
                 # networkId from the instance of the same network on DCNM.
@@ -2356,6 +2384,9 @@ class DcnmNetwork:
                         intvlan_nfmon_changed = True
                     if vlan_nfen_have != vlan_nfen_want:
                         vlan_nfmon_changed = True
+                if self._ndfc_version_gte("12.4.1"):
+                    if xconnect_have != xconnect_want:
+                        xconnect_changed = True
 
                 want.update({"networkId": have["networkId"]})
                 create = want
@@ -2385,6 +2416,7 @@ class DcnmNetwork:
             nf_en_changed,
             intvlan_nfmon_changed,
             vlan_nfmon_changed,
+            xconnect_changed,
         )
 
     def update_create_params(self, net):
@@ -2461,6 +2493,8 @@ class DcnmNetwork:
             template_conf.update(ENABLE_NETFLOW=net.get("netflow_enable", False))
             template_conf.update(SVI_NETFLOW_MONITOR=net.get("intfvlan_nf_monitor", ""))
             template_conf.update(VLAN_NETFLOW_MONITOR=net.get("vlan_nf_monitor", ""))
+        if self._ndfc_version_gte("12.4.1"):
+            template_conf.update(xconnect=net.get("xconnect", False))
 
         if template_conf["vlanId"] is None:
             template_conf["vlanId"] = ""
@@ -2562,6 +2596,8 @@ class DcnmNetwork:
             t_conf.update(ENABLE_NETFLOW=json_to_dict.get("ENABLE_NETFLOW", False))
             t_conf.update(SVI_NETFLOW_MONITOR=json_to_dict.get("SVI_NETFLOW_MONITOR", ""))
             t_conf.update(VLAN_NETFLOW_MONITOR=json_to_dict.get("VLAN_NETFLOW_MONITOR", ""))
+        if self._ndfc_version_gte("12.4.1"):
+            t_conf.update(xconnect=json_to_dict.get("xconnect", False))
 
         if self.fabric_type not in ["multisite_child", "multicluster_child"]:
             t_conf["secondaryGWs"] = self.get_secondary_gws_template_config(t_conf)
@@ -3283,6 +3319,7 @@ class DcnmNetwork:
         nf_en_changed = {}
         intvlan_nfmon_changed = {}
         vlan_nfmon_changed = {}
+        xconnect_changed = {}
 
         for want_c in self.want_create:
             found = False
@@ -3315,6 +3352,7 @@ class DcnmNetwork:
                         nf_en_chg,
                         intvlan_nfmon_chg,
                         vlan_nfmon_chg,
+                        xconnect_chg,
                     ) = self.diff_for_create(want_c, have_c)
 
                     gw_changed.update({want_c["networkName"]: gw_chg})
@@ -3340,6 +3378,7 @@ class DcnmNetwork:
                     nf_en_changed.update({want_c["networkName"]: nf_en_chg})
                     intvlan_nfmon_changed.update({want_c["networkName"]: intvlan_nfmon_chg})
                     vlan_nfmon_changed.update({want_c["networkName"]: vlan_nfmon_chg})
+                    xconnect_changed.update({want_c["networkName"]: xconnect_chg})
                     if diff:
                         diff_create_update.append(diff)
                     break
@@ -3451,6 +3490,7 @@ class DcnmNetwork:
                             or nf_en_changed.get(want_a["networkName"], False)
                             or intvlan_nfmon_changed.get(want_a["networkName"], False)
                             or vlan_nfmon_changed.get(want_a["networkName"], False)
+                            or xconnect_changed.get(want_a["networkName"], False)
                         ):
                             dep_net = want_a["networkName"]
 
@@ -3744,6 +3784,8 @@ class DcnmNetwork:
                 found_c.update({"netflow_enable": json_to_dict.get("ENABLE_NETFLOW", False)})
                 found_c.update({"intfvlan_nf_monitor": json_to_dict.get("SVI_NETFLOW_MONITOR", "")})
                 found_c.update({"vlan_nf_monitor": json_to_dict.get("VLAN_NETFLOW_MONITOR", "")})
+            if self._ndfc_version_gte("12.4.1"):
+                found_c.update({"xconnect": json_to_dict.get("xconnect", False)})
             found_c.update({"attach": []})
 
             del found_c["fabric"]
@@ -4808,6 +4850,8 @@ class DcnmNetwork:
                     t_conf.update(ENABLE_NETFLOW=json_to_dict.get("ENABLE_NETFLOW", False))
                     t_conf.update(SVI_NETFLOW_MONITOR=json_to_dict.get("SVI_NETFLOW_MONITOR", ""))
                     t_conf.update(VLAN_NETFLOW_MONITOR=json_to_dict.get("VLAN_NETFLOW_MONITOR", ""))
+                if self._ndfc_version_gte("12.4.1"):
+                    t_conf.update(xconnect=json_to_dict.get("xconnect", False))
 
                 if self.fabric_type not in ["multisite_child", "multicluster_child"]:
                     t_conf["secondaryGWs"] = self.get_secondary_gws_template_config(t_conf)
@@ -5006,6 +5050,35 @@ class DcnmNetwork:
 
         return skipped_attrs
 
+    def _get_ndfc_version(self):
+        """Return the full NDFC version string (e.g. '12.4.1.245') using ControllerVersion, or None on failure."""
+        try:
+            sender = Sender()
+            sender.ansible_module = self.module
+            rest_send = RestSend(self.module.params)
+            rest_send.response_handler = ResponseHandler()
+            rest_send.sender = sender
+            controller_version = ControllerVersion()
+            controller_version.rest_send = rest_send
+            controller_version.refresh()
+            raw_version = controller_version.version
+            if raw_version:
+                return re.sub(r'[a-zA-Z]+$', '', raw_version)
+        except (ControllerResponseError, ValueError):
+            pass
+        return None
+
+    def _ndfc_version_gte(self, target):
+        """Check if NDFC version >= target. Uses tuple comparison on version segments."""
+        if not self.ndfc_version:
+            return False
+        try:
+            current = tuple(int(x) for x in self.ndfc_version.split(".")[:3])
+            required = tuple(int(x) for x in target.split(".")[:3])
+            return current >= required
+        except (ValueError, AttributeError):
+            return False
+
     def get_template_config_mapping(self):
         """
         Get mapping from network spec attributes to template config keys.
@@ -5043,6 +5116,8 @@ class DcnmNetwork:
             "intfvlan_nf_monitor": "SVI_NETFLOW_MONITOR",
             "vlan_nf_monitor": "VLAN_NETFLOW_MONITOR"
         }
+        if self._ndfc_version_gte("12.4.1"):
+            mapping["xconnect"] = "xconnect"
         return mapping
 
     def get_network_spec(self, fabric_type=None):
@@ -5151,7 +5226,8 @@ class DcnmNetwork:
                 intfvlan_nf_monitor=dict(type="str"),
                 vlan_nf_monitor=dict(type="str"),
             )
-
+            if self._ndfc_version_gte("12.4.1"):
+                net_spec["xconnect"] = dict(type="bool", default=False)
             # Adjust deploy field for query state
             if is_query_state:
                 net_spec["deploy"] = dict(type="bool")
@@ -5665,6 +5741,14 @@ class DcnmNetwork:
         # NetFlow SVI monitor configuration (common for all fabric types, version 12+ only)
         if self.dcnm_version > 11 and cfg.get("intfvlan_nf_monitor", None) is None:
             json_to_dict_want["SVI_NETFLOW_MONITOR"] = json_to_dict_have["SVI_NETFLOW_MONITOR"]
+
+        # XConnect configuration (NDFC >= 12.4.1 only)
+        if self._ndfc_version_gte("12.4.1") and cfg.get("xconnect", None) is None:
+            json_to_dict_want["xconnect"] = json_to_dict_have.get("xconnect", False)
+            if str(json_to_dict_want["xconnect"]).lower() == "true":
+                json_to_dict_want["xconnect"] = True
+            else:
+                json_to_dict_want["xconnect"] = False
 
         want.update({"networkTemplateConfig": json.dumps(json_to_dict_want)})
 

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -5304,8 +5304,8 @@ class DcnmNetwork:
                         if net.get("vrf_name", "") is None or net.get("vrf_name", "") == "":
                             net["vrf_name"] = "NA"
 
-                    if net.get("xconnect", False) is True:
-                        if net.get("is_l2only", False) is not True:
+                    if "xconnect" in net:
+                        if net.get("xconnect", False) is True and net.get("is_l2only", False) is not True:
                             invalid_params.append(
                                 f"Network '{net.get('net_name', 'unknown')}': "
                                 "xconnect requires is_l2only=true"
@@ -5385,8 +5385,8 @@ class DcnmNetwork:
                             if net.get("vrf_name", "") is None:
                                 invalid_params.append("vrf_name is required for L3 Networks")
 
-                        if net.get("xconnect", False) is True:
-                            if net.get("is_l2only", False) is not True:
+                        if "xconnect" in net:
+                            if net.get("xconnect", False) is True and net.get("is_l2only", False) is not True:
                                 invalid_params.append(
                                     f"Network '{net.get('net_name', 'unknown')}': "
                                     "xconnect requires is_l2only=true"

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -5226,8 +5226,7 @@ class DcnmNetwork:
                 intfvlan_nf_monitor=dict(type="str"),
                 vlan_nf_monitor=dict(type="str"),
             )
-            if self._ndfc_version_gte("12.4.1"):
-                net_spec["xconnect"] = dict(type="bool", default=False)
+            net_spec["xconnect"] = dict(type="bool", default=False)
             # Adjust deploy field for query state
             if is_query_state:
                 net_spec["deploy"] = dict(type="bool")
@@ -5305,6 +5304,23 @@ class DcnmNetwork:
                         if net.get("vrf_name", "") is None or net.get("vrf_name", "") == "":
                             net["vrf_name"] = "NA"
 
+                    if net.get("xconnect", False) is True:
+                        if net.get("is_l2only", False) is not True:
+                            invalid_params.append(
+                                f"Network '{net.get('net_name', 'unknown')}': "
+                                "xconnect requires is_l2only=true"
+                            )
+                        if self.ndfc_version is None:
+                            invalid_params.append(
+                                f"Network '{net.get('net_name', 'unknown')}': "
+                                "cannot validate xconnect — NDFC version lookup failed"
+                            )
+                        elif not self._ndfc_version_gte("12.4.1"):
+                            invalid_params.append(
+                                f"Network '{net.get('net_name', 'unknown')}': "
+                                f"xconnect requires NDFC >= 12.4.1 (current: {self.ndfc_version})"
+                            )
+
                     self.validated.append(net)
 
                 if invalid_params:
@@ -5368,6 +5384,23 @@ class DcnmNetwork:
                         else:
                             if net.get("vrf_name", "") is None:
                                 invalid_params.append("vrf_name is required for L3 Networks")
+
+                        if net.get("xconnect", False) is True:
+                            if net.get("is_l2only", False) is not True:
+                                invalid_params.append(
+                                    f"Network '{net.get('net_name', 'unknown')}': "
+                                    "xconnect requires is_l2only=true"
+                                )
+                            if self.ndfc_version is None:
+                                invalid_params.append(
+                                    f"Network '{net.get('net_name', 'unknown')}': "
+                                    "cannot validate xconnect — NDFC version lookup failed"
+                                )
+                            elif not self._ndfc_version_gte("12.4.1"):
+                                invalid_params.append(
+                                    f"Network '{net.get('net_name', 'unknown')}': "
+                                    f"xconnect requires NDFC >= 12.4.1 (current: {self.ndfc_version})"
+                                )
 
                         if any(has_partial_dhcp_config(srvr) for srvr in [
                             dict(srvr_ip=net.get("dhcp_srvr1_ip"), srvr_vrf=net.get("dhcp_srvr1_vrf")),

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -5226,7 +5226,7 @@ class DcnmNetwork:
                 intfvlan_nf_monitor=dict(type="str"),
                 vlan_nf_monitor=dict(type="str"),
             )
-            net_spec["xconnect"] = dict(type="bool", default=False)
+            net_spec["xconnect"] = dict(type="bool")
             # Adjust deploy field for query state
             if is_query_state:
                 net_spec["deploy"] = dict(type="bool")
@@ -5304,7 +5304,7 @@ class DcnmNetwork:
                         if net.get("vrf_name", "") is None or net.get("vrf_name", "") == "":
                             net["vrf_name"] = "NA"
 
-                    if "xconnect" in net:
+                    if net.get("xconnect") is not None:
                         if net.get("xconnect", False) is True and net.get("is_l2only", False) is not True:
                             invalid_params.append(
                                 f"Network '{net.get('net_name', 'unknown')}': "
@@ -5385,7 +5385,7 @@ class DcnmNetwork:
                             if net.get("vrf_name", "") is None:
                                 invalid_params.append("vrf_name is required for L3 Networks")
 
-                        if "xconnect" in net:
+                        if net.get("xconnect") is not None:
                             if net.get("xconnect", False) is True and net.get("is_l2only", False) is not True:
                                 invalid_params.append(
                                     f"Network '{net.get('net_name', 'unknown')}': "


### PR DESCRIPTION
fix: #604 

Add xconnect for ND 4.1:

```
    - cisco.dcnm.dcnm_network:
        state: merged
        fabric: myFab
        config:
          - net_name: TEST-XCONNECT-NET1
            is_l2only: true
            vlan_id: 2001
            xconnect: true
```

```
changed: [myFab] => {
    "changed": true,
    "diff": [
        {
            "arp_suppress": false,
            "attach": [],
            "dhcp_loopback_id": "",
            "dhcp_servers": "",
            "dhcp_srvr1_ip": "",
            "dhcp_srvr1_vrf": "",
            "dhcp_srvr2_ip": "",
            "dhcp_srvr2_vrf": "",
            "dhcp_srvr3_ip": "",
            "dhcp_srvr3_vrf": "",
            "gw_ip_subnet": "",
            "gw_ipv6_subnet": "",
            "int_desc": "",
            "intfvlan_nf_monitor": "",
            "is_l2only": true,
            "l3gw_on_border": false,
            "mtu_l3intf": "",
            "multicast_group_address": "239.1.1.1",
            "net_extension_template": "Default_Network_Extension_Universal",
            "net_id": 30000,
            "net_name": "TEST-XCONNECT-NET1",
            "net_template": "Default_Network_Universal",
            "netflow_enable": false,
            "route_target_both": false,
            "secondary_ip_gw1": "",
            "secondary_ip_gw2": "",
            "secondary_ip_gw3": "",
            "secondary_ip_gw4": "",
            "trm_enable": false,
            "vlan_id": 2001,
            "vlan_name": "",
            "vlan_nf_monitor": "",
            "vrf_name": "NA",
            "xconnect": true
        }
    ],
    "invocation": {
        "module_args": {
            "config": [
                {
                    "is_l2only": true,
                    "net_name": "TEST-XCONNECT-NET1",
                    "vlan_id": 2001,
                    "xconnect": true
                }
            ],
            "fabric": "myFab",
            "state": "merged"
        }
    },
    "response": [
        {
            "DATA": {},
            "MESSAGE": "OK",
            "METHOD": "PUT",
            "REQUEST_PATH": "https://x.x.x.x:443/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/myFab/networks/TEST-XCONNECT-NET1",
            "RETURN_CODE": 200
        }
    ]
}

PLAY RECAP *********************************************************************************************************************************************************************************************************************
myFab                 : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```