### PR TITLE
add qos to interfaces: eth, trunk, po trunk, access, po access

### DIFF
--- a/docs/cisco.dcnm.dcnm_interface_module.rst
+++ b/docs/cisco.dcnm.dcnm_interface_module.rst
@@ -630,6 +630,27 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>enable_qos</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                    <li>yes</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Enable QoS on the interface. This option is applicable only for interfaces whose &#x27;mode&#x27; is &#x27;trunk&#x27;, &#x27;access&#x27;, or &#x27;routed&#x27;</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>int_vrf</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -821,6 +842,42 @@ Parameters
                 </td>
                 <td>
                         <div>Spanning-tree edge port behavior</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>qos_policy</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">""</div>
+                </td>
+                <td>
+                        <div>QoS policy name to apply to the interface. This option is only valid when &#x27;enable_qos&#x27; is true. This option is applicable only for interfaces whose &#x27;mode&#x27; is &#x27;trunk&#x27;, &#x27;access&#x27;, or &#x27;routed&#x27;</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>queuing_policy</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">""</div>
+                </td>
+                <td>
+                        <div>Queuing policy name to apply to the interface. This option is applicable only for interfaces whose &#x27;mode&#x27; is &#x27;trunk&#x27;, &#x27;access&#x27;, or &#x27;routed&#x27;</div>
                 </td>
             </tr>
             <tr>
@@ -1257,6 +1314,27 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>enable_qos</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                    <li>yes</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Enable QoS on the interface. This option is applicable only for interfaces whose &#x27;mode&#x27; is &#x27;trunk&#x27;, &#x27;access&#x27;, or &#x27;l3&#x27;</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>int_vrf</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -1427,6 +1505,42 @@ Parameters
                 </td>
                 <td>
                         <div>interface orphan port behavior when switch is in vPC</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>qos_policy</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">""</div>
+                </td>
+                <td>
+                        <div>QoS policy name to apply to the interface. This option is only valid when &#x27;enable_qos&#x27; is true. This option is applicable only for interfaces whose &#x27;mode&#x27; is &#x27;trunk&#x27;, &#x27;access&#x27;, or &#x27;l3&#x27;</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>queuing_policy</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">""</div>
+                </td>
+                <td>
+                        <div>Queuing policy name to apply to the interface. This option is applicable only for interfaces whose &#x27;mode&#x27; is &#x27;trunk&#x27;, &#x27;access&#x27;, or &#x27;l3&#x27;</div>
                 </td>
             </tr>
             <tr>
@@ -2506,6 +2620,27 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>enable_qos</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                    <li>yes</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Enable QoS on the interface. This option is applicable only for interfaces whose &#x27;mode&#x27; is &#x27;trunk&#x27; or &#x27;access&#x27;</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>lacp_port_priority</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -2890,6 +3025,42 @@ Parameters
                 </td>
                 <td>
                         <div>Spanning-tree edge port behavior</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>qos_policy</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">""</div>
+                </td>
+                <td>
+                        <div>QoS policy name to apply to the interface. This option is only valid when &#x27;enable_qos&#x27; is true. This option is applicable only for interfaces whose &#x27;mode&#x27; is &#x27;trunk&#x27; or &#x27;access&#x27;</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>queuing_policy</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">""</div>
+                </td>
+                <td>
+                        <div>Queuing policy name to apply to the interface. This option is applicable only for interfaces whose &#x27;mode&#x27; is &#x27;trunk&#x27; or &#x27;access&#x27;</div>
                 </td>
             </tr>
 

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -4559,7 +4559,10 @@ class DcnmIntf:
                                         "ENABLE_PFC",
                                         "NATIVE_VLAN",
                                         "PORT_DUPLEX_MODE",
-                                        "SPEED"
+                                        "SPEED",
+                                        "ENABLE_QOS",
+                                        "QOS_POLICY",
+                                        "QUEUING_POLICY"
                                     ]
 
                                     for key in keys_to_check:

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -216,6 +216,24 @@ options:
             type: str
             choices: ['normal', 'fast']
             default: normal
