### PR TITLE
Add FEC on dcnm_interface for ND4.1

### DIFF
--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -1882,7 +1882,11 @@ from ansible_collections.cisco.dcnm.plugins.module_utils.network.dcnm.dcnm impor
     find_dict_in_list_by_key_value,
 )
 from ..module_utils.common.log_v2 import Log
-from ansible_collections.cisco.nac_dc_vxlan.plugins.filter.version_compare import version_compare
+from ..module_utils.common.controller_version_v2 import ControllerVersion
+from ..module_utils.common.rest_send_v2 import RestSend
+from ..module_utils.common.response_handler import ResponseHandler
+from ..module_utils.common.sender_dcnm import Sender
+from ..module_utils.common.exceptions import ControllerResponseError
 
 
 def json_pretty(msg):
@@ -2065,7 +2069,7 @@ class DcnmIntf:
         }
 
         # NDFC 12.4.1+ (ND 4.1.1+) parameters
-        if self.ndfc_version and version_compare(self.ndfc_version, "12.4.1", ">="):
+        if self._ndfc_version_gte("12.4.1"):
             self.keymap.update({
                 "FEC": "fec",
             })
@@ -2171,20 +2175,34 @@ class DcnmIntf:
 
 
     def _get_ndfc_version(self):
-        """Return the full NDFC version string (e.g. '12.4.1.245') or None on failure."""
-        paths = [
-            "/fm/fmrest/about/version",
-            "/appcenter/cisco/ndfc/api/about/version",
-        ]
-        for path in paths:
-            response = dcnm_send(self.module, "GET", path)
-            if response.get("RETURN_CODE") == 200:
-                data = response.get("DATA", {})
-                raw_version = data.get("version", "")
-                if raw_version and raw_version != "DEVEL":
-                    return re.sub(r'[a-zA-Z]+$', '', raw_version)
-        self.log.warning("Unable to determine NDFC version for feature gating")
+        """Return the full NDFC version string (e.g. '12.4.1.245') using ControllerVersion, or None on failure."""
+        try:
+            sender = Sender()
+            sender.ansible_module = self.module
+            rest_send = RestSend(self.module.params)
+            rest_send.response_handler = ResponseHandler()
+            rest_send.sender = sender
+            controller_version = ControllerVersion()
+            controller_version.rest_send = rest_send
+            controller_version.refresh()
+            raw_version = controller_version.version
+            if raw_version:
+                return re.sub(r'[a-zA-Z]+$', '', raw_version)
+        except (ControllerResponseError, ValueError) as error:
+            self.log.warning("Unable to determine NDFC version: %s", error)
         return None
+
+    def _ndfc_version_gte(self, target):
+        """Check if NDFC version >= target. Uses tuple comparison on version segments."""
+        if not self.ndfc_version:
+            return False
+        try:
+            current = tuple(int(x) for x in self.ndfc_version.split(".")[:3])
+            required = tuple(int(x) for x in target.split(".")[:3])
+            return current >= required
+        except (ValueError, AttributeError):
+            return False
+
 
     def dcnm_intf_breakout_format(self, if_name):
         # Define the pattern to match '1/x/y' where x and y are integers
@@ -2701,7 +2719,7 @@ class DcnmIntf:
             queuing_policy=dict(type="str", default=""),
         )
 
-        if self.ndfc_version and version_compare(self.ndfc_version, "12.4.1", ">="):
+        if self._ndfc_version_gte("12.4.1"):
             eth_prof_spec_trunk.update({
                 "fec": dict(type="str", default="auto", choices=["auto", "fc-fec", "off", "rs-cons16", "rs-fec", "rs-ieee"]),
             })
@@ -2729,7 +2747,7 @@ class DcnmIntf:
             queuing_policy=dict(type="str", default=""),
         )
 
-        if self.ndfc_version and version_compare(self.ndfc_version, "12.4.1", ">="):
+        if self._ndfc_version_gte("12.4.1"):
             eth_prof_spec_access.update({
                 "fec": dict(type="str", default="auto", choices=["auto", "fc-fec", "off", "rs-cons16", "rs-fec", "rs-ieee"]),
             })
