### PR TITLE
Handle non-resolvable deferred interfaces in dcnm_interface

### DIFF
--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -4919,6 +4919,29 @@ class DcnmIntf:
                     return False, item["ifname"]
         return True, None
 
+    def dcnm_intf_get_underlay_policy_source(self, intf):
+
+        underlay_policies = intf.get("underlayPolicies") or []
+
+        for policy in underlay_policies:
+            source = policy.get("source")
+            if source:
+                return source
+
+        return None
+
+    def dcnm_intf_skip_non_resolvable_deferred(self, intf):
+
+        self.changed_dict[0]["skipped"].append(
+            {
+                "Name": intf["ifName"],
+                "Alias": intf.get("alias"),
+                "Deletable": intf.get("deletable"),
+                "Underlay Policies": intf.get("underlayPolicies"),
+                "Reason": "Non-deletable interface without resolvable underlay policy source",
+            }
+        )
+
     def dcnm_intf_process_config(self, cfg):
 
         processed = []
@@ -5043,6 +5066,12 @@ class DcnmIntf:
                         continue
 
                 if str(have["deletable"]).lower() == "false":
+                    source = self.dcnm_intf_get_underlay_policy_source(have)
+
+                    if source is None:
+                        self.dcnm_intf_skip_non_resolvable_deferred(have)
+                        continue
+
                     # Add this 'have to a deferred list. We will process this list once we have processed all the 'haves'
                     defer_list.append(have)
                     self.changed_dict[0]["deferred"].append(
@@ -5050,6 +5079,7 @@ class DcnmIntf:
                             "Name": name,
                             "Deletable": have["deletable"],
                             "Underlay Policies": have["underlayPolicies"],
+                            "Source": source,
                         }
                     )
                     continue
@@ -5335,7 +5365,11 @@ class DcnmIntf:
             delem = {}
             sno = intf["serialNo"]
             fabric = intf["fabricName"]
-            name = intf["underlayPolicies"][0]["source"]
+            name = self.dcnm_intf_get_underlay_policy_source(intf)
+
+            if name is None:
+                self.dcnm_intf_skip_non_resolvable_deferred(intf)
+                continue
 
             match = [
                 d

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -5419,6 +5419,29 @@ class DcnmIntf:
                 key = (ifname.lower(), str(sno), fabric)
                 self._replace_pb_input_lookup.setdefault(key, []).append(item)
 
+    def dcnm_intf_get_underlay_policy_source(self, intf):
+
+        underlay_policies = intf.get("underlayPolicies") or []
+
+        for policy in underlay_policies:
+            source = policy.get("source")
+            if source:
+                return source
+
+        return None
+
+    def dcnm_intf_skip_non_resolvable_deferred(self, intf):
+
+        self.changed_dict[0]["skipped"].append(
+            {
+                "Name": intf["ifName"],
+                "Alias": intf.get("alias"),
+                "Deletable": intf.get("deletable"),
+                "Underlay Policies": intf.get("underlayPolicies"),
+                "Reason": "Non-deletable interface without resolvable underlay policy source",
+            }
+        )
+
     def dcnm_intf_process_config(self, cfg):
 
         processed = []
@@ -5569,6 +5592,12 @@ class DcnmIntf:
                         continue
 
                 if str(have["deletable"]).lower() == "false":
+                    source = self.dcnm_intf_get_underlay_policy_source(have)
+
+                    if source is None:
+                        self.dcnm_intf_skip_non_resolvable_deferred(have)
+                        continue
+
                     # Add this 'have to a deferred list. We will process this list once we have processed all the 'haves'
                     defer_list.append(have)
                     self.changed_dict[0]["deferred"].append(
@@ -5576,6 +5605,7 @@ class DcnmIntf:
                             "Name": name,
                             "Deletable": have["deletable"],
                             "Underlay Policies": have["underlayPolicies"],
+                            "Source": source,
                         }
                     )
                     continue
@@ -5839,7 +5869,11 @@ class DcnmIntf:
             delem = {}
             sno = intf["serialNo"]
             fabric = intf["fabricName"]
-            name = intf["underlayPolicies"][0]["source"]
+            name = self.dcnm_intf_get_underlay_policy_source(intf)
+
+            if name is None:
+                self.dcnm_intf_skip_non_resolvable_deferred(intf)
+                continue
 
             match = [
                 d

--- a/tests/unit/modules/dcnm/test_dcnm_intf.py
+++ b/tests/unit/modules/dcnm/test_dcnm_intf.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+import copy
 from unittest.mock import patch
 
 # from units.compat.mock import patch
@@ -194,6 +195,63 @@ class TestDcnmIntfModule(TestDcnmModule):
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
             ]
