### PR TITLE
Fix VRF auto VLAN handling for NDFC 12

### DIFF
--- a/plugins/modules/dcnm_vrf.py
+++ b/plugins/modules/dcnm_vrf.py
@@ -1375,8 +1375,7 @@ class DcnmVrf:
                         have_inst_values = {}
                         if (
                             (want["instanceValues"] is not None and want["instanceValues"] != "")
-                            and
-                            (have["instanceValues"] is not None and have["instanceValues"] != "")
+                            and (have["instanceValues"] is not None and have["instanceValues"] != "")
                         ):
                             want_inst_values = ast.literal_eval(want["instanceValues"])
                             have_inst_values = ast.literal_eval(have["instanceValues"])
@@ -1916,9 +1915,10 @@ class DcnmVrf:
         # Some ND versions give empty bgpPasswordKeyType. Skip comparison if:
         # 1. Have keytype is empty/None (ND has no password configured)
         # 2. Both passwords are empty (no password in want or have)
-        if ((bgp_key_type_have == "" and bgp_key_type_want == 3 and
-             bgp_password_want != "") or (bgp_password_want == ""
-                                          and bgp_password_have == "")):
+        if (
+            (bgp_key_type_have == "" and bgp_key_type_want == 3 and bgp_password_want != "")
+            or (bgp_password_want == "" and bgp_password_have == "")
+        ):
             skip_keys.append("bgpPasswordKeyType")
 
         template_skip_keys = self.get_template_skip_keys()
@@ -2448,7 +2448,7 @@ class DcnmVrf:
                 if vrf.get("vlan_id"):
                     vlan_id = vrf.get("vlan_id")
                 else:
-                    if self.action_fabric_type in ["multisite_parent", "multicluster_parent"]:
+                    if self.dcnm_version > 11 or self.action_fabric_type in ["multisite_parent", "multicluster_parent"]:
                         vlan_id = ""
                     else:
                         # TODO: After DCNM 11.x support is ended, change the default vlan_id to ""
@@ -3578,7 +3578,11 @@ class DcnmVrf:
                 # Check for VRF VLAN ID in the template
                 json_to_dict = json.loads(vrf["vrfTemplateConfig"])
                 vlan_id = json_to_dict.get("vrfVlanId", "0")
-                if vlan_id == 0:
+                if vlan_id == 0 and self.dcnm_version > 11:
+                    vlan_id = ""
+                    json_to_dict.update({"vrfVlanId": vlan_id})
+                    vrf.update({"vrfTemplateConfig": json.dumps(json_to_dict)})
+                elif vlan_id == 0:
                     # Get the next available VLAN ID, vlan 0 shouldn't be pushed
                     # to the controller
                     vlan_path = self.paths["GET_VLAN"].format(self.fabric)
@@ -3787,7 +3791,9 @@ class DcnmVrf:
             vlan_id = json_to_dict.get("vrfVlanId", "0")
             vrf_name = json_to_dict.get("vrfName")
 
-            if vlan_id == 0:
+            if vlan_id == 0 and self.dcnm_version > 11:
+                vlan_id = ""
+            elif vlan_id == 0:
                 vlan_path = self.paths["GET_VLAN"].format(self.fabric)
                 vlan_data = dcnm_send(self.module, "GET", vlan_path)
 

--- a/tests/unit/modules/dcnm/test_dcnm_vrf.py
+++ b/tests/unit/modules/dcnm/test_dcnm_vrf.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import copy
+import json
 from unittest.mock import patch
 
 from ansible_collections.cisco.dcnm.plugins.modules import dcnm_vrf
@@ -1603,6 +1604,34 @@ class TestDcnmVrfModule(TestDcnmModule):
             result["response"][1]["DATA"]["test-vrf-1--XYZKSJHSMK2(leaf2)"], "SUCCESS"
         )
         self.assertEqual(result["response"][2]["DATA"]["status"], "")
+        self.assertEqual(result["response"][2]["RETURN_CODE"], self.SUCCESS_RETURN_CODE)
+
+    def test_dcnm_vrf_12merged_new_multiple_auto_vlan(self):
+        self.version = 12
+        playbook = copy.deepcopy(self.test_data.get("playbook_config"))
+        playbook[0].pop("vlan_id")
+        playbook.append(copy.deepcopy(playbook[0]))
+        playbook[1]["vrf_name"] = "test_vrf_2"
+        playbook[1]["vrf_id"] = "9008012"
+
+        set_module_args(dict(state="merged", fabric="standalone_fabric", config=playbook))
+        result = self.execute_module(changed=True, failed=False, use_action_plugin=True)
+        self.version = 11
+
+        bulk_create_payload = None
+        for call in self.run_dcnm_send.call_args_list:
+            args = call.args
+            if len(args) < 4:
+                continue
+            if args[1] == "POST" and args[2].endswith("/bulk-create/vrfs"):
+                bulk_create_payload = json.loads(args[3])
+                break
+
+        self.assertIsNotNone(bulk_create_payload)
+        self.assertEqual(len(bulk_create_payload), 2)
+        for vrf in bulk_create_payload:
+            vrf_template_config = json.loads(vrf["vrfTemplateConfig"])
+            self.assertEqual(vrf_template_config["vrfVlanId"], "")
         self.assertEqual(result["response"][2]["RETURN_CODE"], self.SUCCESS_RETURN_CODE)
 
     def test_dcnm_vrf_msd_merged(self):


### PR DESCRIPTION
## Summary
- Treat omitted `vlan_id` as controller auto-allocation (`""`) for NDFC 12+ VRF creates
- Preserve legacy DCNM 11 behavior that uses `0` and the VLAN resource-manager lookup
- Add unit coverage for creating multiple VRFs with explicit `vrf_id` and no `vlan_id`

## Root cause
When `vrf_id` was provided and `vlan_id` was omitted, the module kept `vrfVlanId` as `0`. During NDFC 12 bulk create, that could cause duplicate auto-selected VLAN handling instead of letting NDFC allocate each VRF VLAN independently.

## Validation
- `PYTHONPATH=/private/tmp:/Users/deepakbansald/.ansible/collections pytest -q tests/unit/modules/dcnm/test_dcnm_vrf.py::TestDcnmVrfModule::test_dcnm_vrf_12merged_new_multiple_auto_vlan tests/unit/modules/dcnm/test_dcnm_vrf.py::TestDcnmVrfModule::test_dcnm_vrf_12merged_new tests/unit/modules/dcnm/test_dcnm_vrf.py::TestDcnmVrfModule::test_dcnm_vrf_merged_new`
- `flake8 plugins/modules/dcnm_vrf.py tests/unit/modules/dcnm/test_dcnm_vrf.py`
- `python -m py_compile plugins/modules/dcnm_vrf.py tests/unit/modules/dcnm/test_dcnm_vrf.py`

Fixes #676