### PR TITLE
DCNM_INTERFACE: overridden state not resetting interfaces removed from playbook config

### DIFF
--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -4702,8 +4702,12 @@ class DcnmIntf:
         for item in self.pb_input:
             # For overridden state, we will not touch anything that is present in incoming config,
             # because those interfaces will anyway be modified in the current run
+            # Must check both interface name AND serial number to ensure we're comparing the same
+            # interface on the same switch (not just the same interface name on different switches)
             if (self.module.params["state"] == "overridden") and (
                 item["ifname"] == have["ifName"]
+            ) and (
+                item.get("sno") == have.get("serialNo")
             ):
                 return False, item["ifname"]
             if item.get("members"):
@@ -4885,29 +4889,48 @@ class DcnmIntf:
                     continue
 
                 if uelem is not None:
-                    # Before defaulting ethernet interfaces, check if they are
-                    # member of any port-channel. If so, do not default that
-                    rc, intf = self.dcnm_intf_can_be_replaced(have)
-                    if rc is True:
-                        self.dcnm_intf_merge_intf_info(
-                            uelem, self.diff_replace
+                    # Before defaulting ethernet interfaces, check if this interface is present in want.
+                    # If yes, ignore the interface, because configuration from want will be applied anyway.
+                    # This ensures that Ethernet interfaces removed from the playbook config are reset to default,
+                    # while those still in the config are left alone to be configured later.
+                    match_want = [
+                        d
+                        for d in self.want
+                        if (
+                            (
+                                name.lower()
+                                == d["interfaces"][0]["ifName"].lower()
+                            )
+                            and (str(sno) == str(d["interfaces"][0]["serialNumber"]))
+                            and (fabric == d["interfaces"][0]["fabricName"])
                         )
-                        self.changed_dict[0]["replaced"].append(
-                            copy.deepcopy(uelem)
-                        )
-                        delem["serialNumber"] = sno
-                        delem["ifName"] = name
-                        delem["fabricName"] = self.fabric
-                        if str(deploy).lower() == "true":
-                            # Do not create interface E1/x/y, interface is created with breakout
-                            pattern = r'^Ethernet1/\d+/\d+$'
-                            if_name = delem.get('ifName')
+                    ]
 
-                            if not re.match(pattern, if_name):
-                                self.diff_deploy.append(delem)
-                                self.changed_dict[0]["deploy"].append(
-                                    copy.deepcopy(delem)
-                                )
+                    # Only default/reset this interface if it's NOT in the playbook config
+                    if not match_want:
+                        # Before defaulting ethernet interfaces, check if they are
+                        # member of any port-channel. If so, do not default that
+                        rc, intf = self.dcnm_intf_can_be_replaced(have)
+                        if rc is True:
+                            self.dcnm_intf_merge_intf_info(
+                                uelem, self.diff_replace
+                            )
+                            self.changed_dict[0]["replaced"].append(
+                                copy.deepcopy(uelem)
+                            )
+                            delem["serialNumber"] = sno
+                            delem["ifName"] = name
+                            delem["fabricName"] = self.fabric
+                            if str(deploy).lower() == "true":
+                                # Do not create interface E1/x/y, interface is created with breakout
+                                pattern = r'^Ethernet1/\d+/\d+$'
+                                if_name = delem.get('ifName')
+
+                                if not re.match(pattern, if_name):
+                                    self.diff_deploy.append(delem)
+                                    self.changed_dict[0]["deploy"].append(
+                                        copy.deepcopy(delem)
+                                    )
             # Sub-interafces are returned as INTERFACE_ETHERNET in have_all. So do an
             # additional check to see if it is physical. If not assume it to be sub-interface
             # for now. We will have to re-visit this check if there are additional non-physical


### PR DESCRIPTION
## Fix: dcnm_interface module overridden state not resetting interfaces removed from playbook config

### Problem Description

When using `state: overridden` with the `dcnm_interface` module, Ethernet interfaces that were removed from the playbook configuration were not being reset to their default trunk mode. Instead, they retained their previous configuration from earlier playbook runs.

**Example Scenario:**
- Playbook 1: Configure Ethernet1/20 on switch 10.122.84.181 as access mode VLAN 200
- Playbook 2: Remove Ethernet1/20 from switch 10.122.84.181 config (keep it on other switches)
- **Expected**: Ethernet1/20 on switch 10.122.84.181 should be reset to default trunk mode
- **Actual**: Ethernet1/20 on switch 10.122.84.181 remained in access mode VLAN 200 (bug)

### Root Cause

The bug was in the `dcnm_intf_can_be_replaced()` method (line ~4704-4707). When checking if an Ethernet interface could be reset to default in `overridden` mode, the method only compared **interface names** without considering **switch serial numbers**.

This caused false matches when the same interface name existed on different switches:
- Interface Ethernet1/20 on switch A (not in playbook) would match Ethernet1/20 on switch B (in playbook)
- The function would incorrectly return `False`, blocking the reset operation on switch A
- Result: Interface on switch A remained in its previous configured state instead of being reset

### Changes Made

**1. Enhanced overridden state logic for Ethernet interfaces** (line ~4895)
- Added switch-aware comparison to check if an Ethernet interface exists in the desired configuration (`self.want`)
- Only reset interfaces to default if they are NOT in the playbook config for that specific switch
- Ensures proper per-switch, per-interface tracking

**2. Fixed `dcnm_intf_can_be_replaced()` method** (line ~4707)
- Added serial number comparison alongside interface name comparison
- Changed from: `item["ifname"] == have["ifName"]`
- Changed to: `item["ifname"] == have["ifName"] AND item.get("sno") == have.get("serialNo")`
- Prevents false positives when the same interface name exists on multiple switches

### Expected Behavior After Fix

**Playbook 1** (Initial configuration):
- ✓ Ethernet1/20 on 10.122.84.181 → access mode VLAN 200
- ✓ Ethernet1/21 on 10.122.84.181 → access mode VLAN 200
- ✓ Ethernet1/20 on 10.122.84.182 → access mode VLAN 200

**Playbook 2** (Ethernet1/20 removed from switch .181):
- ✓ **Ethernet1/20 on 10.122.84.181 → reset to default trunk mode** (FIXED!)
- ✓ Ethernet1/21 on 10.122.84.181 → remains access mode VLAN 200
- ✓ Ethernet1/20 on 10.122.84.182 → remains access mode VLAN 200

### Testing

Tested with the scenario described above:
- First run configures interfaces on multiple switches
- Second run with interfaces removed from specific switches
- Verified that removed interfaces are properly reset to default trunk mode
- Verified that interfaces kept in config maintain their configuration
- Verified that same interface names on different switches are handled independently

### Impact

This fix ensures that `state: overridden` works correctly for Ethernet interfaces when:
- The same interface name exists on multiple switches in the fabric
- Interfaces are selectively removed from specific switches while kept on others
- Proper per-switch interface lifecycle management is required