@@ -2749,7 +2767,7 @@ class DcnmIntf:
             queuing_policy=dict(type="str", default=""),
         )
 
-        if self.ndfc_version and version_compare(self.ndfc_version, "12.4.1", ">="):
+        if self._ndfc_version_gte("12.4.1"):
             eth_prof_spec_routed_host.update({
                 "fec": dict(type="str", default="auto", choices=["auto", "fc-fec", "off", "rs-cons16", "rs-fec", "rs-ieee"]),
             })
@@ -2786,7 +2804,7 @@ class DcnmIntf:
                 type="str", default="auto", choices=["auto", "full", "half"]),
         )
 
-        if self.ndfc_version and version_compare(self.ndfc_version, "12.4.1", ">="):
+        if self._ndfc_version_gte("12.4.1"):
             eth_prof_spec_dot1q_tunnel_host.update({
                 "fec": dict(type="str", default="auto", choices=["auto", "fc-fec", "off", "rs-cons16", "rs-fec", "rs-ieee"]),
             })
@@ -3610,7 +3628,7 @@ class DcnmIntf:
                 intf["interfaces"][0]["nvPairs"]["QUEUING_POLICY"] = delem[profile]["queuing_policy"]
             else:
                 intf["interfaces"][0]["nvPairs"]["QUEUING_POLICY"] = ""
-            if self.ndfc_version and version_compare(self.ndfc_version, "12.4.1", ">="):
+            if self._ndfc_version_gte("12.4.1"):
                 intf["interfaces"][0]["nvPairs"]["FEC"] = delem[profile].get("fec", "auto")
         if delem[profile]["mode"] == "access":
             intf["interfaces"][0]["nvPairs"]["BPDUGUARD_ENABLED"] = delem[
@@ -3649,7 +3667,7 @@ class DcnmIntf:
                 intf["interfaces"][0]["nvPairs"]["QUEUING_POLICY"] = delem[profile]["queuing_policy"]
             else:
                 intf["interfaces"][0]["nvPairs"]["QUEUING_POLICY"] = ""
-            if self.ndfc_version and version_compare(self.ndfc_version, "12.4.1", ">="):
+            if self._ndfc_version_gte("12.4.1"):
                 intf["interfaces"][0]["nvPairs"]["FEC"] = delem[profile].get("fec", "auto")
         if delem[profile]["mode"] == "routed":
             intf["interfaces"][0]["nvPairs"]["INTF_VRF"] = delem[profile][
@@ -3684,7 +3702,7 @@ class DcnmIntf:
                 intf["interfaces"][0]["nvPairs"]["QUEUING_POLICY"] = delem[profile]["queuing_policy"]
             else:
                 intf["interfaces"][0]["nvPairs"]["QUEUING_POLICY"] = ""
-            if self.ndfc_version and version_compare(self.ndfc_version, "12.4.1", ">="):
+            if self._ndfc_version_gte("12.4.1"):
                 intf["interfaces"][0]["nvPairs"]["FEC"] = delem[profile].get("fec", "auto")
         if delem[profile]["mode"] == "monitor":
             intf["interfaces"][0]["nvPairs"]["INTF_NAME"] = ifname
@@ -3743,7 +3761,7 @@ class DcnmIntf:
             intf["interfaces"][0]["nvPairs"]["INTF_NAME"] = ifname
             intf["interfaces"][0]["nvPairs"][
                 "PORT_DUPLEX_MODE"] = delem[profile]["duplex"]
-            if self.ndfc_version and version_compare(self.ndfc_version, "12.4.1", ">="):
+            if self._ndfc_version_gte("12.4.1"):
                 intf["interfaces"][0]["nvPairs"]["FEC"] = delem[profile].get("fec", "auto")
 
     def dcnm_intf_get_st_fex_payload(self, delem, intf, profile):
@@ -4618,7 +4636,7 @@ class DcnmIntf:
                                         "QUEUING_POLICY"
                                     ]
 
-                                    if self.ndfc_version and version_compare(self.ndfc_version, "12.4.1", ">="):
+                                    if self._ndfc_version_gte("12.4.1"):
                                         keys_to_check.append("FEC")
 
                                     for key in keys_to_check:

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -1882,6 +1882,7 @@ from ansible_collections.cisco.dcnm.plugins.module_utils.network.dcnm.dcnm impor
     find_dict_in_list_by_key_value,
 )
 from ..module_utils.common.log_v2 import Log
