### PR TITLE
[ignore] Replace VRF in VLAN2300 with System Command - PROD_VRF_App → TEST_VRF…

### DIFF
--- a/playbooks/crescit_baseline_demo/05_seed_interface_profiles.yaml
+++ b/playbooks/crescit_baseline_demo/05_seed_interface_profiles.yaml
@@ -37,8 +37,11 @@
             switch:
               - "{{ leaf1 }}"
             profile:
-              int_vrf: PROD_VRF_App
+              int_vrf: TEST_VRF_App  # Changed from PROD_VRF_App to TEST_VRF_App
               ipv4_addr: 10.130.0.1/24
               mtu: 9216
-              desc: "Baseline gateway SVI for PROD_VRF_App"
+              desc: "Baseline gateway SVI for TEST_VRF_App with L3 retention"  # Updated description
+              system:
+                vrf-member-change:
+                  retain-l3-config: true  # System command to preserve L3 config
         deploy: "{{ deploy_changes }}"


### PR DESCRIPTION
…_App

Changes:
- Updated interface VLAN2300 VRF assignment from PROD_VRF_App to TEST_VRF_App
- Added system vrf-member-change retain-l3-config command
- Updated interface description to reflect L3 retention
- Maintains existing SVI configuration (IP address, MTU, switch binding)
- Preserves L3 configuration during VRF change

Impact:
- Risk Level: Medium-High
- Affected Services: Services using VLAN2300
- L3 Preservation: Layer 3 configurations maintained during change
- Testing Required: Verify both L2 and L3 connectivity after VRF change

Technical Notes:
- Using system command for L3 config preservation
- This approach is safer for production environments
- Ensures routing tables remain intact during VRF change
- Requires verification of both VRF and L3 functionality post-change

Related to: VRF configuration evaluation series