### PR TITLE
check vPC pair order and map the expected order dynamically

### DIFF
--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -3106,25 +3106,72 @@ class DcnmIntf:
         )
         intf["interfaces"][0].update({"ifName": ifname})
 
+        # Dynamic Peer Mapping: Determine the actual ND PEER1/PEER2 assignment
+        # based on the vpc_pair_sn order, regardless of playbook switch order
+        peer1_members = delem[profile]["peer1_members"]
+        peer2_members = delem[profile]["peer2_members"]
+        peer1_allowed_vlans = delem[profile].get("peer1_allowed_vlans")
+        peer2_allowed_vlans = delem[profile].get("peer2_allowed_vlans")
+        peer1_native_vlan = delem[profile].get("peer1_native_vlan")
+        peer2_native_vlan = delem[profile].get("peer2_native_vlan")
+        peer1_access_vlan = delem[profile].get("peer1_access_vlan")
+        peer2_access_vlan = delem[profile].get("peer2_access_vlan")
+        peer1_pcid = delem[profile]["peer1_pcid"]
+        peer2_pcid = delem[profile]["peer2_pcid"]
+        peer1_description = delem[profile]["peer1_description"]
+        peer2_description = delem[profile]["peer2_description"]
+        peer1_cmds = delem[profile]["peer1_cmds"]
+        peer2_cmds = delem[profile]["peer2_cmds"]
+
+        # Get the vPC pair serial number from ND (format: SERIAL1~SERIAL2)
+        vpc_pair_sn = self.vpc_ip_sn.get(delem["switch"][0], "")
+
+        if "~" in vpc_pair_sn:
+            vpc_sn_parts = vpc_pair_sn.split("~")
+            switch_0_sn = self.ip_sn.get(delem["switch"][0], "")
+            switch_1_sn = self.ip_sn.get(delem["switch"][1], "")
+
+            # Check if playbook switch order matches ND vPC pair order
+            if switch_0_sn == vpc_sn_parts[0] and switch_1_sn == vpc_sn_parts[1]:
+                # Playbook order matches ND order - no swap needed
+                pass
+            elif switch_0_sn == vpc_sn_parts[1] and switch_1_sn == vpc_sn_parts[0]:
+                # Playbook order is reversed from ND order - swap all peer parameters
+                peer1_members, peer2_members = peer2_members, peer1_members
+                peer1_allowed_vlans, peer2_allowed_vlans = peer2_allowed_vlans, peer1_allowed_vlans
+                peer1_native_vlan, peer2_native_vlan = peer2_native_vlan, peer1_native_vlan
+                peer1_access_vlan, peer2_access_vlan = peer2_access_vlan, peer1_access_vlan
+                peer1_pcid, peer2_pcid = peer2_pcid, peer1_pcid
+                peer1_description, peer2_description = peer2_description, peer1_description
+                peer1_cmds, peer2_cmds = peer2_cmds, peer1_cmds
+            else:
+                # Serial numbers don't match vPC pair - this is an error condition
+                self.module.fail_json(
+                    msg=f"vPC {ifname} configuration error: Switch serial numbers "
+                        f"[{switch_0_sn}, {switch_1_sn}] do not match ND vPC pair "
+                        f"[{vpc_sn_parts[0]}, {vpc_sn_parts[1]}]. Verify that the "
+                        f"switches specified in the playbook are part of the same vPC pair."
+                )
+
         if delem[profile]["mode"] == "trunk":
 
-            if delem[profile]["peer1_members"] is None:
+            if peer1_members is None:
                 intf["interfaces"][0]["nvPairs"][
                     "PEER1_MEMBER_INTERFACES"
                 ] = ""
             else:
                 intf["interfaces"][0]["nvPairs"][
                     "PEER1_MEMBER_INTERFACES"
-                ] = ",".join(delem[profile]["peer1_members"])
+                ] = ",".join(peer1_members)
 