+          enable_qos:
+            description:
+            - Enable QoS on the interface.
+              This option is applicable only for interfaces whose 'mode' is 'trunk' or 'access'
+            type: bool
+            default: false
+          qos_policy:
+            description:
+            - QoS policy name to apply to the interface. This option is only valid when 'enable_qos' is true.
+              This option is applicable only for interfaces whose 'mode' is 'trunk' or 'access'
+            type: str
+            default: ""
+          queuing_policy:
+            description:
+            - Queuing policy name to apply to the interface.
+              This option is applicable only for interfaces whose 'mode' is 'trunk' or 'access'
+            type: str
+            default: ""
       profile_vpc:
         description:
         - Though the key shown here is 'profile_vpc' the actual key to be used in playbook
@@ -368,6 +386,24 @@ options:
             type: str
             choices: ['normal', 'fast']
             default: normal
+          enable_qos:
+            description:
+            - Enable QoS on the interface.
+              This option is applicable only for interfaces whose 'mode' is 'trunk' or 'access'
+            type: bool
+            default: false
+          qos_policy:
+            description:
+            - QoS policy name to apply to the interface. This option is only valid when 'enable_qos' is true.
+              This option is applicable only for interfaces whose 'mode' is 'trunk' or 'access'
+            type: str
+            default: ""
+          queuing_policy:
+            description:
+            - Queuing policy name to apply to the interface.
+              This option is applicable only for interfaces whose 'mode' is 'trunk' or 'access'
+            type: str
+            default: ""
       profile_subint:
         description:
         - Though the key shown here is 'profile_subint' the actual key to be used in playbook
@@ -638,6 +674,24 @@ options:
             - State of Switchport Monitor for SPAN/ERSPAN
             type: bool
             default: false
+          enable_qos:
+            description:
+            - Enable QoS on the interface.
+              This option is applicable only for interfaces whose 'mode' is 'trunk', 'access', or 'routed'
+            type: bool
+            default: false
+          qos_policy:
+            description:
+            - QoS policy name to apply to the interface. This option is only valid when 'enable_qos' is true.
+              This option is applicable only for interfaces whose 'mode' is 'trunk', 'access', or 'routed'
+            type: str
+            default: ""
+          queuing_policy:
+            description:
+            - Queuing policy name to apply to the interface.
+              This option is applicable only for interfaces whose 'mode' is 'trunk', 'access', or 'routed'
+            type: str
+            default: ""
       profile_svi:
         description:
         - Though the key shown here is 'profile_svi' the actual key to be used in playbook
@@ -2002,6 +2056,9 @@ class DcnmIntf:
             "ENABLE_PFC": "enable_pfc",
             "ENABLE_MONITOR": "enable_monitor",
             "CDP_ENABLE": "enable_cdp",
+            "ENABLE_QOS": "enable_qos",
+            "QOS_POLICY": "qos_policy",
+            "QUEUING_POLICY": "queuing_policy",
 
         }
 
@@ -2367,6 +2424,9 @@ class DcnmIntf:
             disable_lacp_suspend_individual=dict(type="bool", default=False),
             lacp_port_priority=dict(type="int", default=32768, range_min=1, range_max=65535),
             lacp_rate=dict(type="str", default="normal"),