+
+        if (
+            "test_dcnm_intf_override_eth_intf_types_skip_non_resolvable_deferred"
+            in self._testMethodName
+        ):
+
+            playbook_have_all_data = copy.deepcopy(
+                self.have_all_payloads_data.get("payloads")
+            )
+            for intf in playbook_have_all_data["DATA"]:
+                if intf["ifName"] == "Ethernet1/1":
+                    intf["deletable"] = "False"
+                    intf["underlayPolicies"] = None
+                    break
+
+            eth_1_2_access_intf = self.have_all_payloads_data.get(
+                "eth_1_2_access_payload"
+            )
+            eth_3_2_access_intf = self.have_all_payloads_data.get(
+                "eth_3_2_access_payload"
+            )
+            self.breakout_policies_data = loadPlaybookData(
+                "dcnm_intf_breakout_policies"
+            )
+            empty_breakout_resp = self.breakout_policies_data.get(
+                "empty_breakout_policies"
+            )
+
+            def dcnm_send_side_effect(*args, **kwargs):
+                path = args[2]
+
+                if path.endswith("/accessmode"):
+                    return self.mock_monitor_false_resp
+                if "/control/policies/switches/" in path:
+                    return empty_breakout_resp
+                if "interface/detail?serialNumber=" in path:
+                    return playbook_have_all_data
+                if (
+                    "interface?serialNumber=" in path
+                    and "ifName=Ethernet1/1" in path
+                ):
+                    raise AssertionError(
+                        "Skipped deferred interface should not be queried again"
+                    )
+                if (
+                    "interface?serialNumber=" in path
+                    and "ifName=Ethernet1/2" in path
+                ):
+                    return eth_1_2_access_intf
+                if (
+                    "interface?serialNumber=" in path
+                    and "ifName=Ethernet3/2" in path
+                ):
+                    return eth_3_2_access_intf
+                return self.playbook_mock_succ_resp
+
+            self.run_dcnm_send.side_effect = dcnm_send_side_effect
 
         if (
             "test_dcnm_intf_override_eth_intf_types_only"
@@ -5811,6 +5869,65 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.assertEqual(len(result["diff"][0]["deleted"]), 0)
         self.assertEqual(len(result["diff"][0]["replaced"]), 2)
         self.assertEqual(len(result["diff"][0]["overridden"]), 0)
+
+    def test_dcnm_intf_override_eth_intf_types_skip_non_resolvable_deferred(
+        self,
+    ):
+
+        self.config_data = loadPlaybookData("dcnm_intf_common_configs")
+        self.have_all_payloads_data = loadPlaybookData(
+            "dcnm_intf_have_all_payloads"
+        )
+
+        self.playbook_config = self.config_data.get("override_eth_only_config")
+        self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
+        self.mock_ip_sn = self.config_data.get("mock_ip_sn")
+        self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
+        self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
+
+        set_module_args(
+            dict(
+                state="overridden",
+                fabric="test_fabric",
+                override_intf_types=["eth"],
+                deploy=False,
+                config=[],
+            )
+        )
+        result = self.execute_module(changed=True, failed=False)
+
+        self.assertEqual(len(result["diff"][0]["deferred"]), 0)
+        self.assertEqual(len(result["diff"][0]["deleted"]), 0)
+        self.assertLessEqual(len(result["diff"][0]["replaced"]), 2)
+        self.assertEqual(len(result["diff"][0]["overridden"]), 0)
+
+        self.assertFalse(
+            any(
+                intf["interfaces"][0]["ifName"].lower() == "ethernet1/1"
+                for intf in result["diff"][0]["replaced"]
+            )
+        )
+        self.assertTrue(
+            all(
+                intf["interfaces"][0]["ifName"].lower()
+                in ["ethernet1/2", "ethernet3/2"]
+                for intf in result["diff"][0]["replaced"]
+            )
+        )
+        self.assertTrue(
+            any(
+                intf["Name"].lower() == "ethernet1/1"
+                and intf["Reason"]
+                == "Non-deletable interface without resolvable underlay policy source"
+                for intf in result["diff"][0]["skipped"]
+            )
+        )
 
     def test_dcnm_intf_override_sub_int_intf_types_only(self):
 

--- a/tests/unit/modules/dcnm/test_dcnm_intf.py
+++ b/tests/unit/modules/dcnm/test_dcnm_intf.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+import copy
 from unittest.mock import patch
 
 # from units.compat.mock import patch
@@ -206,6 +207,63 @@ class TestDcnmIntfModule(TestDcnmModule):
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
             ]