-            if delem[profile]["peer2_members"] is None:
+            if peer2_members is None:
                 intf["interfaces"][0]["nvPairs"][
                     "PEER2_MEMBER_INTERFACES"
                 ] = ""
             else:
                 intf["interfaces"][0]["nvPairs"][
                     "PEER2_MEMBER_INTERFACES"
-                ] = ",".join(delem[profile]["peer2_members"])
+                ] = ",".join(peer2_members)
 
             intf["interfaces"][0]["nvPairs"]["PC_MODE"] = delem[profile][
                 "pc_mode"
@@ -3138,51 +3185,39 @@ class DcnmIntf:
             intf["interfaces"][0]["nvPairs"]["MTU"] = str(
                 delem[profile]["mtu"]
             )
-            intf["interfaces"][0]["nvPairs"]["PEER1_ALLOWED_VLANS"] = delem[
-                profile
-            ]["peer1_allowed_vlans"]
-            intf["interfaces"][0]["nvPairs"]["PEER2_ALLOWED_VLANS"] = delem[
-                profile
-            ]["peer2_allowed_vlans"]
-            intf["interfaces"][0]["nvPairs"]["PEER1_NATIVE_VLAN"] = delem[
-                profile
-            ]["peer1_native_vlan"]
-            intf["interfaces"][0]["nvPairs"]["PEER2_NATIVE_VLAN"] = delem[
-                profile
-            ]["peer2_native_vlan"]
-            if delem[profile]["peer1_pcid"] == 0:
+            intf["interfaces"][0]["nvPairs"]["PEER1_ALLOWED_VLANS"] = peer1_allowed_vlans
+            intf["interfaces"][0]["nvPairs"]["PEER2_ALLOWED_VLANS"] = peer2_allowed_vlans
+            intf["interfaces"][0]["nvPairs"]["PEER1_NATIVE_VLAN"] = peer1_native_vlan
+            intf["interfaces"][0]["nvPairs"]["PEER2_NATIVE_VLAN"] = peer2_native_vlan
+            if peer1_pcid == 0:
                 intf["interfaces"][0]["nvPairs"]["PEER1_PCID"] = str(port_id)
             else:
-                intf["interfaces"][0]["nvPairs"]["PEER1_PCID"] = str(
-                    delem[profile]["peer1_pcid"]
-                )
+                intf["interfaces"][0]["nvPairs"]["PEER1_PCID"] = str(peer1_pcid)
 
-            if delem[profile]["peer2_pcid"] == 0:
+            if peer2_pcid == 0:
                 intf["interfaces"][0]["nvPairs"]["PEER2_PCID"] = str(port_id)
             else:
-                intf["interfaces"][0]["nvPairs"]["PEER2_PCID"] = str(
-                    delem[profile]["peer2_pcid"]
-                )
+                intf["interfaces"][0]["nvPairs"]["PEER2_PCID"] = str(peer2_pcid)
 
         if delem[profile]["mode"] == "access":
 
-            if delem[profile]["peer1_members"] is None:
+            if peer1_members is None:
                 intf["interfaces"][0]["nvPairs"][
                     "PEER1_MEMBER_INTERFACES"
                 ] = ""
             else:
                 intf["interfaces"][0]["nvPairs"][
                     "PEER1_MEMBER_INTERFACES"
-                ] = ",".join(delem[profile]["peer1_members"])
+                ] = ",".join(peer1_members)
 
