### PR TITLE
DCNM_VRF: Fix Paths in Module and Action Plugin

### DIFF
--- a/plugins/module_utils/network/dcnm/dcnm.py
+++ b/plugins/module_utils/network/dcnm/dcnm.py
@@ -1617,17 +1617,17 @@ def deploy_fabric(action_module, task_vars, tmp, fabric, fabric_type, deploy_pay
     )
 
     # Get fabric type and build appropriate path
-    base_path = f"/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{fabric}/vrfs"
+    base_path = f"/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{fabric}/vrfs"
     proxy = ""
 
     # Determine deployment path and payload based on fabric type
     if fabric_type == "multicluster_parent":
         # Multicluster parent uses different endpoint and payload format
-        if action_module.ndfc_version >= 12.4:
+        if action_module.ndfc_version >= 12.2:
             proxy = "/onemanage"
 
         deploy_path = proxy + base_path.replace(
-            f"lan-fabric/rest/control/fabrics/{fabric}/vrfs",
+            f"lan-fabric/rest/top-down/fabrics/{fabric}/vrfs",
             "onemanage/top-down/vrfs/deploy"
         )
     else:

--- a/plugins/modules/dcnm_vrf.py
+++ b/plugins/modules/dcnm_vrf.py
@@ -1177,7 +1177,7 @@ class DcnmVrf:
                 self.resource_paths[path] = proxy + self.action_fabric_cluster + self.resource_paths[path]
         elif self.action_fabric_type == "multicluster_parent":
             # onemanage proxy path
-            if self.dcnm_version >= 12.4:
+            if self.dcnm_version >= 12.2:
                 proxy = "/onemanage"
             for path in self.paths:
                 self.paths[path] = proxy + self.paths[path].replace("lan-fabric/rest", "onemanage")


### PR DESCRIPTION
Fix Deploy Path in Action Plugin for MSD Fabrics. 
Prepend onemanage to Multicluster API paths in 3.2 as well.