### PR TITLE
Handle string fabric discovery responses

### DIFF
--- a/plugins/module_utils/network/dcnm/dcnm.py
+++ b/plugins/module_utils/network/dcnm/dcnm.py
@@ -15,9 +15,10 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+import ast
 import copy
-import socket
 import json
+import socket
 import time
 import html
 import re
@@ -1412,13 +1413,45 @@ def obtain_federated_fabric_associations(action_module, task_vars, tmp):
             tmp=tmp
         )
 
+        if isinstance(federated_fabric_associations, str):
+            try:
+                federated_fabric_associations = json.loads(federated_fabric_associations)
+            except ValueError:
+                return action_module.error_handler.handle_failure(
+                    "Unexpected response format from federated fabric associations API: "
+                    f"{type(federated_fabric_associations).__name__}"
+                )
+
+        if not isinstance(federated_fabric_associations, dict):
+            return action_module.error_handler.handle_failure(
+                "Unexpected response format from federated fabric associations API: "
+                f"{type(federated_fabric_associations).__name__}"
+            )
+
         # Special handling for the following cases:
         #   * Federation manager does not exist (standalone or MSD fabrics in a non-clustered environment)
         #   * ND3.2 returns an invalid JSON response for remote users
         if federated_fabric_associations.get('failed') and federated_fabric_associations.get('msg'):
             message = federated_fabric_associations.get('msg')
-            error_msg = message.get('DATA')
-            error_code = message.get('RETURN_CODE')
+
+            if isinstance(message, str):
+                try:
+                    parsed_message = json.loads(message)
+                except ValueError:
+                    try:
+                        parsed_message = ast.literal_eval(message)
+                    except (ValueError, SyntaxError):
+                        parsed_message = None
+
+                if isinstance(parsed_message, dict):
+                    message = parsed_message
+
+            if isinstance(message, dict):
+                error_msg = message.get('DATA')
+                error_code = message.get('RETURN_CODE')
+            else:
+                error_msg = message
+                error_code = federated_fabric_associations.get('RETURN_CODE')
 
             # For ND3.2 error_msg will be a string
             # For ND4.X error_msg will be a dict
@@ -1436,7 +1469,8 @@ def obtain_federated_fabric_associations(action_module, task_vars, tmp):
                     details=error_details
                 )
 
-            if error_msg in FEDERATION_MANAGER_NOT_FOUND_ERRORS:
+            if error_msg in FEDERATION_MANAGER_NOT_FOUND_ERRORS or \
+               any(error in error_msg for error in FEDERATION_MANAGER_NOT_FOUND_ERRORS):
                 # Return the same error message for both ND3.2 and ND4.X for consistency
                 return 'A federation manager does not exist'
 