+from ansible_collections.cisco.nac_dc_vxlan.plugins.filter.version_compare import version_compare
 
 
 def json_pretty(msg):
@@ -1968,6 +1969,7 @@ class DcnmIntf:
         ]
 
         self.dcnm_version = dcnm_version_supported(self.module)
+        self.ndfc_version = self._get_ndfc_version()
 
         self.inventory_data = {}
         self.manageable = []
@@ -2061,6 +2063,12 @@ class DcnmIntf:
             "QUEUING_POLICY": "queuing_policy",
 
         }
+
+        # NDFC 12.4.1+ (ND 4.1.1+) parameters
+        if self.ndfc_version and version_compare(self.ndfc_version, "12.4.1", ">="):
+            self.keymap.update({
+                "FEC": "fec",
+            })
 
         # New Interfaces
         self.pol_types = {
@@ -2160,6 +2168,23 @@ class DcnmIntf:
 
         msg = "ENTERED DcnmIntf: "
         self.log.debug(msg)
+
+
+    def _get_ndfc_version(self):
+        """Return the full NDFC version string (e.g. '12.4.1.245') or None on failure."""
+        paths = [
+            "/fm/fmrest/about/version",
+            "/appcenter/cisco/ndfc/api/about/version",
+        ]
+        for path in paths:
+            response = dcnm_send(self.module, "GET", path)
+            if response.get("RETURN_CODE") == 200:
+                data = response.get("DATA", {})
+                raw_version = data.get("version", "")
+                if raw_version and raw_version != "DEVEL":
+                    return re.sub(r'[a-zA-Z]+$', '', raw_version)
+        self.log.warning("Unable to determine NDFC version for feature gating")
+        return None
 
     def dcnm_intf_breakout_format(self, if_name):
         # Define the pattern to match '1/x/y' where x and y are integers
@@ -2676,6 +2701,11 @@ class DcnmIntf:
             queuing_policy=dict(type="str", default=""),
         )
 
+        if self.ndfc_version and version_compare(self.ndfc_version, "12.4.1", ">="):
+            eth_prof_spec_trunk.update({
+                "fec": dict(type="str", default="auto", choices=["auto", "fc-fec", "off", "rs-cons16", "rs-fec", "rs-ieee"]),
+            })
+
         eth_prof_spec_access = dict(
             mode=dict(required=True, type="str"),
             bpdu_guard=dict(type="str", default="true"),
@@ -2699,6 +2729,11 @@ class DcnmIntf:
             queuing_policy=dict(type="str", default=""),
         )
 
+        if self.ndfc_version and version_compare(self.ndfc_version, "12.4.1", ">="):
+            eth_prof_spec_access.update({
+                "fec": dict(type="str", default="auto", choices=["auto", "fc-fec", "off", "rs-cons16", "rs-fec", "rs-ieee"]),
+            })
+
         eth_prof_spec_routed_host = dict(
             int_vrf=dict(type="str", default="default"),
             ipv4_addr=dict(type="ipv4", default=""),
@@ -2713,6 +2748,11 @@ class DcnmIntf:
             qos_policy=dict(type="str", default=""),
             queuing_policy=dict(type="str", default=""),
         )
+
+        if self.ndfc_version and version_compare(self.ndfc_version, "12.4.1", ">="):
+            eth_prof_spec_routed_host.update({
+                "fec": dict(type="str", default="auto", choices=["auto", "fc-fec", "off", "rs-cons16", "rs-fec", "rs-ieee"]),
+            })
 
         eth_prof_spec_epl_routed_host = dict(
             mode=dict(required=True, type="str"),
@@ -2745,6 +2785,11 @@ class DcnmIntf:
             duplex=dict(
                 type="str", default="auto", choices=["auto", "full", "half"]),
         )