-            if delem[profile]["peer2_members"] is None:
+            if peer2_members is None:
                 intf["interfaces"][0]["nvPairs"][
                     "PEER2_MEMBER_INTERFACES"
                 ] = ""
             else:
                 intf["interfaces"][0]["nvPairs"][
                     "PEER2_MEMBER_INTERFACES"
-                ] = ",".join(delem[profile]["peer2_members"])
+                ] = ",".join(peer2_members)
 
             intf["interfaces"][0]["nvPairs"]["PC_MODE"] = delem[profile][
                 "pc_mode"
@@ -3196,45 +3231,29 @@ class DcnmIntf:
             intf["interfaces"][0]["nvPairs"]["MTU"] = str(
                 delem[profile]["mtu"]
             )
-            intf["interfaces"][0]["nvPairs"]["PEER1_ACCESS_VLAN"] = delem[
-                profile
-            ]["peer1_access_vlan"]
-            intf["interfaces"][0]["nvPairs"]["PEER2_ACCESS_VLAN"] = delem[
-                profile
-            ]["peer2_access_vlan"]
+            intf["interfaces"][0]["nvPairs"]["PEER1_ACCESS_VLAN"] = peer1_access_vlan
+            intf["interfaces"][0]["nvPairs"]["PEER2_ACCESS_VLAN"] = peer2_access_vlan
 
-            if delem[profile]["peer1_pcid"] == 0:
+            if peer1_pcid == 0:
                 intf["interfaces"][0]["nvPairs"]["PEER1_PCID"] = str(port_id)
             else:
-                intf["interfaces"][0]["nvPairs"]["PEER1_PCID"] = str(
-                    delem[profile]["peer1_pcid"]
-                )
+                intf["interfaces"][0]["nvPairs"]["PEER1_PCID"] = str(peer1_pcid)
 
-            if delem[profile]["peer2_pcid"] == 0:
+            if peer2_pcid == 0:
                 intf["interfaces"][0]["nvPairs"]["PEER2_PCID"] = str(port_id)
             else:
-                intf["interfaces"][0]["nvPairs"]["PEER2_PCID"] = str(
-                    delem[profile]["peer2_pcid"]
-                )
+                intf["interfaces"][0]["nvPairs"]["PEER2_PCID"] = str(peer2_pcid)
 
-        intf["interfaces"][0]["nvPairs"]["PEER1_PO_DESC"] = delem[profile][
-            "peer1_description"
-        ]
-        intf["interfaces"][0]["nvPairs"]["PEER2_PO_DESC"] = delem[profile][
-            "peer2_description"
-        ]
-        if delem[profile]["peer1_cmds"] is None:
+        intf["interfaces"][0]["nvPairs"]["PEER1_PO_DESC"] = peer1_description
+        intf["interfaces"][0]["nvPairs"]["PEER2_PO_DESC"] = peer2_description
+        if peer1_cmds is None:
             intf["interfaces"][0]["nvPairs"]["PEER1_PO_CONF"] = ""
         else:
-            intf["interfaces"][0]["nvPairs"]["PEER1_PO_CONF"] = "\n".join(
-                delem[profile]["peer1_cmds"]
-            )
-        if delem[profile]["peer2_cmds"] is None:
+            intf["interfaces"][0]["nvPairs"]["PEER1_PO_CONF"] = "\n".join(peer1_cmds)
+        if peer2_cmds is None:
             intf["interfaces"][0]["nvPairs"]["PEER2_PO_CONF"] = ""
         else:
-            intf["interfaces"][0]["nvPairs"]["PEER2_PO_CONF"] = "\n".join(
-                delem[profile]["peer2_cmds"]
-            )
+            intf["interfaces"][0]["nvPairs"]["PEER2_PO_CONF"] = "\n".join(peer2_cmds)
         intf["interfaces"][0]["nvPairs"]["ADMIN_STATE"] = str(
             delem[profile]["admin_state"]
         ).lower()

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -3129,29 +3129,41 @@ class DcnmIntf:
         if "~" in vpc_pair_sn:
             vpc_sn_parts = vpc_pair_sn.split("~")
             switch_0_sn = self.ip_sn.get(delem["switch"][0], "")
-            switch_1_sn = self.ip_sn.get(delem["switch"][1], "")
 
-            # Check if playbook switch order matches ND vPC pair order
-            if switch_0_sn == vpc_sn_parts[0] and switch_1_sn == vpc_sn_parts[1]:
-                # Playbook order matches ND order - no swap needed
-                pass
-            elif switch_0_sn == vpc_sn_parts[1] and switch_1_sn == vpc_sn_parts[0]:
-                # Playbook order is reversed from ND order - swap all peer parameters
-                peer1_members, peer2_members = peer2_members, peer1_members
-                peer1_allowed_vlans, peer2_allowed_vlans = peer2_allowed_vlans, peer1_allowed_vlans
-                peer1_native_vlan, peer2_native_vlan = peer2_native_vlan, peer1_native_vlan
-                peer1_access_vlan, peer2_access_vlan = peer2_access_vlan, peer1_access_vlan
-                peer1_pcid, peer2_pcid = peer2_pcid, peer1_pcid
-                peer1_description, peer2_description = peer2_description, peer1_description
-                peer1_cmds, peer2_cmds = peer2_cmds, peer1_cmds
+            if len(delem["switch"]) < 2:
+                # Single switch in playbook - swap if it maps to ND's PEER2
+                if switch_0_sn == vpc_sn_parts[1]:
+                    peer1_members, peer2_members = peer2_members, peer1_members
+                    peer1_allowed_vlans, peer2_allowed_vlans = peer2_allowed_vlans, peer1_allowed_vlans
+                    peer1_native_vlan, peer2_native_vlan = peer2_native_vlan, peer1_native_vlan
+                    peer1_access_vlan, peer2_access_vlan = peer2_access_vlan, peer1_access_vlan
+                    peer1_pcid, peer2_pcid = peer2_pcid, peer1_pcid
+                    peer1_description, peer2_description = peer2_description, peer1_description
+                    peer1_cmds, peer2_cmds = peer2_cmds, peer1_cmds
             else:
-                # Serial numbers don't match vPC pair - this is an error condition
-                self.module.fail_json(
-                    msg=f"vPC {ifname} configuration error: Switch serial numbers "
-                        f"[{switch_0_sn}, {switch_1_sn}] do not match ND vPC pair "
-                        f"[{vpc_sn_parts[0]}, {vpc_sn_parts[1]}]. Verify that the "
-                        f"switches specified in the playbook are part of the same vPC pair."
-                )
+                switch_1_sn = self.ip_sn.get(delem["switch"][1], "")
+
+                # Check if playbook switch order matches ND vPC pair order
+                if switch_0_sn == vpc_sn_parts[0] and switch_1_sn == vpc_sn_parts[1]:
+                    # Playbook order matches ND order - no swap needed
+                    pass
+                elif switch_0_sn == vpc_sn_parts[1] and switch_1_sn == vpc_sn_parts[0]:
+                    # Playbook order is reversed from ND order - swap all peer parameters
+                    peer1_members, peer2_members = peer2_members, peer1_members
+                    peer1_allowed_vlans, peer2_allowed_vlans = peer2_allowed_vlans, peer1_allowed_vlans
+                    peer1_native_vlan, peer2_native_vlan = peer2_native_vlan, peer1_native_vlan
+                    peer1_access_vlan, peer2_access_vlan = peer2_access_vlan, peer1_access_vlan
+                    peer1_pcid, peer2_pcid = peer2_pcid, peer1_pcid
+                    peer1_description, peer2_description = peer2_description, peer1_description
+                    peer1_cmds, peer2_cmds = peer2_cmds, peer1_cmds
+                else:
+                    # Serial numbers don't match vPC pair - this is an error condition
+                    self.module.fail_json(
+                        msg=f"vPC {ifname} configuration error: Switch serial numbers "
+                            f"[{switch_0_sn}, {switch_1_sn}] do not match ND vPC pair "
+                            f"[{vpc_sn_parts[0]}, {vpc_sn_parts[1]}]. Verify that the "
+                            f"switches specified in the playbook are part of the same vPC pair."
+                    )
 
         if delem[profile]["mode"] == "trunk":
 


### PR DESCRIPTION
When you reverse the order of switches in the playbook configuration and then update interface descriptions (or other properties), the interfaces end up being configured on the opposite vPC member than intended.

The vpc_pair_sn format returned by NDFC is FIXED and ORDERED based on how the vPC pair is configured in NDFC (typically ordered by vPC domain priority, role, or alphabetically by serial number). The format is always PEER1_SERIAL~PEER2_SERIAL.

**Example Scenario:**
**From the test results above:**

* peerOneId: "94WN5222IZ3" (leaf1 @ 10.229.42.121)
* peerTwoId: "9WOLPXTSUHB" (leaf2 @ 10.229.42.122)
* serialNumber: "94WN5222IZ3~9WOLPXTSUHB" (NDFC fixed order)

**Initial Configuration:**

```
switch: ['10.229.42.122', '10.229.42.121']  # leaf2, leaf1
# vpc_pair_sn returned by NDFC: "94WN5222IZ3~9WOLPXTSUHB"
# NDFC mapping: PEER1 = 94WN5222IZ3 (leaf1), PEER2 = 9WOLPXTSUHB (leaf2)
peer1_members: ['Ethernet1/12']  # User expects this on leaf2 (switch[0])
peer2_members: ['Ethernet1/11']  # User expects this on leaf1 (switch[1])

# BUT ACTUALLY:
# PEER1_MEMBER_INTERFACES: Ethernet1/12 → Goes to 94WN5222IZ3 (leaf1) ❌
# PEER2_MEMBER_INTERFACES: Ethernet1/11 → Goes to 9WOLPXTSUHB (leaf2) ❌
```

**When You Reverse the Order:**

```
switch: ['10.229.42.121', '10.229.42.122']  # leaf1, leaf2 (reversed)
# vpc_pair_sn returned by NDFC: STILL "94WN5222IZ3~9WOLPXTSUHB" (NDFC determines this!)
peer1_members: ['Ethernet1/11']  # User expects this on leaf1 (switch[0])
peer2_members: ['Ethernet1/12']  # User expects this on leaf2 (switch[1])

# BUT ACTUALLY:
# PEER1_MEMBER_INTERFACES: Ethernet1/11 → Still goes to 94WN5222IZ3 (leaf1) ❌
# PEER2_MEMBER_INTERFACES: Ethernet1/12 → Still goes to 9WOLPXTSUHB (leaf2) ❌
```

The module does NOT verify which switch in your switch: [] list corresponds to PEER1 vs PEER2 according to NDFC's vpc_pair_sn ordering.

Result: When you change the switch order in your playbook, you're essentially swapping which interfaces you think are peer1_members vs peer2_members, but NDFC's PEER1/PEER2 assignment remains fixed to the serial number order.

**Solution:**

Implement Dynamic Peer Mapping. In function, ``dcnm_intf_get_vpc_payload`` we detect members an assign values based on SN. 

**Playbook**

To reproduce issue, create vPC, then update vPC by changing the order. Finally configure vPC interface asymmetric or with description to see the issue.

```
---
- name: test inventory
  hosts: nac-ndfc1
  gather_facts: false

  tasks:
    - name: Query VPC switch pairs
      cisco.dcnm.dcnm_vpc_pair:
        src_fabric: "nac-ndfc1"
        state: query
        config:
          - peerOneId: 10.229.42.122
            peerTwoId: 10.229.42.121

    - name: Query VPC switch pairs - opposite order
      cisco.dcnm.dcnm_vpc_pair:
        src_fabric: "nac-ndfc1"
        state: query
        config:
          - peerOneId: 10.229.42.121 # 94WN5222IZ3 leaf1
            peerTwoId: 10.229.42.122 # 9WOLPXTSUHB leaf2

    - name: debug vpc11 Interface
      cisco.dcnm.dcnm_interface:
        fabric: "nac-ndfc1"
        state: query
        config:
          - switch:
             - 10.229.42.122 #leaf2 (1/12)
             - 10.229.42.121 #leaf1 (1/11)
            name: vpc11


    - name: update vpc11
      cisco.dcnm.dcnm_interface:
        fabric: "nac-ndfc1"
        state: replaced
        config:
          - name: vpc11
            type: vpc
            switch:
              - 10.229.42.122
              - 10.229.42.121
            deploy: false
            profile:
              admin_state: True
              mode: access
              peer1_pcid: 11
              peer2_pcid: 11
              port_type_fast: True
              mtu: jumbo
              speed: auto
              pc_mode: active
              peer1_members: ["ethernet1/12"]
              peer2_members: ["ethernet1/11"]
              peer1_cmds: |2-
                
              peer2_cmds: |2-
                
              peer1_description: "vPC to Server11"
              peer2_description: "vPC to Server11"
              bpdu_guard: True
              disable_lacp_suspend_individual: False
              enable_lacp_vpc_convergence: False
              lacp_port_priority: 32768
              lacp_rate: normal
              peer1_access_vlan: 1
              peer2_access_vlan: 1

    - name: debug vpc11 Interface
      cisco.dcnm.dcnm_interface:
        fabric: "nac-ndfc1"
        state: query
        config:
          - switch:
             - 10.229.42.122 #leaf2 (1/12)
             - 10.229.42.121 #leaf1 (1/11)
            name: vpc11
```

```shell
PLAY [test inventory] ***********************************************************************************************************************************************************************************************

TASK [Query VPC switch pairs] ***************************************************************************************************************************************************************************************
Monday 02 February 2026  10:15:37 +0100 (0:00:00.049)       0:00:00.049 ******* 
Monday 02 February 2026  10:15:37 +0100 (0:00:00.048)       0:00:00.048 ******* 
ok: [nac-ndfc1] => {"changed": false, "response": [{"nvPairs": {}, "peerOneDbId": 202060, "peerOneId": "94WN5222IZ3", "peerTwoDbId": 204090, "peerTwoId": "9WOLPXTSUHB", "templateName": "", "useVirtualPeerlink": false}]}

TASK [Query VPC switch pairs - opposite order] **********************************************************************************************************************************************************************
Monday 02 February 2026  10:15:42 +0100 (0:00:05.042)       0:00:05.091 ******* 
Monday 02 February 2026  10:15:42 +0100 (0:00:05.042)       0:00:05.091 ******* 
ok: [nac-ndfc1] => {"changed": false, "response": [{"nvPairs": {}, "peerOneDbId": 202060, "peerOneId": "94WN5222IZ3", "peerTwoDbId": 204090, "peerTwoId": "9WOLPXTSUHB", "templateName": "", "useVirtualPeerlink": false}]}

TASK [debug vpc11 Interface] ****************************************************************************************************************************************************************************************
Monday 02 February 2026  10:15:47 +0100 (0:00:04.524)       0:00:09.615 ******* 
Monday 02 February 2026  10:15:47 +0100 (0:00:04.524)       0:00:09.615 ******* 
ok: [nac-ndfc1] => {"changed": false, "response": [{"interfaces": [{"ifName": "vpc11", "nvPairs": {"ADMIN_STATE": "true", "BANDWIDTH": "", "BPDUFILTER_ENABLED": "no", "BPDUGUARD_ENABLED": "true", "CDP_ENABLE": "true", "COPY_DESC": "false", "DISABLE_LACP_SUSPEND": "false", "ENABLE_LACP_VPC_CONV": "false", "ENABLE_MIRROR_CONFIG": "false", "ENABLE_NETFLOW": "false", "ENABLE_PFC": "false", "ENABLE_QOS": "false", "ENABLE_STORM_CONTROL": "false", "FABRIC_NAME": "nac-ndfc1", "INHERIT_BW": "", "INTF_NAME": "vPC11", "LACP_PORT_PRIO": "32768", "LACP_RATE": "normal", "LINK_TYPE": "auto", "MTU": "jumbo", "NEGOTIATE_AUTO": "true", "NETFLOW_MONITOR": "", "NETFLOW_SAMPLER": "", "PC_MODE": "active", "PEER1_ACCESS_VLAN": "1", "PEER1_MEMBER_INTERFACES": "ethernet1/12", "PEER1_PCID": "11", "PEER1_PO_CONF": "", "PEER1_PO_DESC": "vPC to Server11", "PEER2_ACCESS_VLAN": "1", "PEER2_MEMBER_INTERFACES": "ethernet1/11", "PEER2_PCID": "11", "PEER2_PO_CONF": "", "PEER2_PO_DESC": "vPC to Server11", "POLICY_DESC": "", "POLICY_ID": "POLICY-252450", "PORTTYPE_FAST_ENABLED": "true", "PORT_DUPLEX_MODE": "auto", "PRIORITY": "500", "PTP": "false", "QOS_POLICY": "", "QUEUING_POLICY": "", "SERIAL_NUMBER": "", "SPEED": "Auto", "STORM_CONTROL_ACTION": "no", "STORM_CONTROL_BCAST_LEVEL_PERCENT": "", "STORM_CONTROL_BCAST_LEVEL_PPS": "", "STORM_CONTROL_MCAST_LEVEL_PERCENT": "", "STORM_CONTROL_MCAST_LEVEL_PPS": "", "STORM_CONTROL_UCAST_LEVEL_PERCENT": "", "STORM_CONTROL_UCAST_LEVEL_PPS": "", "createVpc": "true"}, "serialNumber": "94WN5222IZ3~9WOLPXTSUHB"}], "policy": "int_vpc_access_host"}]}

TASK [update vpc11] *************************************************************************************************************************************************************************************************
Monday 02 February 2026  10:15:50 +0100 (0:00:02.947)       0:00:12.563 ******* 
Monday 02 February 2026  10:15:50 +0100 (0:00:02.947)       0:00:12.563 ******* 
changed: [nac-ndfc1] => {"changed": true, "response": [{"DATA": {}, "MESSAGE": "OK", "METHOD": "PUT", "REQUEST_PATH": "https://x.x.x.x:443/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/interface", "RETURN_CODE": 200}]}

TASK [debug vpc11 Interface] ****************************************************************************************************************************************************************************************
Monday 02 February 2026  10:15:58 +0100 (0:00:08.627)       0:00:21.190 ******* 
Monday 02 February 2026  10:15:58 +0100 (0:00:08.627)       0:00:21.190 ******* 
ok: [nac-ndfc1] => {"changed": false, "response": [{"interfaces": [{"ifName": "vpc11", "nvPairs": {"ADMIN_STATE": "true", "BANDWIDTH": "", "BPDUFILTER_ENABLED": "no", "BPDUGUARD_ENABLED": "true", "CDP_ENABLE": "true", "COPY_DESC": "false", "DISABLE_LACP_SUSPEND": "false", "ENABLE_LACP_VPC_CONV": "false", "ENABLE_MIRROR_CONFIG": "false", "ENABLE_NETFLOW": "false", "ENABLE_PFC": "false", "ENABLE_QOS": "false", "ENABLE_STORM_CONTROL": "false", "FABRIC_NAME": "nac-ndfc1", "INHERIT_BW": "", "INTF_NAME": "vPC11", "LACP_PORT_PRIO": "32768", "LACP_RATE": "normal", "LINK_TYPE": "auto", "MARK_DELETED": "false", "MTU": "jumbo", "NEGOTIATE_AUTO": "true", "NETFLOW_MONITOR": "", "NETFLOW_SAMPLER": "", "PC_MODE": "active", "PEER1_ACCESS_VLAN": "1", "PEER1_MEMBER_INTERFACES": "ethernet1/11", "PEER1_PCID": "11", "PEER1_PO_CONF": "", "PEER1_PO_DESC": "vPC to Server11", "PEER2_ACCESS_VLAN": "1", "PEER2_MEMBER_INTERFACES": "ethernet1/12", "PEER2_PCID": "11", "PEER2_PO_CONF": "", "PEER2_PO_DESC": "vPC to Server11", "POLICY_DESC": "", "POLICY_ID": "POLICY-252450", "PORTTYPE_FAST_ENABLED": "true", "PORT_DUPLEX_MODE": "auto", "PRIORITY": "500", "PTP": "false", "QOS_POLICY": "", "QUEUING_POLICY": "", "SPEED": "Auto", "STORM_CONTROL_ACTION": "no", "STORM_CONTROL_BCAST_LEVEL_PERCENT": "", "STORM_CONTROL_BCAST_LEVEL_PPS": "", "STORM_CONTROL_MCAST_LEVEL_PERCENT": "", "STORM_CONTROL_MCAST_LEVEL_PPS": "", "STORM_CONTROL_UCAST_LEVEL_PERCENT": "", "STORM_CONTROL_UCAST_LEVEL_PPS": "", "createVpc": "false"}, "serialNumber": "94WN5222IZ3~9WOLPXTSUHB"}], "policy": "int_vpc_access_host"}]}

PLAY RECAP **********************************************************************************************************************************************************************************************************
nac-ndfc1                  : ok=5    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   


PLAYBOOK RECAP ******************************************************************************************************************************************************************************************************
Playbook run took 0 days, 0 hours, 0 minutes, 24 seconds


TASKS RECAP *********************************************************************************************************************************************************************************************************
Monday 02 February 2026  10:16:02 +0100 (0:00:03.481)       0:00:24.672 ******* 
=============================================================================== 
Query VPC switch pairs --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 5.04s
Query VPC switch pairs - opposite order ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- 4.52s
debug vpc11 Interface ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 2.95s
update vpc11 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 8.63s
debug vpc11 Interface ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 3.48s

ROLES RECAP *********************************************************************************************************************************************************************************************************
Monday 02 February 2026  10:16:02 +0100 (0:00:03.481)       0:00:24.671 ******* 
=============================================================================== 
cisco.dcnm.dcnm_interface ---------------------------------------------- 15.06s
cisco.dcnm.dcnm_vpc_pair ------------------------------------------------ 9.57s
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
total ------------------------------------------------------------------ 24.62s
```