### PR TITLE
Enable Fabric Associations Lookup on Secondary Cluster

### DIFF
--- a/plugins/module_utils/network/dcnm/dcnm.py
+++ b/plugins/module_utils/network/dcnm/dcnm.py
@@ -34,6 +34,12 @@ try:
 except ImportError:
     HAS_REQUESTS = False
 
+FEDERATION_MANAGER_NOT_FOUND_ERRORS = [
+    'Invalid JSON response: this API is allowed only for remote user',
+    'A federation manager does not exist',
+    'Invalid JSON response: cannot serve APIs as federation state is secondary. Use primary cluster for APIs'
+]
+
 dcnm_paths = {
     11: {"TEMPLATE_WITH_NAME": "/rest/config/templates/{}"},
     12: {
@@ -1416,10 +1422,17 @@ def obtain_federated_fabric_associations(action_module, task_vars, tmp):
                 error_msg = error_msg.get('error')
 
             if not isinstance(error_msg, str):
-                raise Exception("Unexpected error message format received from federated fabric associations API.")
+                error_details = {
+                    "error_msg_type": type(error_msg).__name__,
+                    "error_msg_value": str(error_msg),
+                    "response": federated_fabric_associations
+                }
+                return action_module.error_handler.handle_failure(
+                    "Unexpected error message format from federated fabric associations API",
+                    details=error_details
+                )
 
-            error_messages = ['Invalid JSON response: this API is allowed only for remote user', 'A federation manager does not exist']
-            if error_msg in error_messages:
+            if error_msg in FEDERATION_MANAGER_NOT_FOUND_ERRORS:
                 # Return the same error message for both ND3.2 and ND4.X for consistency
                 return 'A federation manager does not exist'
 

--- a/plugins/module_utils/network/dcnm/dcnm.py
+++ b/plugins/module_utils/network/dcnm/dcnm.py
@@ -1445,7 +1445,6 @@ def obtain_federated_fabric_associations(action_module, task_vars, tmp):
                error_msg.startswith("Invalid JSON response: <html>"):
                 return 'A federation manager does not exist'
 
-
         # Validate API response structure and extract data
         response_data = action_module.error_handler.validate_api_response(
             federated_fabric_associations,

--- a/plugins/module_utils/network/dcnm/dcnm.py
+++ b/plugins/module_utils/network/dcnm/dcnm.py
@@ -1415,7 +1415,10 @@ def obtain_federated_fabric_associations(action_module, task_vars, tmp):
         #   * Federation manager does not exist (standalone or MSD fabrics in a non-clustered environment)
         #   * ND3.2 returns an invalid JSON response for remote users
         if federated_fabric_associations.get('failed') and federated_fabric_associations.get('msg'):
-            error_msg = federated_fabric_associations.get('msg').get('DATA')
+            message = federated_fabric_associations.get('msg')
+            error_msg = message.get('DATA')
+            error_code = message.get('RETURN_CODE')
+
             # For ND3.2 error_msg will be a string
             # For ND4.X error_msg will be a dict
             if isinstance(error_msg, dict):
@@ -1435,6 +1438,13 @@ def obtain_federated_fabric_associations(action_module, task_vars, tmp):
             if error_msg in FEDERATION_MANAGER_NOT_FOUND_ERRORS:
                 # Return the same error message for both ND3.2 and ND4.X for consistency
                 return 'A federation manager does not exist'
+
+            # ND3.1 Returns a very cryptic error message using RC 404
+            # 'Invalid JSON response: <html>\r\n<head><title>404 Not Found<...<snip>...n'
+            if action_module.ndfc_version < 12.4 and error_code == 404 and \
+               error_msg.startswith("Invalid JSON response: <html>"):
+                return 'A federation manager does not exist'
+
 
         # Validate API response structure and extract data
         response_data = action_module.error_handler.validate_api_response(


### PR DESCRIPTION
## Summary

This PR enhances the `obtain_federated_fabric_associations()` function to properly handle federation manager lookup failures across multiple ND/NDFC versions, with specific focus on enabling API lookups on secondary cluster configurations.

## Problem Statement

The federation manager API lookup was failing in several scenarios:
- **Secondary cluster environments**: API calls on secondary clusters were not being gracefully handled
- **ND 3.1 version compatibility**: Cryptic HTML error responses (404) were not recognized
- **Error handling inconsistency**: Generic exceptions prevented proper error diagnosis
- **Hardcoded error strings**: Limited flexibility for handling new error patterns

## Changes Made

### 1. Introduced Global Error Constants (+4 lines)
- Added `FEDERATION_MANAGER_NOT_FOUND_ERRORS` constant at module level (lines 37-41)
- Centralized error message patterns for maintainability
- Added new error pattern: `'Invalid JSON response: cannot serve APIs as federation state is secondary. Use primary cluster for APIs'`

### 2. Enhanced Error Response Parsing (+9 lines)
- Extract both `DATA` and `RETURN_CODE` from error responses (lines 1418-1420)
- Improved error message extraction logic for consistency across ND versions
- Better separation of concerns for error handling

### 3. Improved Error Type Handling (+8 lines)
- Replaced generic `Exception` with structured error handling (lines 1428-1436)
- Added detailed error context including:
  - Error message type
  - Error message value
  - Full response object
- Leverages `error_handler.handle_failure()` for consistent error reporting

### 4. Added ND 3.1 Compatibility Fix (+6 lines)
- Special handling for ND 3.1's cryptic HTML 404 responses (lines 1442-1446)
- Detects HTML error responses that start with `"Invalid JSON response: <html>"`
- Version-aware check (`ndfc_version < 12.4`) to avoid false positives
- Returns standardized error message for consistency

### Testing Considerations
- Verify secondary cluster API behavior
- Test ND 3.1 federation manager detection
- Validate ND 3.2 and ND 4.x error handling
- Ensure backward compatibility with existing deployments

**Tests above are passing**

## Breaking Changes

None - all changes are backward compatible.

## Related Issues

Addresses federation manager lookup failures in multi-cluster and legacy ND environments.