### PR TITLE
Fix for Issue #626

### DIFF
--- a/plugins/module_utils/fabric_group/common.py
+++ b/plugins/module_utils/fabric_group/common.py
@@ -156,9 +156,19 @@ class FabricGroupCommon:
         """
         -   Remove DEPLOY key from payloads prior to sending them
             to the controller.
+
+        ## Notes
+
+        -   For VXLAN child fabrics, DEPLOY is at the top level
+            of the payload.
+        -   For MCFG parent fabrics, DEPLOY is nested within
+            `payload["nvPairs"]`.
+        -   This method removes DEPLOY from both locations.
         """
         for payload in self._payloads_to_commit:
             payload.pop("DEPLOY", None)
+            if isinstance(payload.get("nvPairs"), dict):
+                payload["nvPairs"].pop("DEPLOY", None)
 
     def _verify_payload(self, payload: dict[str, Any]) -> None:
         """

--- a/tests/unit/modules/dcnm/dcnm_fabric_group/fixtures/payloads_FabricGroupCommon.json
+++ b/tests/unit/modules/dcnm/dcnm_fabric_group/fixtures/payloads_FabricGroupCommon.json
@@ -67,5 +67,61 @@
             "FABRIC_NAME": "f1",
             "FABRIC_TYPE": "VXLAN_EVPN"
         }
+    ],
+    "test_fabric_group_common_00030a": [
+        {
+            "TEST_NOTES": [
+                "DEPLOY at top level only (VXLAN child fabric).",
+                "Tests that DEPLOY is removed from the top level."
+            ],
+            "BGP_AS": 65001,
+            "DEPLOY": true,
+            "FABRIC_NAME": "f1",
+            "FABRIC_TYPE": "VXLAN_EVPN"
+        }
+    ],
+    "test_fabric_group_common_00031a": [
+        {
+            "TEST_NOTES": [
+                "DEPLOY in nvPairs only (MCFG parent fabric).",
+                "Tests that DEPLOY is removed from nvPairs.",
+                "This tests the fix for GitHub issue #626."
+            ],
+            "BGP_AS": 65001,
+            "FABRIC_NAME": "MFG1",
+            "FABRIC_TYPE": "MCFG",
+            "nvPairs": {
+                "DEPLOY": false,
+                "ANYCAST_GW_MAC": "00:11:22:33:44:55"
+            }
+        }
+    ],
+    "test_fabric_group_common_00032a": [
+        {
+            "TEST_NOTES": [
+                "DEPLOY at both top level and in nvPairs.",
+                "Tests that DEPLOY is removed from both locations.",
+                "This tests the fix for GitHub issue #626."
+            ],
+            "BGP_AS": 65001,
+            "DEPLOY": true,
+            "FABRIC_NAME": "MFG1",
+            "FABRIC_TYPE": "MCFG",
+            "nvPairs": {
+                "DEPLOY": false,
+                "ANYCAST_GW_MAC": "00:11:22:33:44:55"
+            }
+        }
+    ],
+    "test_fabric_group_common_00033a": [
+        {
+            "TEST_NOTES": [
+                "No DEPLOY at top level or in nvPairs.",
+                "Tests that payloads without DEPLOY are handled gracefully."
+            ],
+            "BGP_AS": 65001,
+            "FABRIC_NAME": "f1",
+            "FABRIC_TYPE": "VXLAN_EVPN"
+        }
     ]
 }

--- a/tests/unit/modules/dcnm/dcnm_fabric_group/test_fabric_group_common.py
+++ b/tests/unit/modules/dcnm/dcnm_fabric_group/test_fabric_group_common.py
@@ -213,3 +213,127 @@ def test_fabric_group_common_00024(fabric_group_common) -> None:
     # Verify payload is unchanged (no ANYCAST_GW_MAC was added)
     assert "ANYCAST_GW_MAC" not in instance._payloads_to_commit[0]
     assert instance._payloads_to_commit[0]["FABRIC_NAME"] == original_payload["FABRIC_NAME"]
+
+
+def test_fabric_group_common_00030(fabric_group_common) -> None:
+    """
+    # Summary
+
+    Verify `_fixup_deploy` removes DEPLOY from top level.
+
+    ## Test
+
+    - DEPLOY at top level is removed
+    - `ValueError` is not raised
+
+    ## Classes and Methods
+
+    - FabricGroupCommon.__init__()
+    - FabricGroupCommon._fixup_deploy()
+    """
+    method_name = inspect.stack()[0][3]
+    key = f"{method_name}a"
+
+    with does_not_raise():
+        instance = fabric_group_common
+        instance._payloads_to_commit = payloads_fabric_group_common(key)
+        assert "DEPLOY" in instance._payloads_to_commit[0]
+        instance._fixup_deploy()
+
+    assert "DEPLOY" not in instance._payloads_to_commit[0]
+
+
+def test_fabric_group_common_00031(fabric_group_common) -> None:
+    """
+    # Summary
+
+    Verify `_fixup_deploy` removes DEPLOY from nvPairs (MCFG fabric).
+
+    ## Test
+
+    - DEPLOY in nvPairs is removed
+    - `ValueError` is not raised
+    - This tests the fix for GitHub issue #626
+
+    ## Classes and Methods
+
+    - FabricGroupCommon.__init__()
+    - FabricGroupCommon._fixup_deploy()
+    """
+    method_name = inspect.stack()[0][3]
+    key = f"{method_name}a"
+
+    with does_not_raise():
+        instance = fabric_group_common
+        instance._payloads_to_commit = payloads_fabric_group_common(key)
+        assert "DEPLOY" in instance._payloads_to_commit[0]["nvPairs"]
+        instance._fixup_deploy()
+
+    assert "DEPLOY" not in instance._payloads_to_commit[0]["nvPairs"]
+    # Verify other nvPairs keys are preserved
+    assert "ANYCAST_GW_MAC" in instance._payloads_to_commit[0]["nvPairs"]
+
+
+def test_fabric_group_common_00032(fabric_group_common) -> None:
+    """
+    # Summary
+
+    Verify `_fixup_deploy` removes DEPLOY from both top level and nvPairs.
+
+    ## Test
+
+    - DEPLOY at top level is removed
+    - DEPLOY in nvPairs is removed
+    - `ValueError` is not raised
+    - This tests the fix for GitHub issue #626
+
+    ## Classes and Methods
+
+    - FabricGroupCommon.__init__()
+    - FabricGroupCommon._fixup_deploy()
+    """
+    method_name = inspect.stack()[0][3]
+    key = f"{method_name}a"
+
+    with does_not_raise():
+        instance = fabric_group_common
+        instance._payloads_to_commit = payloads_fabric_group_common(key)
+        assert "DEPLOY" in instance._payloads_to_commit[0]
+        assert "DEPLOY" in instance._payloads_to_commit[0]["nvPairs"]
+        instance._fixup_deploy()
+
+    assert "DEPLOY" not in instance._payloads_to_commit[0]
+    assert "DEPLOY" not in instance._payloads_to_commit[0]["nvPairs"]
+    # Verify other nvPairs keys are preserved
+    assert "ANYCAST_GW_MAC" in instance._payloads_to_commit[0]["nvPairs"]
+
+
+def test_fabric_group_common_00033(fabric_group_common) -> None:
+    """
+    # Summary
+
+    Verify `_fixup_deploy` handles payloads without DEPLOY gracefully.
+
+    ## Test
+
+    - Payload has no DEPLOY at top level or in nvPairs
+    - Method completes without error
+    - Payload is unchanged
+
+    ## Classes and Methods
+
+    - FabricGroupCommon.__init__()
+    - FabricGroupCommon._fixup_deploy()
+    """
+    method_name = inspect.stack()[0][3]
+    key = f"{method_name}a"
+
+    with does_not_raise():
+        instance = fabric_group_common
+        instance._payloads_to_commit = payloads_fabric_group_common(key)
+        original_payload = instance._payloads_to_commit[0].copy()
+        instance._fixup_deploy()
+
+    # Verify payload is unchanged (no DEPLOY was present)
+    assert "DEPLOY" not in instance._payloads_to_commit[0]
+    assert instance._payloads_to_commit[0]["FABRIC_NAME"] == original_payload["FABRIC_NAME"]


### PR DESCRIPTION
# Fix DEPLOY Flag Not Sanitized in nvPairs for MCFG Payloads

Fixes #626

## Summary

The `dcnm_fabric_group` module fails when managing Multi-Cluster Fabric Groups (MCFG) on Nexus Dashboard 3.2(2m) / NDFC 12.2.x with the error:

```
Failed to create the fabric, due to invalid fields [{DEPLOY=false}]
```

## Root Cause

The `_fixup_deploy()` method in `plugins/module_utils/fabric_group/common.py` only removes the internal `DEPLOY` control flag from the top level of the payload:

```python
def _fixup_deploy(self) -> None:
    for payload in self._payloads_to_commit:
        payload.pop("DEPLOY", None)
```

However, MCFG payloads wrap configuration within `nvPairs`, allowing `DEPLOY` to persist and be transmitted to the controller, causing validation errors on stricter NDFC versions.

## Fix

Extended `_fixup_deploy()` to also sanitize `DEPLOY` from within `nvPairs`, following the same pattern already used by `_fixup_anycast_gw_mac()`:

```python
def _fixup_deploy(self) -> None:
    for payload in self._payloads_to_commit:
        payload.pop("DEPLOY", None)
        if isinstance(payload.get("nvPairs"), dict):
            payload["nvPairs"].pop("DEPLOY", None)
```

## Unit Tests Added

Added 4 new unit tests to `tests/unit/modules/dcnm/dcnm_fabric_group/test_fabric_group_common.py`:

| Test | Description |
|------|-------------|
| `test_fabric_group_common_00030` | Verifies DEPLOY is removed from top level (VXLAN child fabrics) |
| `test_fabric_group_common_00031` | Verifies DEPLOY is removed from nvPairs (MCFG parent fabrics) |
|`test_fabric_group_common_00032` | Verifies DEPLOY is removed from both locations simultaneously |
|`test_fabric_group_common_00033` | Verifies payloads without DEPLOY are handled gracefully |

## Test Results

```
tests/unit/modules/dcnm/dcnm_fabric_group/test_fabric_group_common.py::test_fabric_group_common_00010 PASSED
tests/unit/modules/dcnm/dcnm_fabric_group/test_fabric_group_common.py::test_fabric_group_common_00020 PASSED
tests/unit/modules/dcnm/dcnm_fabric_group/test_fabric_group_common.py::test_fabric_group_common_00021 PASSED
tests/unit/modules/dcnm/dcnm_fabric_group/test_fabric_group_common.py::test_fabric_group_common_00022 PASSED
tests/unit/modules/dcnm/dcnm_fabric_group/test_fabric_group_common.py::test_fabric_group_common_00023 PASSED
tests/unit/modules/dcnm/dcnm_fabric_group/test_fabric_group_common.py::test_fabric_group_common_00024 PASSED
tests/unit/modules/dcnm/dcnm_fabric_group/test_fabric_group_common.py::test_fabric_group_common_00030 PASSED
tests/unit/modules/dcnm/dcnm_fabric_group/test_fabric_group_common.py::test_fabric_group_common_00031 PASSED
tests/unit/modules/dcnm/dcnm_fabric_group/test_fabric_group_common.py::test_fabric_group_common_00032 PASSED
tests/unit/modules/dcnm/dcnm_fabric_group/test_fabric_group_common.py::test_fabric_group_common_00033 PASSED

10 passed in 0.03s
```

## Environment

- **Affected Versions:** ND 3.2(2m) / NDFC 12.2.x
- **Tolerant Versions:** ND 4.1(1g)