+
+        if self.ndfc_version and version_compare(self.ndfc_version, "12.4.1", ">="):
+            eth_prof_spec_dot1q_tunnel_host.update({
+                "fec": dict(type="str", default="auto", choices=["auto", "fc-fec", "off", "rs-cons16", "rs-fec", "rs-ieee"]),
+            })
 
         if "trunk" == cfg[0]["profile"]["mode"]:
             self.dcnm_intf_validate_interface_input(
@@ -3565,6 +3610,8 @@ class DcnmIntf:
                 intf["interfaces"][0]["nvPairs"]["QUEUING_POLICY"] = delem[profile]["queuing_policy"]
             else:
                 intf["interfaces"][0]["nvPairs"]["QUEUING_POLICY"] = ""
+            if self.ndfc_version and version_compare(self.ndfc_version, "12.4.1", ">="):
+                intf["interfaces"][0]["nvPairs"]["FEC"] = delem[profile].get("fec", "auto")
         if delem[profile]["mode"] == "access":
             intf["interfaces"][0]["nvPairs"]["BPDUGUARD_ENABLED"] = delem[
                 profile
@@ -3602,6 +3649,8 @@ class DcnmIntf:
                 intf["interfaces"][0]["nvPairs"]["QUEUING_POLICY"] = delem[profile]["queuing_policy"]
             else:
                 intf["interfaces"][0]["nvPairs"]["QUEUING_POLICY"] = ""
+            if self.ndfc_version and version_compare(self.ndfc_version, "12.4.1", ">="):
+                intf["interfaces"][0]["nvPairs"]["FEC"] = delem[profile].get("fec", "auto")
         if delem[profile]["mode"] == "routed":
             intf["interfaces"][0]["nvPairs"]["INTF_VRF"] = delem[profile][
                 "int_vrf"
@@ -3635,6 +3684,8 @@ class DcnmIntf:
                 intf["interfaces"][0]["nvPairs"]["QUEUING_POLICY"] = delem[profile]["queuing_policy"]
             else:
                 intf["interfaces"][0]["nvPairs"]["QUEUING_POLICY"] = ""
+            if self.ndfc_version and version_compare(self.ndfc_version, "12.4.1", ">="):
+                intf["interfaces"][0]["nvPairs"]["FEC"] = delem[profile].get("fec", "auto")
         if delem[profile]["mode"] == "monitor":
             intf["interfaces"][0]["nvPairs"]["INTF_NAME"] = ifname
         if delem[profile]["mode"] == "epl_routed":
@@ -3692,6 +3743,8 @@ class DcnmIntf:
             intf["interfaces"][0]["nvPairs"]["INTF_NAME"] = ifname
             intf["interfaces"][0]["nvPairs"][
                 "PORT_DUPLEX_MODE"] = delem[profile]["duplex"]
+            if self.ndfc_version and version_compare(self.ndfc_version, "12.4.1", ">="):
+                intf["interfaces"][0]["nvPairs"]["FEC"] = delem[profile].get("fec", "auto")
 
     def dcnm_intf_get_st_fex_payload(self, delem, intf, profile):
 
@@ -4564,6 +4617,9 @@ class DcnmIntf:
                                         "QOS_POLICY",
                                         "QUEUING_POLICY"
                                     ]
+
+                                    if self.ndfc_version and version_compare(self.ndfc_version, "12.4.1", ">="):
+                                        keys_to_check.append("FEC")
 
                                     for key in keys_to_check:
                                         # Remove the key from nv_keys only if it exists and is not present in 'have'

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -2173,7 +2173,6 @@ class DcnmIntf:
         msg = "ENTERED DcnmIntf: "
         self.log.debug(msg)
 
-
     def _get_ndfc_version(self):
         """Return the full NDFC version string (e.g. '12.4.1.245') using ControllerVersion, or None on failure."""
         try:
@@ -2202,7 +2201,6 @@ class DcnmIntf:
             return current >= required
         except (ValueError, AttributeError):
             return False
-
 
     def dcnm_intf_breakout_format(self, if_name):
         # Define the pattern to match '1/x/y' where x and y are integers

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -2187,13 +2187,13 @@ class DcnmIntf:
             raw_version = controller_version.version
             if raw_version:
                 return re.sub(r'[a-zA-Z]+$', '', raw_version)
-        except (ControllerResponseError, ValueError) as error:
-            self.log.warning("Unable to determine NDFC version: %s", error)
+        except (ControllerResponseError, ValueError, AssertionError, Exception):
+            pass
         return None
 
     def _ndfc_version_gte(self, target):
         """Check if NDFC version >= target. Uses tuple comparison on version segments."""
-        if not self.ndfc_version:
+        if not getattr(self, 'ndfc_version', None):
             return False
         try:
             current = tuple(int(x) for x in self.ndfc_version.split(".")[:3])

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -4890,6 +4890,14 @@ class DcnmIntf:
                 != str(have_nv.get("NATIVE_VLAN")).lower()
             ):
                 return "DCNM_INTF_NOT_MATCH"
+
+        if self._ndfc_version_gte("12.4.1"):
+            if (
+                str(intf_nv.get("FEC", "auto")).lower()
+                != str(have_nv.get("FEC", "auto")).lower()
+            ):
+                return "DCNM_INTF_NOT_MATCH"
+
         return "DCNM_INTF_MATCH"
 
     def dcnm_intf_get_default_eth_payload(self, ifname, sno, fabric):
@@ -4936,6 +4944,9 @@ class DcnmIntf:
             eth_payload["interfaces"][0]["nvPairs"]["NATIVE_VLAN"] = ""
             eth_payload["interfaces"][0]["nvPairs"]["INTF_NAME"] = ifname
 
+            if self._ndfc_version_gte("12.4.1"):
+                eth_payload["interfaces"][0]["nvPairs"]["FEC"] = "auto"
+
             eth_payload["interfaces"][0]["ifName"] = ifname
             eth_payload["interfaces"][0]["serialNumber"] = sno
             eth_payload["interfaces"][0]["fabricName"] = fabric
@@ -4953,6 +4964,9 @@ class DcnmIntf:
             eth_payload["interfaces"][0]["nvPairs"]["IP"] = ""
             eth_payload["interfaces"][0]["nvPairs"]["PREFIX"] = ""
             eth_payload["interfaces"][0]["nvPairs"]["ROUTING_TAG"] = ""
+
+            if self._ndfc_version_gte("12.4.1"):
+                eth_payload["interfaces"][0]["nvPairs"]["FEC"] = "auto"
 
             eth_payload["interfaces"][0]["ifName"] = ifname
             eth_payload["interfaces"][0]["serialNumber"] = sno

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -2717,10 +2717,9 @@ class DcnmIntf:
             queuing_policy=dict(type="str", default=""),
         )
 