+            enable_qos=dict(type="bool", default=False),
+            qos_policy=dict(type="str", default=""),
+            queuing_policy=dict(type="str", default=""),
         )
 
         pc_prof_spec_access = dict(
@@ -2390,6 +2450,9 @@ class DcnmIntf:
             disable_lacp_suspend_individual=dict(type="bool", default=False),
             lacp_port_priority=dict(type="int", default=32768, range_min=1, range_max=65535),
             lacp_rate=dict(type="str", default="normal"),
+            enable_qos=dict(type="bool", default=False),
+            qos_policy=dict(type="str", default=""),
+            queuing_policy=dict(type="str", default=""),
         )
 
         pc_prof_spec_l3 = dict(
@@ -2478,6 +2541,9 @@ class DcnmIntf:
             enable_lacp_vpc_convergence=dict(type="bool", default=False),
             lacp_port_priority=dict(type="int", default=32768, range_min=1, range_max=65535),
             lacp_rate=dict(type="str", default="normal"),
+            enable_qos=dict(type="bool", default=False),
+            qos_policy=dict(type="str", default=""),
+            queuing_policy=dict(type="str", default=""),
         )
 
         vpc_prof_spec_access = dict(
@@ -2502,6 +2568,9 @@ class DcnmIntf:
             peer1_description=dict(type="str", default=""),
             peer2_description=dict(type="str", default=""),
             admin_state=dict(type="bool", default=True),
+            enable_qos=dict(type="bool", default=False),
+            qos_policy=dict(type="str", default=""),
+            queuing_policy=dict(type="str", default=""),
         )
 
         if "trunk" == cfg[0]["profile"]["mode"]:
@@ -2599,6 +2668,9 @@ class DcnmIntf:
             enable_pfc=dict(type="bool", default=False),
             duplex=dict(
                 type="str", default="auto", choices=["auto", "full", "half"]),
