### PR TITLE
Adding duplex to dot1q

### DIFF
--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -2661,6 +2661,8 @@ class DcnmIntf:
             cmds=dict(type="list", elements="str"),
             description=dict(type="str", default=""),
             admin_state=dict(type="bool", default=True),
+            duplex=dict(
+                type="str", default="auto", choices=["auto", "full", "half"]),
         )
 
         if "trunk" == cfg[0]["profile"]["mode"]:
@@ -3513,6 +3515,8 @@ class DcnmIntf:
                 "access_vlan"
             ]
             intf["interfaces"][0]["nvPairs"]["INTF_NAME"] = ifname
+            intf["interfaces"][0]["nvPairs"][
+                "PORT_DUPLEX_MODE"] = delem[profile]["duplex"]
 
     def dcnm_intf_get_st_fex_payload(self, delem, intf, profile):
 


### PR DESCRIPTION
Fixes #634 to add support for duplex definition on dot1q ports