+
+        if (
+            "test_dcnm_intf_override_eth_intf_types_skip_non_resolvable_deferred"
+            in self._testMethodName
+        ):
+
+            playbook_have_all_data = copy.deepcopy(
+                self.have_all_payloads_data.get("payloads")
+            )
+            for intf in playbook_have_all_data["DATA"]:
+                if intf["ifName"] == "Ethernet1/1":
+                    intf["deletable"] = "False"
+                    intf["underlayPolicies"] = None
+                    break
+
+            eth_1_2_access_intf = self.have_all_payloads_data.get(
+                "eth_1_2_access_payload"
+            )
+            eth_3_2_access_intf = self.have_all_payloads_data.get(
+                "eth_3_2_access_payload"
+            )
+            self.breakout_policies_data = loadPlaybookData(
+                "dcnm_intf_breakout_policies"
+            )
+            empty_breakout_resp = self.breakout_policies_data.get(
+                "empty_breakout_policies"
+            )
+
+            def dcnm_send_side_effect(*args, **kwargs):
+                path = args[2]
+
+                if path.endswith("/accessmode"):
+                    return self.mock_monitor_false_resp
+                if "/control/policies/switches/" in path:
+                    return empty_breakout_resp
+                if "interface/detail?serialNumber=" in path:
+                    return playbook_have_all_data
+                if (
+                    "interface?serialNumber=" in path
+                    and "ifName=Ethernet1/1" in path
+                ):
+                    raise AssertionError(
+                        "Skipped deferred interface should not be queried again"
+                    )
+                if (
+                    "interface?serialNumber=" in path
+                    and "ifName=Ethernet1/2" in path
+                ):
+                    return eth_1_2_access_intf
+                if (
+                    "interface?serialNumber=" in path
+                    and "ifName=Ethernet3/2" in path
+                ):
+                    return eth_3_2_access_intf
+                return self.playbook_mock_succ_resp
+
+            self.run_dcnm_send.side_effect = dcnm_send_side_effect
 
         if (
             "test_dcnm_intf_override_eth_intf_types_only"
@@ -6077,6 +6135,65 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.assertEqual(len(result["diff"][0]["deleted"]), 0)
         self.assertEqual(len(result["diff"][0]["replaced"]), 3)
         self.assertEqual(len(result["diff"][0]["overridden"]), 0)
+
+    def test_dcnm_intf_override_eth_intf_types_skip_non_resolvable_deferred(
+        self,
+    ):
+
+        self.config_data = loadPlaybookData("dcnm_intf_common_configs")
+        self.have_all_payloads_data = loadPlaybookData(
+            "dcnm_intf_have_all_payloads"
+        )
+
+        self.playbook_config = self.config_data.get("override_eth_only_config")
+        self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
+        self.mock_ip_sn = self.config_data.get("mock_ip_sn")
+        self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
+        self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
+
+        set_module_args(
+            dict(
+                state="overridden",
+                fabric="test_fabric",
+                override_intf_types=["eth"],
+                deploy=False,
+                config=[],
+            )
+        )
+        result = self.execute_module(changed=True, failed=False)
+
+        self.assertEqual(len(result["diff"][0]["deferred"]), 0)
+        self.assertEqual(len(result["diff"][0]["deleted"]), 0)
+        self.assertLessEqual(len(result["diff"][0]["replaced"]), 2)
+        self.assertEqual(len(result["diff"][0]["overridden"]), 0)
+
+        self.assertFalse(
+            any(
+                intf["interfaces"][0]["ifName"].lower() == "ethernet1/1"
+                for intf in result["diff"][0]["replaced"]
+            )
+        )
+        self.assertTrue(
+            all(
+                intf["interfaces"][0]["ifName"].lower()
+                in ["ethernet1/2", "ethernet3/2"]
+                for intf in result["diff"][0]["replaced"]
+            )
+        )
+        self.assertTrue(
+            any(
+                intf["Name"].lower() == "ethernet1/1"
+                and intf["Reason"]
+                == "Non-deletable interface without resolvable underlay policy source"
+                for intf in result["diff"][0]["skipped"]
+            )
+        )
 
     def test_dcnm_intf_override_sub_int_intf_types_only(self):
 

--- a/tests/unit/modules/dcnm/test_dcnm_intf.py
+++ b/tests/unit/modules/dcnm/test_dcnm_intf.py
@@ -6185,21 +6185,15 @@ class TestDcnmIntfModule(TestDcnmModule):
 
         self.assertEqual(len(result["diff"][0]["deferred"]), 0)
         self.assertEqual(len(result["diff"][0]["deleted"]), 0)
-        self.assertLessEqual(len(result["diff"][0]["replaced"]), 2)
+        self.assertEqual(len(result["diff"][0]["replaced"]), 2)
         self.assertEqual(len(result["diff"][0]["overridden"]), 0)
 
-        self.assertFalse(
-            any(
-                intf["interfaces"][0]["ifName"].lower() == "ethernet1/1"
-                for intf in result["diff"][0]["replaced"]
-            )
-        )
-        self.assertTrue(
-            all(
+        self.assertEqual(
+            {
                 intf["interfaces"][0]["ifName"].lower()
-                in ["ethernet1/2", "ethernet3/2"]
                 for intf in result["diff"][0]["replaced"]
-            )
+            },
+            {"ethernet1/2", "ethernet3/2"},
         )
         self.assertTrue(
             any(

--- a/tests/unit/modules/dcnm/test_dcnm_intf.py
+++ b/tests/unit/modules/dcnm/test_dcnm_intf.py
@@ -228,6 +228,11 @@ class TestDcnmIntfModule(TestDcnmModule):
             eth_3_2_access_intf = self.have_all_payloads_data.get(
                 "eth_3_2_access_payload"
             )
+            eth_bulk_payload = self.build_bulk_payload(
+                eth_1_2_access_intf,
+                eth_3_2_access_intf,
+            )
+            eth_vpc_empty_payload = self.build_bulk_payload()
             self.breakout_policies_data = loadPlaybookData(
                 "dcnm_intf_breakout_policies"
             )
@@ -244,6 +249,16 @@ class TestDcnmIntfModule(TestDcnmModule):
                     return empty_breakout_resp
                 if "interface/detail?serialNumber=" in path:
                     return playbook_have_all_data
+                if (
+                    "interface?serialNumber=SAL1819SAN8" in path
+                    and "ifName=" not in path
+                ):
+                    return eth_bulk_payload
+                if (
+                    "interface?serialNumber=" in path
+                    and "ifName=" not in path
+                ):
+                    return eth_vpc_empty_payload
                 if (
                     "interface?serialNumber=" in path
                     and "ifName=Ethernet1/1" in path


### PR DESCRIPTION
Fixes #658

## Summary

This change fixes a crash in `dcnm_interface` during `state=overridden` when the module processes non-deletable Ethernet interfaces returned by NDFC without a resolvable underlay policy source.

## Problem

In the deferred override flow, the module assumes that every non-deletable Ethernet interface has:

```python
underlayPolicies[0]["source"]
```

That is not always true.

With NDFC 4.2, ISN and External fabrics can return physical Ethernet interfaces with:

- `deletable: false`
- `underlayPolicies: null`

When those interfaces enter the deferred path, the module crashes with:

```text
TypeError: 'NoneType' object is not subscriptable
```

## Root Cause

The deferred flow treats all `deletable=false` Ethernet interfaces as if they were resolvable later via `underlayPolicies[].source`.

That assumption is invalid for protected or unmanaged Ethernet interfaces in ISN and External fabrics.

## Changes

- Added a helper to safely extract a usable underlay policy `source`
- Added a helper to record non-resolvable deferred interfaces under `diff.skipped`
- Updated the override flow so that Ethernet interfaces are only added to `deferred` when:
  - `deletable == false`, and
  - a valid `underlayPolicies[].source` exists
- Added a defensive check in the deferred loop to avoid direct indexing of `underlayPolicies[0]["source"]`
- Added a unit test that covers:
  - `state=overridden`
  - physical Ethernet
  - `deletable=false`
  - `underlayPolicies=None`

## Behavior After This Change

For non-deletable Ethernet interfaces without a resolvable policy source, the module now:

- does not crash
- does not add them to `deferred`
- reports them in `diff.skipped`
- leaves them untouched

This preserves the existing deferred behavior for interfaces that do have a valid `source`.

## Validation

Manual validation:

- NDFC 4.2
- ISN fabric: remove flow completed successfully
- External fabric: remove flow completed successfully
- Problematic physical Ethernet interfaces were reported under `skipped`
- No `NoneType` or `subscriptable` failure was observed

Unit validation:

- Added coverage for `deletable=false` plus `underlayPolicies=None` in `test_dcnm_intf.py`