+            enable_qos=dict(type="bool", default=False),
+            qos_policy=dict(type="str", default=""),
+            queuing_policy=dict(type="str", default=""),
         )
 
         eth_prof_spec_access = dict(
@@ -2619,6 +2691,9 @@ class DcnmIntf:
             enable_pfc=dict(type="bool", default=False),
             duplex=dict(
                 type="str", default="auto", choices=["auto", "full", "half"]),
+            enable_qos=dict(type="bool", default=False),
+            qos_policy=dict(type="str", default=""),
+            queuing_policy=dict(type="str", default=""),
         )
 
         eth_prof_spec_routed_host = dict(
@@ -2631,6 +2706,9 @@ class DcnmIntf:
             cmds=dict(type="list", elements="str"),
             description=dict(type="str", default=""),
             admin_state=dict(type="bool", default=True),
+            enable_qos=dict(type="bool", default=False),
+            qos_policy=dict(type="str", default=""),
+            queuing_policy=dict(type="str", default=""),
         )
 
         eth_prof_spec_epl_routed_host = dict(
@@ -2978,6 +3056,19 @@ class DcnmIntf:
                 intf["interfaces"][0]["nvPairs"]["LACP_RATE"] = delem[profile]["lacp_rate"]
             else:
                 intf["interfaces"][0]["nvPairs"]["LACP_RATE"] = "normal"
+            if delem[profile].get("enable_qos"):
+                intf["interfaces"][0]["nvPairs"]["ENABLE_QOS"] = delem[profile]["enable_qos"]
+                if delem[profile].get("qos_policy"):
+                    intf["interfaces"][0]["nvPairs"]["QOS_POLICY"] = delem[profile]["qos_policy"]
+                else:
+                    intf["interfaces"][0]["nvPairs"]["QOS_POLICY"] = ""
+            else:
+                intf["interfaces"][0]["nvPairs"]["ENABLE_QOS"] = False
+                intf["interfaces"][0]["nvPairs"]["QOS_POLICY"] = ""
+            if delem[profile].get("queuing_policy"):
+                intf["interfaces"][0]["nvPairs"]["QUEUING_POLICY"] = delem[profile]["queuing_policy"]
+            else:
+                intf["interfaces"][0]["nvPairs"]["QUEUING_POLICY"] = ""
         if delem[profile]["mode"] == "access":
             if delem[profile]["members"] is None:
                 intf["interfaces"][0]["nvPairs"]["MEMBER_INTERFACES"] = ""
@@ -3023,6 +3114,19 @@ class DcnmIntf:
                 intf["interfaces"][0]["nvPairs"]["LACP_RATE"] = delem[profile]["lacp_rate"]
             else:
                 intf["interfaces"][0]["nvPairs"]["LACP_RATE"] = "normal"
+            if delem[profile].get("enable_qos"):
+                intf["interfaces"][0]["nvPairs"]["ENABLE_QOS"] = delem[profile]["enable_qos"]
+                if delem[profile].get("qos_policy"):
+                    intf["interfaces"][0]["nvPairs"]["QOS_POLICY"] = delem[profile]["qos_policy"]
+                else:
+                    intf["interfaces"][0]["nvPairs"]["QOS_POLICY"] = ""
+            else:
+                intf["interfaces"][0]["nvPairs"]["ENABLE_QOS"] = False
+                intf["interfaces"][0]["nvPairs"]["QOS_POLICY"] = ""
+            if delem[profile].get("queuing_policy"):
+                intf["interfaces"][0]["nvPairs"]["QUEUING_POLICY"] = delem[profile]["queuing_policy"]
+            else:
+                intf["interfaces"][0]["nvPairs"]["QUEUING_POLICY"] = ""
         if delem[profile]["mode"] == "l3":
             if delem[profile]["members"] is None:
                 intf["interfaces"][0]["nvPairs"]["MEMBER_INTERFACES"] = ""
@@ -3256,6 +3360,19 @@ class DcnmIntf:
             intf["interfaces"][0]["nvPairs"]["LACP_RATE"] = delem[profile]["lacp_rate"]
         else:
             intf["interfaces"][0]["nvPairs"]["LACP_RATE"] = "normal"
+        if delem[profile].get("enable_qos"):
+            intf["interfaces"][0]["nvPairs"]["ENABLE_QOS"] = delem[profile]["enable_qos"]
+            if delem[profile].get("qos_policy"):
+                intf["interfaces"][0]["nvPairs"]["QOS_POLICY"] = delem[profile]["qos_policy"]
+            else:
+                intf["interfaces"][0]["nvPairs"]["QOS_POLICY"] = ""
+        else:
+            intf["interfaces"][0]["nvPairs"]["ENABLE_QOS"] = False
+            intf["interfaces"][0]["nvPairs"]["QOS_POLICY"] = ""
+        if delem[profile].get("queuing_policy"):
+            intf["interfaces"][0]["nvPairs"]["QUEUING_POLICY"] = delem[profile]["queuing_policy"]
+        else:
+            intf["interfaces"][0]["nvPairs"]["QUEUING_POLICY"] = ""
         intf["interfaces"][0]["nvPairs"]["INTF_NAME"] = ifname
         intf["interfaces"][0]["nvPairs"]["SPEED"] = self.dcnm_intf_xlate_speed(
             str(delem[profile].get("speed", ""))
@@ -3416,6 +3533,19 @@ class DcnmIntf:
                 "ENABLE_MONITOR"] = delem[profile]["enable_monitor"]
             intf["interfaces"][0]["nvPairs"][
                 "PORT_DUPLEX_MODE"] = delem[profile]["duplex"]
+            if delem[profile].get("enable_qos"):
+                intf["interfaces"][0]["nvPairs"]["ENABLE_QOS"] = delem[profile]["enable_qos"]
+                if delem[profile].get("qos_policy"):
+                    intf["interfaces"][0]["nvPairs"]["QOS_POLICY"] = delem[profile]["qos_policy"]
+                else:
+                    intf["interfaces"][0]["nvPairs"]["QOS_POLICY"] = ""
+            else:
+                intf["interfaces"][0]["nvPairs"]["ENABLE_QOS"] = False
+                intf["interfaces"][0]["nvPairs"]["QOS_POLICY"] = ""
+            if delem[profile].get("queuing_policy"):
+                intf["interfaces"][0]["nvPairs"]["QUEUING_POLICY"] = delem[profile]["queuing_policy"]
+            else:
+                intf["interfaces"][0]["nvPairs"]["QUEUING_POLICY"] = ""
         if delem[profile]["mode"] == "access":
             intf["interfaces"][0]["nvPairs"]["BPDUGUARD_ENABLED"] = delem[
                 profile
@@ -3440,6 +3570,19 @@ class DcnmIntf:
                 "ENABLE_MONITOR"] = delem[profile]["enable_monitor"]
             intf["interfaces"][0]["nvPairs"][
                 "PORT_DUPLEX_MODE"] = delem[profile]["duplex"]
+            if delem[profile].get("enable_qos"):
+                intf["interfaces"][0]["nvPairs"]["ENABLE_QOS"] = delem[profile]["enable_qos"]
+                if delem[profile].get("qos_policy"):
+                    intf["interfaces"][0]["nvPairs"]["QOS_POLICY"] = delem[profile]["qos_policy"]
+                else:
+                    intf["interfaces"][0]["nvPairs"]["QOS_POLICY"] = ""
+            else:
+                intf["interfaces"][0]["nvPairs"]["ENABLE_QOS"] = False
+                intf["interfaces"][0]["nvPairs"]["QOS_POLICY"] = ""
+            if delem[profile].get("queuing_policy"):
+                intf["interfaces"][0]["nvPairs"]["QUEUING_POLICY"] = delem[profile]["queuing_policy"]
+            else:
+                intf["interfaces"][0]["nvPairs"]["QUEUING_POLICY"] = ""
         if delem[profile]["mode"] == "routed":
             intf["interfaces"][0]["nvPairs"]["INTF_VRF"] = delem[profile][
                 "int_vrf"
@@ -3460,6 +3603,19 @@ class DcnmIntf:
                 delem[profile]["mtu"]
             )
             intf["interfaces"][0]["nvPairs"]["INTF_NAME"] = ifname
+            if delem[profile].get("enable_qos"):
+                intf["interfaces"][0]["nvPairs"]["ENABLE_QOS"] = delem[profile]["enable_qos"]
+                if delem[profile].get("qos_policy"):
+                    intf["interfaces"][0]["nvPairs"]["QOS_POLICY"] = delem[profile]["qos_policy"]
+                else:
+                    intf["interfaces"][0]["nvPairs"]["QOS_POLICY"] = ""
+            else:
+                intf["interfaces"][0]["nvPairs"]["ENABLE_QOS"] = False
+                intf["interfaces"][0]["nvPairs"]["QOS_POLICY"] = ""
+            if delem[profile].get("queuing_policy"):
+                intf["interfaces"][0]["nvPairs"]["QUEUING_POLICY"] = delem[profile]["queuing_policy"]
+            else:
+                intf["interfaces"][0]["nvPairs"]["QUEUING_POLICY"] = ""
         if delem[profile]["mode"] == "monitor":
             intf["interfaces"][0]["nvPairs"]["INTF_NAME"] = ifname
         if delem[profile]["mode"] == "epl_routed":

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -4265,7 +4265,8 @@ class DcnmIntf:
             "ENABLE_LACP_VPC_CONV",
             "ENABLE_PFC",
             "ENABLE_MONITOR",
-            "CDP_ENABLE"
+            "CDP_ENABLE",
+            "ENABLE_QOS"
         ]
         if k in boolean_keys:
             # This is a special case where the value is a boolean and we need to compare it as such

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -219,19 +219,19 @@ options:
           enable_qos:
             description:
             - Enable QoS on the interface.