-        if self._ndfc_version_gte("12.4.1"):
-            eth_prof_spec_trunk.update({
-                "fec": dict(type="str", default="auto", choices=["auto", "fc-fec", "off", "rs-cons16", "rs-fec", "rs-ieee"]),
-            })
+        eth_prof_spec_trunk.update({
+            "fec": dict(type="str", choices=["auto", "fc-fec", "off", "rs-cons16", "rs-fec", "rs-ieee"]),
+        })
 
         eth_prof_spec_access = dict(
             mode=dict(required=True, type="str"),
@@ -2745,10 +2744,9 @@ class DcnmIntf:
             queuing_policy=dict(type="str", default=""),
         )
 
-        if self._ndfc_version_gte("12.4.1"):
-            eth_prof_spec_access.update({
-                "fec": dict(type="str", default="auto", choices=["auto", "fc-fec", "off", "rs-cons16", "rs-fec", "rs-ieee"]),
-            })
+        eth_prof_spec_access.update({
+            "fec": dict(type="str", choices=["auto", "fc-fec", "off", "rs-cons16", "rs-fec", "rs-ieee"]),
+        })
 
         eth_prof_spec_routed_host = dict(
             int_vrf=dict(type="str", default="default"),
@@ -2765,10 +2763,9 @@ class DcnmIntf:
             queuing_policy=dict(type="str", default=""),
         )
 
