### PR TITLE
Fix for tor pairing

### DIFF
--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -4973,10 +4973,10 @@ class DcnmIntf:
                         # This includes both TOR-side and leaf-side port-channels:
                         # - TOR side: "tor-connected-to-vPC-leaf:" or "tor-connected-to-leaf:"
                         # - Leaf side: "leaf-connected-to-vPC-tor:" or "leaf-connected-to-tor:"
-                        if have["alias"] is not None and (
-                            "tor-connected-to" in have["alias"]
-                            or "leaf-connected-to-vPC-tor" in have["alias"]
-                            or "leaf-connected-to-tor" in have["alias"]
+                        if have.get("alias") is not None and (
+                            "tor-connected-to" in have.get("alias")
+                            or "leaf-connected-to-vPC-tor" in have.get("alias")
+                            or "leaf-connected-to-tor" in have.get("alias")
                         ):
                             self.changed_dict[0]["skipped"].append(
                                 {
@@ -5031,14 +5031,14 @@ class DcnmIntf:
                     # - ifType: INTERFACE_VPC
                     # - underlayPolicies templateName starting with "int_vpc_uplink_"
                     # - alias patterns: "tor-connected-to", "leaf-connected-to-vPC-tor"
-                    if have["ifType"] == "INTERFACE_VPC":
+                    if have.get("ifType") == "INTERFACE_VPC":
                         is_tor_uplink = False
 
                         # Check alias patterns for TOR uplinks
-                        if have["alias"] is not None and (
-                            "tor-connected-to" in have["alias"]
-                            or "leaf-connected-to-vPC-tor" in have["alias"]
-                            or "leaf-connected-to-tor" in have["alias"]
+                        if have.get("alias") is not None and (
+                            "tor-connected-to" in have.get("alias")
+                            or "leaf-connected-to-vPC-tor" in have.get("alias")
+                            or "leaf-connected-to-tor" in have.get("alias")
                         ):
                             is_tor_uplink = True
 


### PR DESCRIPTION
Fix for #617 

## Summary:

Fixed a bug where vPC interfaces (vPC1, vPC2, etc.) were incorrectly marked for deletion during state: overridden operations, causing errors like "Peer-1/2 member port is a member of vPCx, remove port from vPCx first".

### Solution:
#### Made vPC protection unconditional - all INTERFACE_VPC type interfaces are now skipped during override operations, regardless of alias value. This aligns with the existing code comments which stated "Skip ALL vPC interfaces unconditionally during override."
 ---
  NDFC API Response (interface/detail endpoint)

  vPC interfaces returned by NDFC have alias: null:
```json
  {
    "alias": null,
    "ifName": "vPC1",
    "ifType": "INTERFACE_VPC",
    "serialNo": "9HI8CRDYHUB~9TNO7SBHL14",
    "sysName": "fabric1-l1~fabric1-l2",
    "fabricName": "nac-fabric1-tor",
    "complianceStatus": "In-Sync",
    "isDeletable": true,
    "mode": "trunk",
    "underlayPolicies": [...]
  }

  {
    "alias": null,
    "ifName": "vPC1",
    "ifType": "INTERFACE_VPC",
    "serialNo": "9OT6NKEJ39F~9AI0TOS9PRW",
    "sysName": "fabric1-s2~fabric1-s1",
    "fabricName": "nac-fabric1-tor",
    "complianceStatus": "In-Sync",
    "isDeletable": true
  }

  {
    "alias": null,
    "ifName": "vPC2",
    "ifType": "INTERFACE_VPC",
    "serialNo": "9OT6NKEJ39F~9AI0TOS9PRW",
    "sysName": "fabric1-s2~fabric1-s1",
    "fabricName": "nac-fabric1-tor",
    "complianceStatus": "In-Sync",
    "isDeletable": true
  }
```
  ---
  Ansible Module Invocation
```yaml
  cisco.dcnm.dcnm_interface:
    fabric: nac-fabric1-tor
    state: overridden
    config: []
```
  ---
  Ansible Log Output (before fix)

  vPC interfaces incorrectly marked for deletion:
```json
  "deleted": [
      {
          "fabricName": "nac-fabric1-tor",
          "ifName": "vPC1",
          "interfaceDbId": 0,
          "interfaceType": "INTERFACE_VPC",
          "serialNumber": "9HI8CRDYHUB~9TNO7SBHL14"
      },
      {
          "fabricName": "nac-fabric1-tor",
          "ifName": "vPC1",
          "interfaceDbId": 0,
          "interfaceType": "INTERFACE_VPC",
          "serialNumber": "9OT6NKEJ39F~9AI0TOS9PRW"
      },
      {
          "fabricName": "nac-fabric1-tor",
          "ifName": "vPC2",
          "interfaceDbId": 0,
          "interfaceType": "INTERFACE_VPC",
          "serialNumber": "9OT6NKEJ39F~9AI0TOS9PRW"
      }
  ]
```
  ---

