### PR TITLE
Add extra NDFC message response when trying to access onemanage endpoints on a standalone NDFC

### DIFF
--- a/plugins/module_utils/network/dcnm/dcnm.py
+++ b/plugins/module_utils/network/dcnm/dcnm.py
@@ -37,7 +37,8 @@ except ImportError:
 FEDERATION_MANAGER_NOT_FOUND_ERRORS = [
     'Invalid JSON response: this API is allowed only for remote user',
     'A federation manager does not exist',
-    'Invalid JSON response: cannot serve APIs as federation state is secondary. Use primary cluster for APIs'
+    'Invalid JSON response: cannot serve APIs as federation state is secondary. Use primary cluster for APIs',
+    'Invalid JSON response: cannot serve APIs as federation state is not established yet'
 ]
 
 dcnm_paths = {


### PR DESCRIPTION
Just as above, hit this error message when trying to configure a standalone fabric, on a standalone NDFC and attempting to deploy a VRF on ND version 3.2(2m)