-              This option is applicable only for interfaces whose 'mode' is 'trunk' or 'access'
+              This option is applicable only for interfaces whose 'mode' is 'trunk', 'access', or 'l3'
             type: bool
             default: false
           qos_policy:
             description:
             - QoS policy name to apply to the interface. This option is only valid when 'enable_qos' is true.
-              This option is applicable only for interfaces whose 'mode' is 'trunk' or 'access'
+              This option is applicable only for interfaces whose 'mode' is 'trunk', 'access', or 'l3'
             type: str
             default: ""
           queuing_policy:
             description:
             - Queuing policy name to apply to the interface.
-              This option is applicable only for interfaces whose 'mode' is 'trunk' or 'access'
+              This option is applicable only for interfaces whose 'mode' is 'trunk', 'access', or 'l3'
             type: str
             default: ""
       profile_vpc:
@@ -2468,6 +2468,9 @@ class DcnmIntf:
             cmds=dict(type="list", elements="str"),
             description=dict(type="str", default=""),
             admin_state=dict(type="bool", default=True),
+            enable_qos=dict(type="bool", default=False),
+            qos_policy=dict(type="str", default=""),
+            queuing_policy=dict(type="str", default=""),
         )
 
         pc_prof_spec_dot1q = dict(
@@ -3069,6 +3072,7 @@ class DcnmIntf:
                 intf["interfaces"][0]["nvPairs"]["QUEUING_POLICY"] = delem[profile]["queuing_policy"]
             else:
                 intf["interfaces"][0]["nvPairs"]["QUEUING_POLICY"] = ""
+
         if delem[profile]["mode"] == "access":
             if delem[profile]["members"] is None:
                 intf["interfaces"][0]["nvPairs"]["MEMBER_INTERFACES"] = ""
@@ -3127,6 +3131,7 @@ class DcnmIntf:
                 intf["interfaces"][0]["nvPairs"]["QUEUING_POLICY"] = delem[profile]["queuing_policy"]
             else:
                 intf["interfaces"][0]["nvPairs"]["QUEUING_POLICY"] = ""
+
         if delem[profile]["mode"] == "l3":
             if delem[profile]["members"] is None:
                 intf["interfaces"][0]["nvPairs"]["MEMBER_INTERFACES"] = ""
@@ -3156,6 +3161,20 @@ class DcnmIntf:
             intf["interfaces"][0]["nvPairs"]["MTU"] = str(
                 delem[profile]["mtu"]
             )
+
+            if delem[profile].get("enable_qos"):
+                intf["interfaces"][0]["nvPairs"]["ENABLE_QOS"] = delem[profile]["enable_qos"]
+                if delem[profile].get("qos_policy"):
+                    intf["interfaces"][0]["nvPairs"]["QOS_POLICY"] = delem[profile]["qos_policy"]
+                else:
+                    intf["interfaces"][0]["nvPairs"]["QOS_POLICY"] = ""
+            else:
+                intf["interfaces"][0]["nvPairs"]["ENABLE_QOS"] = False
+                intf["interfaces"][0]["nvPairs"]["QOS_POLICY"] = ""
+            if delem[profile].get("queuing_policy"):
+                intf["interfaces"][0]["nvPairs"]["QUEUING_POLICY"] = delem[profile]["queuing_policy"]
+            else:
+                intf["interfaces"][0]["nvPairs"]["QUEUING_POLICY"] = ""
 
         if delem[profile]["mode"] == "dot1q":
             if delem[profile]["members"] is None:

--- a/tests/integration/targets/dcnm_interface/tasks/main.yaml
+++ b/tests/integration/targets/dcnm_interface/tasks/main.yaml
@@ -25,9 +25,6 @@
     loop_var: test_case_to_run
   tags: sanity
 
-- name: Meta
-  ansible.builtin.meta: end_play
-
 ###############################################
 ##                FACTS                      ##
 ###############################################

--- a/tests/integration/targets/dcnm_interface/templates/dcnm_eth/merge_conf.j2
+++ b/tests/integration/targets/dcnm_interface/templates/dcnm_eth/merge_conf.j2
@@ -14,6 +14,7 @@
     port_type_fast: true
     mtu: jumbo
     allowed_vlans: none
+    enable_qos: true
     cmds:
       - no shutdown
     description: "eth interface acting as trunk"
@@ -31,6 +32,7 @@
     port_type_fast: true
     mtu: default
     access_vlan: 31
+    enable_qos: true
     cmds:
       - no shutdown
     description: "eth interface acting as access"

--- a/tests/unit/modules/dcnm/test_dcnm_intf.py
+++ b/tests/unit/modules/dcnm/test_dcnm_intf.py
@@ -3107,7 +3107,10 @@ class TestDcnmIntfModule(TestDcnmModule):
             "CONF",
             "DISABLE_LACP_SUSPEND",
             "LACP_PORT_PRIO",
-            "LACP_RATE"
+            "LACP_RATE",
+            "ENABLE_QOS",
+            "QOS_POLICY",
+            "QUEUING_POLICY"
         ]
 
         for d in result["diff"][0]["replaced"]:
@@ -3357,6 +3360,9 @@ class TestDcnmIntfModule(TestDcnmModule):
             "SPEED",
             "IPv6",
             "IPv6_PREFIX",
+            "ENABLE_QOS",
+            "QOS_POLICY",
+            "QUEUING_POLICY",
         ]
 
         for d in result["diff"][0]["replaced"]:
@@ -4337,7 +4343,10 @@ class TestDcnmIntfModule(TestDcnmModule):
             "ENABLE_LACP_VPC_CONV",
             "DISABLE_LACP_SUSPEND",
             "LACP_PORT_PRIO",
-            "LACP_RATE"
+            "LACP_RATE",
+            "ENABLE_QOS",
+            "QOS_POLICY",
+            "QUEUING_POLICY"
         ]
 
         for d in result["diff"][0]["replaced"]:


### PR DESCRIPTION
## Add QoS and Queuing Policy support for Port-Channel, vPC, and Ethernet interfaces

### Summary

Adds three new configurable parameters to the `dcnm_interface` Ansible module for managing QoS and queuing policies on switch interfaces:

| Parameter | Type | Default | Description |
|-----------|------|---------|-------------|
| `enable_qos` | bool | `false` | Enable QoS on the interface |
| `qos_policy` | str | `""` | QoS policy name (only applied when `enable_qos` is `true`) |
| `queuing_policy` | str | `""` | Queuing policy name |