--- a/tests/unit/module_utils/network/dcnm/test_fabric_associations.py
+++ b/tests/unit/module_utils/network/dcnm/test_fabric_associations.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2026 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+from ansible_collections.cisco.dcnm.plugins.module_utils.common.action_error_handler import ActionErrorHandler
+from ansible_collections.cisco.dcnm.plugins.module_utils.network.dcnm.dcnm import (
+    obtain_federated_fabric_associations,
+)
+
+
+class MockLogger:
+    def debug(self, *args, **kwargs):
+        pass
+
+    def error(self, *args, **kwargs):
+        pass
+
+    def info(self, *args, **kwargs):
+        pass
+
+
+class MockActionModule:
+    def __init__(self, response, ndfc_version=12.2):
+        self.error_handler = ActionErrorHandler(MockLogger())
+        self.logger = MockLogger()
+        self.ndfc_version = ndfc_version
+        self.response = response
+
+    def _execute_module(self, **kwargs):
+        return self.response
+
+
+def test_obtain_federated_fabric_associations_handles_stringified_failure_msg():
+    """
+    Verify Ansible Core versions that return failed module msg as a stringified
+    dict do not trigger AttributeError during fabric discovery.
+    """
+    response = {
+        "failed": True,
+        "msg": (
+            "{'RETURN_CODE': 503, 'METHOD': 'GET', "
+            "'REQUEST_PATH': 'https://controller/appcenter/cisco/ndfc/api/v1/onemanage/fabrics', "
+            "'MESSAGE': 'Service Unavailable', "
+            "'DATA': 'Invalid JSON response: this API is allowed only for remote user'}"
+        ),
+    }
+    action_module = MockActionModule(response)
+
+    result = obtain_federated_fabric_associations(action_module, {}, None)
+
+    assert result == "A federation manager does not exist"
+
+
+def test_obtain_federated_fabric_associations_handles_json_string_response():
+    """
+    Verify string JSON responses are normalized before API response validation.
+    """
+    response = json.dumps(
+        {
+            "response": {
+                "RETURN_CODE": 200,
+                "MESSAGE": "OK",
+                "DATA": [
+                    {
+                        "fabricName": "parent",
+                        "fabricType": "Federated",
+                        "fabricState": "parent",
+                        "members": [
+                            {
+                                "fabricName": "child",
+                                "clusterName": "cluster-1",
+                                "fabricType": "VXLAN",
+                                "fabricState": "member",
+                            }
+                        ],
+                    }
+                ],
+            }
+        }
+    )
+    action_module = MockActionModule(response)
+
+    result = obtain_federated_fabric_associations(action_module, {}, None)
+
+    assert result["parent"]["fabricType"] == "Federated"
+    assert result["child"]["clusterName"] == "cluster-1"


### PR DESCRIPTION
## Summary

Fix `obtain_federated_fabric_associations()` so fabric discovery can handle string responses from `_execute_module()` before calling `.get()`.

The change normalizes JSON string responses, parses stringified failed `msg` payloads, and preserves the existing federation-manager-not-found behavior used for standalone or non-federated controller responses.

## Root Cause

With Ansible Core 2.20.1, a failed `cisco.dcnm.dcnm_rest` call can return `msg` as a stringified dictionary. The fabric discovery helper assumed `msg` was already a dict and called:

```python
message.get("DATA")
```

That raised:

```text
'str' object has no attribute 'get'
```

This affected both `dcnm_network state=query` and `dcnm_vrf state=query` because both modules use the shared fabric discovery helper.

## Lab Validation

Tested against a local NDFC lab:

- Nexus Dashboard: 3.2.2m
- NDFC / Fabric Controller: 12.2.3.70
- cisco.dcnm: 3.11.1

Before this fix:

- Python 3.14.4 + Ansible Core 2.20.1 failed during `fabric_discovery`
- `dcnm_rest` returned `RETURN_CODE: 200` for the fabric API, confirming controller reachability
- `dcnm_network state=query` and `dcnm_vrf state=query` failed with `'str' object has no attribute 'get'`

After this fix was applied to the installed collection:

- Ansible Core 2.20.1 `dcnm_network state=query`: `ok=3 failed=0`
- Ansible Core 2.20.1 `dcnm_vrf` + `dcnm_network` query repro: `ok=4 failed=0`
- Supported stack Python 3.12.13 + Ansible Core 2.17.13: `ok=3 failed=0`

## Tests

- `PYTHONPATH=/private/tmp .venv/bin/python -m pytest tests/unit/module_utils/network/dcnm/test_fabric_associations.py -q`
- `.venv/bin/flake8 plugins/module_utils/network/dcnm/dcnm.py tests/unit/module_utils/network/dcnm/test_fabric_associations.py`
- `python3 -m py_compile plugins/module_utils/network/dcnm/dcnm.py tests/unit/module_utils/network/dcnm/test_fabric_associations.py`
- `git diff --check`

Note: the pytest command used a temporary symlink so this checkout could be imported as `ansible_collections.cisco.dcnm`.

Fixes #510
