### PR TITLE
Remove support for python version 3.9 in actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,14 +53,8 @@ jobs:
     strategy:
       matrix:
         ansible: [2.15.13, 2.16.14, 2.17.12, 2.18.6]
-        python: ["3.9", "3.10", "3.11"]
+        python: ["3.10", "3.11"]
         exclude:
-          - ansible: 2.16.14
-            python: "3.9"
-          - ansible: 2.17.12
-            python: "3.9"
-          - ansible: 2.18.6
-            python: "3.9"
           - ansible: 2.18.6
             python: "3.10"
     steps:


### PR DESCRIPTION
Python version 3.9 has reached EOL and GitHub actions is removing support for it.

Message as seen in GitHub actions

```
Error: Version 3.9 with arch x64 not found
Available versions:

3.10.19 (x64)
3.11.14 (x64)
3.12.12 (x64)
3.13.11 (x64)
3.14.2 (x64)
```