### Supported Interface Types and Modes

| Interface Type | Modes |
|----------------|-------|
| Port-Channel (`pc`) | `trunk`, `access`, `l3` |
| Virtual Port-Channel (`vpc`) | `trunk`, `access` |
| Ethernet (`eth`) | `trunk`, `access`, `routed` |

### Changes

- **Keymap**: Added `ENABLE_QOS`, `QOS_POLICY`, and `QUEUING_POLICY` mappings to the NDFC-to-playbook key translation dictionary
- **Validation specs**: Added the three new parameters to the profile validation specs for each supported interface type and mode (`pc_prof_spec_trunk`, `pc_prof_spec_access`, `pc_prof_spec_l3`, `vpc_prof_spec_trunk`, `vpc_prof_spec_access`, `eth_prof_spec_trunk`, `eth_prof_spec_access`, `eth_prof_spec_routed_host`)
- **Payload builders**: Added `ENABLE_QOS`, `QOS_POLICY`, and `QUEUING_POLICY` nvPairs population logic in `dcnm_intf_get_pc_payload` (trunk, access, l3), `dcnm_intf_get_vpc_payload` (trunk, access), and `dcnm_intf_get_eth_payload` (trunk, access, routed) — `QOS_POLICY` is conditionally set only when `enable_qos` is `true`
- **Documentation**: Updated the module `DOCUMENTATION` docstring for `profile_pc`, `profile_vpc`, and `profile_eth` with descriptions, types, defaults, and applicable mode annotations for all three new parameters

### Usage Example

```yaml
- name: Configure L3 port-channel with QoS
  cisco.dcnm.dcnm_interface:
    fabric: my_fabric
    state: merged
    config:
      - name: po100
        type: pc
        switch:
          - 192.168.1.1
        deploy: true
        profile:
          mode: l3
          members:
            - Ethernet1/10
          int_vrf: my-vrf
          ipv4_addr: 10.1.1.1
          ipv4_mask_len: 24
          enable_qos: true
          qos_policy: my-qos-policy
          queuing_policy: my-queuing-policy

- name: Configure trunk ethernet with QoS
  cisco.dcnm.dcnm_interface:
    fabric: my_fabric
    state: merged
    config:
      - name: eth1/1
        type: eth
        switch:
          - 192.168.1.1
        deploy: true
        profile:
          mode: trunk
          enable_qos: true
          qos_policy: my-qos-policy
          queuing_policy: my-queuing-policy