-        if self._ndfc_version_gte("12.4.1"):
-            eth_prof_spec_routed_host.update({
-                "fec": dict(type="str", default="auto", choices=["auto", "fc-fec", "off", "rs-cons16", "rs-fec", "rs-ieee"]),
-            })
+        eth_prof_spec_routed_host.update({
+            "fec": dict(type="str", choices=["auto", "fc-fec", "off", "rs-cons16", "rs-fec", "rs-ieee"]),
+        })
 
         eth_prof_spec_epl_routed_host = dict(
             mode=dict(required=True, type="str"),
@@ -2802,10 +2799,9 @@ class DcnmIntf:
                 type="str", default="auto", choices=["auto", "full", "half"]),
         )
 
-        if self._ndfc_version_gte("12.4.1"):
-            eth_prof_spec_dot1q_tunnel_host.update({
-                "fec": dict(type="str", default="auto", choices=["auto", "fc-fec", "off", "rs-cons16", "rs-fec", "rs-ieee"]),
-            })
+        eth_prof_spec_dot1q_tunnel_host.update({
+            "fec": dict(type="str", choices=["auto", "fc-fec", "off", "rs-cons16", "rs-fec", "rs-ieee"]),
+        })
 
         if "trunk" == cfg[0]["profile"]["mode"]:
             self.dcnm_intf_validate_interface_input(
@@ -2829,6 +2825,19 @@ class DcnmIntf:
             self.dcnm_intf_validate_interface_input(
                 cfg, eth_spec, eth_prof_spec_dot1q_tunnel_host
             )
+
+        fec_value = cfg[0]["profile"].get("fec")
+        if fec_value is not None:
+            if self.ndfc_version is None:
+                self.module.fail_json(
+                    msg=f"Interface '{cfg[0]['name']}': fec='{fec_value}' requested but "
+                    "NDFC version could not be determined. Ensure the controller is reachable."
+                )
+            if not self._ndfc_version_gte("12.4.1"):
+                self.module.fail_json(
+                    msg=f"Interface '{cfg[0]['name']}': fec requires NDFC >= 12.4.1 "
+                    f"(current: {self.ndfc_version})."
+                )
 
     def dcnm_intf_validate_vlan_interface_input(self, cfg):
 


### PR DESCRIPTION
#660 

Use existing plugin: version_compare to compare and push only if ND >= 4.1.1

```
---
- name: test inventory
  hosts: nac-ndfc1
  gather_facts: false

  tasks:

  - name: Configure 25G with fc-fec on E1/12
    cisco.dcnm.dcnm_interface:
      fabric: "nac-ndfc1"
      state: merged
      config:
        - name: eth1/12
          type: eth
          switch:
            - "10.229.42.121"
          deploy: false
          profile:
            mode: trunk
            admin_state: true
            speed: 25Gb
            fec: rs-fec
            description: "ETH 1/12 25G fc-fec"
```

```
TASK [Configure 25G with fc-fec on E1/12] *************************************************************************************************
task path: /Users/ccoueffe/Documents/Devnet/NDFC-Ansible-As-Code/ndfc-ansbile-as-code/nac-ndfc/playbooks/play-interface_fec.yaml:8
Monday 30 March 2026  14:45:06 +0200 (0:00:00.053)       0:00:00.053 ********** 
Monday 30 March 2026  14:45:06 +0200 (0:00:00.053)       0:00:00.053 ********** 
changed: [nac-ndfc1] => {
    "changed": true,
    "diff": [
        {
            "debugs": [],
            "deferred": [],
            "delete_deploy": [],
            "deleted": [],
            "deploy": [],
            "merged": [
                {
                    "interfaceType": "INTERFACE_ETHERNET",
                    "interfaces": [
                        {
                            "ifName": "Ethernet1/12",
                            "nvPairs": {
                                "FEC": "rs-fec"
                            }
                        }
                    ]
                }
            ],
            "overridden": [],
            "query": [],
            "replaced": [],
            "skipped": []
        }
    ],
    "invocation": {
        "module_args": {
            "check_deploy": false,
            "config": [
                {
                    "deploy": false,
                    "name": "eth1/12",
                    "profile": {
                        "admin_state": true,
                        "description": "ETH 1/12 25G fc-fec",
                        "fec": "rs-fec",
                        "mode": "trunk",
                        "speed": "25Gb"
                    },
                    "switch": [
                        "10.229.42.121"
                    ],
                    "type": "eth"
                }
            ],
            "deploy": true,
            "fabric": "nac-ndfc1",
            "override_intf_types": [],
            "state": "merged"
        }
    },
    "response": [
        {
            "DATA": {},
            "MESSAGE": "OK",
            "METHOD": "PUT",
            "REQUEST_PATH": "https://x.x.x.x:443/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/interface",
            "RETURN_CODE": 200
        }
    ]
}

PLAY RECAP ********************************************************************************************************************************
nac-ndfc1                  : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```

Second run indepotent

```
TASK [Configure 25G with fc-fec on E1/12] *************************************************************************************************
task path: /Users/ccoueffe/Documents/Devnet/NDFC-Ansible-As-Code/ndfc-ansbile-as-code/nac-ndfc/playbooks/play-interface_fec.yaml:8
Monday 30 March 2026  14:50:22 +0200 (0:00:00.054)       0:00:00.054 ********** 
Monday 30 March 2026  14:50:22 +0200 (0:00:00.054)       0:00:00.054 ********** 
ok: [nac-ndfc1] => {
    "changed": false,
    "diff": [
        {
            "debugs": [],
            "deferred": [],
            "delete_deploy": [],
            "deleted": [],
            "deploy": [],
            "merged": [],
            "overridden": [],
            "query": [],
            "replaced": [],
            "skipped": []
        }
    ],
    "invocation": {
        "module_args": {
            "check_deploy": false,
            "config": [
                {
                    "deploy": false,
                    "name": "eth1/12",
                    "profile": {
                        "admin_state": true,
                        "description": "ETH 1/12 25G fc-fec",
                        "fec": "rs-fec",
                        "mode": "trunk",
                        "speed": "25Gb"
                    },
                    "switch": [
                        "10.229.42.121"
                    ],
                    "type": "eth"
                }
            ],
            "deploy": true,
            "fabric": "nac-ndfc1",
            "override_intf_types": [],
            "state": "merged"
        }
    },
    "response": []
}

PLAY RECAP ********************************************************************************************************************************
nac-ndfc1                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   


PLAYBOOK RECAP ****************************************************************************************************************************
Playbook run took 0 days, 0 hours, 0 minutes, 6 seconds
```

Using Replaced

```
  - name: Configure 25G with fc-fec on E1/12
    cisco.dcnm.dcnm_interface:
      fabric: "nac-ndfc1"
      state: replaced
      config:
        - name: eth1/12
          type: eth
          switch:
            - "10.229.42.121"
          deploy: false
          profile:
            mode: trunk
            admin_state: true
            speed: 25Gb
            fec: fc-fec
            description: "ETH 1/12 25G fc-fec"
```

```
Monday 30 March 2026  14:52:11 +0200 (0:00:00.063)       0:00:00.063 ********** 
changed: [nac-ndfc1] => {
    "changed": true,
    "diff": [
        {
            "debugs": [],
            "deferred": [],
            "delete_deploy": [],
            "deleted": [],
            "deploy": [],
            "merged": [],
            "overridden": [],
            "query": [],
            "replaced": [
                {
                    "interfaceType": "INTERFACE_ETHERNET",
                    "interfaces": [
                        {
                            "ifName": "Ethernet1/12",
                            "nvPairs": {
                                "FEC": "fc-fec"
                            }
                        }
                    ]
                }
            ],
            "skipped": []
        }
    ],
    "invocation": {
        "module_args": {
            "check_deploy": false,
            "config": [
                {
                    "deploy": false,
                    "name": "eth1/12",
                    "profile": {
                        "admin_state": true,
                        "description": "ETH 1/12 25G fc-fec",
                        "fec": "fc-fec",
                        "mode": "trunk",
                        "speed": "25Gb"
                    },
                    "switch": [
                        "10.229.42.121"
                    ],
                    "type": "eth"
                }
            ],
            "deploy": true,
            "fabric": "nac-ndfc1",
            "override_intf_types": [],
            "state": "replaced"
        }
    },
    "response": [
        {
            "DATA": {},
            "MESSAGE": "OK",
            "METHOD": "PUT",
            "REQUEST_PATH": "https://x.x.x.x:443/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/interface",
            "RETURN_CODE": 200
        }
    ]
}

PLAY RECAP ********************************************************************************************************************************
nac-ndfc1                  : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   


PLAYBOOK RECAP ****************************************************************************************************************************
Playbook run took 0 days, 0 hours, 0 minutes, 7 seconds
```

Test with Access mode
```
  - name: Configure 25G with fc-fec on E1/12
    cisco.dcnm.dcnm_interface:
      fabric: "nac-ndfc1"
      state: replaced
      config:
        - name: eth1/12
          type: eth
          switch:
            - "10.229.42.121"
          deploy: false
          profile:
            mode: access
            admin_state: true
            speed: 25Gb
            fec: fc-fec
            description: "ETH 1/12 25G fc-fec"
```

```
Monday 30 March 2026  14:54:50 +0200 (0:00:00.048)       0:00:00.048 ********** 
changed: [nac-ndfc1] => {
    "changed": true,
    "diff": [
        {
            "debugs": [],
            "deferred": [],
            "delete_deploy": [],
            "deleted": [],
            "deploy": [],
            "merged": [],
            "overridden": [],
            "query": [],
            "replaced": [
                {
                    "interfaceType": "INTERFACE_ETHERNET",
                    "interfaces": [
                        {
                            "fabricName": "nac-ndfc1",
                            "ifName": "Ethernet1/12",
                            "interfaceType": "INTERFACE_ETHERNET",
                            "nvPairs": {
                                "ACCESS_VLAN": "",
                                "ADMIN_STATE": "true",
                                "BPDUGUARD_ENABLED": "true",
                                "CDP_ENABLE": true,
                                "CONF": "",
                                "DESC": "ETH 1/12 25G fc-fec",
                                "ENABLE_MONITOR": false,
                                "ENABLE_ORPHAN_PORT": false,
                                "ENABLE_PFC": false,
                                "ENABLE_QOS": false,
                                "FEC": "fc-fec",
                                "INTF_NAME": "Ethernet1/12",
                                "MTU": "jumbo",
                                "PORTTYPE_FAST_ENABLED": "true",
                                "PORT_DUPLEX_MODE": "auto",
                                "QOS_POLICY": "",
                                "QUEUING_POLICY": "",
                                "SPEED": "25Gb"
                            },
                            "serialNumber": "9YWYW0DZU81"
                        }
                    ],
                    "policy": "int_access_host"
                }
            ],
            "skipped": []
        }
    ],
    "invocation": {
        "module_args": {
            "check_deploy": false,
            "config": [
                {
                    "deploy": false,
                    "name": "eth1/12",
                    "profile": {
                        "admin_state": true,
                        "description": "ETH 1/12 25G fc-fec",
                        "fec": "fc-fec",
                        "mode": "access",
                        "speed": "25Gb"
                    },
                    "switch": [
                        "10.229.42.121"
                    ],
                    "type": "eth"
                }
            ],
            "deploy": true,
            "fabric": "nac-ndfc1",
            "override_intf_types": [],
            "state": "replaced"
        }
    },
    "response": [
        {
            "DATA": {},
            "MESSAGE": "OK",
            "METHOD": "PUT",
            "REQUEST_PATH": "https://x.x.x.x:443/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/interface",
            "RETURN_CODE": 200
        }
    ]
}

PLAY RECAP ********************************************************************************************************************************
nac-ndfc1                  : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```
