### PR TITLE
[DO NOT MERGE] Fix torport remove attachments

### DIFF
--- a/plugins/action/dcnm_network.py
+++ b/plugins/action/dcnm_network.py
@@ -768,7 +768,10 @@ class ActionModule(ActionBase):
 
                         # Extract actual payload and validate type based on deploy_mode
                         deploy_payload = deploy_payload_wrapper.get("payload", None)
-                        deploy_mode = fabric_module_args.get("deploy_mode", "switch")
+                        deploy_mode = deploy_payload_wrapper.get(
+                            "deploy_mode",
+                            fabric_module_args.get("deploy_mode", "switch")
+                        )
 
                         if deploy_mode == "switch":
                             if not isinstance(deploy_payload, list):

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -79,7 +79,7 @@ options:
     - Controls the deployment method when deploy is enabled
     - When set to 'switch' (default), deployments use switch-level API with serial numbers
     - When set to 'resource', deployments use resource-level API with network names
-    - This parameter is ignored for multicluster parent fabrics which always use switch-level deployment
+    - Multicluster parent network deployments use resource-level API internally
     - Applies to both create/deploy and delete/undeploy operations
     type: str
     required: false
@@ -1323,6 +1323,46 @@ class DcnmNetwork:
             elif peer_torports and not network_torports:
                 network["torports"] = copy.deepcopy(peer_torports)
 
+    @staticmethod
+    def torports_to_payload_string(torports):
+        if not torports:
+            return ""
+
+        if isinstance(torports, str):
+            return torports
+
+        torconfig_list = []
+        if isinstance(torports, list):
+            for torport in torports:
+                if isinstance(torport, dict):
+                    switch_name = torport.get("switch")
+                    ports = torport.get("torPorts", "")
+                    if switch_name:
+                        torconfig_list.append(f"{switch_name}({ports})")
+                    continue
+                if torport:
+                    torconfig_list.append(str(torport))
+            return " ".join(torconfig_list)
+
+        return str(torports)
+
+    def get_attachment_torports_string(self, attachment):
+        for key in ("torPorts", "torports", "tor_ports"):
+            if key in attachment:
+                return self.torports_to_payload_string(attachment.get(key))
+        return ""
+
+    def normalize_attachment_torports_for_payload(self, attachment):
+        torports = self.get_attachment_torports_string(attachment)
+
+        if "torports" in attachment:
+            del attachment["torports"]
+        if "tor_ports" in attachment:
+            del attachment["tor_ports"]
+
+        if torports or "torPorts" in attachment:
+            attachment["torPorts"] = torports
+
     def diff_for_attach_deploy(self, want_a, have_a, replace=False):
         caller = inspect.stack()[1][3]
 
@@ -1753,6 +1793,55 @@ class DcnmNetwork:
         result = {serial: ",".join(nets) for serial, nets in serial_to_networks.items()}
 
         msg = "Returning transformed payload: "
+        msg += f"{json.dumps(result, indent=4)}"
+        self.log.debug(msg)
+
+        return result
+
+    def network_serial_payload_transform_for_deploy(self, payload: dict) -> dict:
+        """
+        Transform final deploy payload using both attach and detach serial maps.
+
+        The replaced/overridden paths can put both attach and detach work under
+        diff_deploy.  Resource deploy must target every switch touched by either
+        side of that diff.
+        """
+        caller = inspect.stack()[1][3]
+
+        msg = "ENTERED. "
+        msg += f"caller: {caller}."
+        self.log.debug(msg)
+
+        if not payload or "networkNames" not in payload:
+            return payload
+
+        network_names_str = payload["networkNames"]
+        if not network_names_str:
+            return {}
+
+        network_names_list = []
+        seen_networks = set()
+        for network_name in network_names_str.split(","):
+            network_name = network_name.strip()
+            if network_name and network_name not in seen_networks:
+                seen_networks.add(network_name)
+                network_names_list.append(network_name)
+
+        serial_to_networks = {}
+        for network_name in network_names_list:
+            serials = set()
+            serials.update(self.network_sn_attach_map.get(network_name, set()))
+            serials.update(self.network_sn_detach_map.get(network_name, set()))
+
+            for serial in sorted(serials):
+                if serial not in serial_to_networks:
+                    serial_to_networks[serial] = []
+                if network_name not in serial_to_networks[serial]:
+                    serial_to_networks[serial].append(network_name)
+
+        result = {serial: ",".join(networks) for serial, networks in serial_to_networks.items()}
+
+        msg = "Returning combined transformed payload: "
         msg += f"{json.dumps(result, indent=4)}"
         self.log.debug(msg)
 
@@ -3626,8 +3715,9 @@ class DcnmNetwork:
                     found_c["attach"].append(detach_d)
                 attach_d.update({"ports": a_w["switchPorts"]})
                 attach_d.update({"deploy": a_w["deployment"]})
-                if a_w.get("torPorts"):
-                    attach_d.update({"tor_ports": a_w["torPorts"]})
+                torports = self.get_attachment_torports_string(a_w)
+                if torports:
+                    attach_d.update({"tor_ports": torports})
                 found_c["attach"].append(attach_d)
 
             diff.append(found_c)
@@ -3654,8 +3744,9 @@ class DcnmNetwork:
                     new_attach_list.append(detach_d)
                 attach_d.update({"ports": a_w["switchPorts"]})
                 attach_d.update({"deploy": a_w["deployment"]})
-                if a_w.get("torPorts"):
-                    attach_d.update({"tor_ports": a_w["torPorts"]})
+                torports = self.get_attachment_torports_string(a_w)
+                if torports:
+                    attach_d.update({"tor_ports": torports})
                 new_attach_list.append(attach_d)
 
             if new_attach_list:
@@ -3807,7 +3898,7 @@ class DcnmNetwork:
             return
 
         method = "POST"
-        if self.deploy_mode == "switch":
+        if self.deploy_mode == "switch" and self.fabric_type != "multicluster_parent":
             # Use switch-level deploy (undeploy operation for delete)
             self.deploy_network_switches(
                 network_names=[net["networkName"]],
@@ -4126,7 +4217,7 @@ class DcnmNetwork:
                 msg = f"Batch deploying (undeploy) {len(batch_deploy_payload)} attachment(s)"
                 self.log.debug(msg)
 
-                if self.deploy_mode == "switch":
+                if self.deploy_mode == "switch" and self.fabric_type != "multicluster_parent":
                     # Use switch-level deploy (undeploy operation for delete)
                     self.deploy_network_switches(
                         network_names=networks_needing_deploy,
@@ -4450,6 +4541,7 @@ class DcnmNetwork:
                 for v_a in d_a["lanAttachList"]:
                     if v_a.get("is_deploy"):
                         del v_a["is_deploy"]
+                    self.normalize_attachment_torports_for_payload(v_a)
 
             resp = dcnm_send(self.module, method, detach_path, json.dumps(self.diff_detach))
             self.result["response"].append(resp)
@@ -4464,7 +4556,7 @@ class DcnmNetwork:
         payload = copy.deepcopy(self.diff_undeploy)
         delete_ready = False
         if self.diff_undeploy:
-            if self.deploy_mode == "switch":
+            if self.deploy_mode == "switch" and self.fabric_type != "multicluster_parent":
                 # Use switch-level deploy (undeploy operation)
                 self.deploy_network_switches(payload, is_rollback, is_undeploy=True)
             elif self.dcnm_version >= 12:
@@ -4510,7 +4602,7 @@ class DcnmNetwork:
                 # Reset delete_ready since we're performing another deploy operation
                 delete_ready = False
 
-                if self.deploy_mode == "switch":
+                if self.deploy_mode == "switch" and self.fabric_type != "multicluster_parent":
                     # Use switch-level deploy (undeploy retry)
                     self.deploy_network_switches(payload, is_rollback, is_undeploy=True)
                 elif self.dcnm_version >= 12:
@@ -4704,13 +4796,7 @@ class DcnmNetwork:
                 for v_a in d_a["lanAttachList"]:
                     if v_a.get("is_deploy"):
                         del v_a["is_deploy"]
-                    # Clean up tor_ports/torports keys if they exist and are empty
-                    if v_a.get("tor_ports") is not None:
-                        if not v_a["tor_ports"]:
-                            del v_a["tor_ports"]
-                    if v_a.get("torports") is not None:
-                        if not v_a["torports"]:
-                            del v_a["torports"]
+                    self.normalize_attachment_torports_for_payload(v_a)
 
             # Calculate dynamic retry count based on number of attachments
             attachment_count = sum(len(net.get("lanAttachList", [])) for net in self.diff_attach)
@@ -4724,8 +4810,17 @@ class DcnmNetwork:
             for attempt in range(0, retry_count):
                 resp = dcnm_send(self.module, method, attach_path, json.dumps(self.diff_attach))
                 update_in_progress = False
-                for key in resp["DATA"].keys():
-                    if re.search(r"Failed.*Please try after some time", str(resp["DATA"][key])):
+                data = resp.get("DATA", {})
+                if isinstance(data, dict):
+                    response_values = data.values()
+                elif isinstance(data, list):
+                    response_values = data
+                elif data is None:
+                    response_values = []
+                else:
+                    response_values = [data]
+                for value in response_values:
+                    if re.search(r"Failed.*Please try after some time", str(value)):
                         update_in_progress = True
                 if update_in_progress:
                     time.sleep(1)
@@ -4747,7 +4842,14 @@ class DcnmNetwork:
         if self.diff_deploy:
             # For multicluster_parent and multisite_parent, prepare payload for action plugin
             if self.fabric_type == "multicluster_parent" or self.fabric_type == "multisite_parent":
-                # Transform payload based on deploy_mode
+                if self.fabric_type == "multicluster_parent":
+                    # NDFC accepts multicluster parent network deploys through
+                    # the top-down resource endpoint, not switch config-deploy.
+                    diff_deploy = self.network_serial_payload_transform_for_deploy(self.diff_deploy)
+                    self.deploy_payload = {"payload": diff_deploy, "deploy_mode": "resource"}
+                    return
+
+                # Transform multisite parent payload based on deploy_mode
                 if self.deploy_mode == "switch":
                     # Use centralized method to get switch serials (normal deploy)
                     diff_deploy = self.get_deploy_switch_serials(self.diff_deploy, is_undeploy=False)
@@ -5235,6 +5337,12 @@ class DcnmNetwork:
                     fail = True
                     changed = False
                     break
+        if op == "attach" and isinstance(res.get("DATA"), str):
+            data_text = res["DATA"].lower()
+            error_markers = ["failed", "error", "invalid", "exception", "unable"]
+            if any(marker in data_text for marker in error_markers):
+                fail = True
+                changed = False
 
         return fail, changed
 

--- a/tests/unit/modules/dcnm/test_dcnm_network.py
+++ b/tests/unit/modules/dcnm/test_dcnm_network.py
@@ -1694,6 +1694,80 @@ class TestDcnmNetworkModule(TestDcnmModule):
         self.assertFalse(diff)
         self.assertFalse(dep_net)
 
+    def test_dcnm_net_normalize_attachment_torports_for_payload(self):
+        dcnm_net = self._build_diff_network({})
+        attachment = {
+            "serialNumber": "9NN7E41N16A",
+            "torports": [
+                {"switch": "dt-n9k6", "torPorts": "Ethernet1/13,Ethernet1/14"},
+                {"switch": "dt-n9k7", "torPorts": "Ethernet1/15,Ethernet1/16"},
+            ],
+        }
+
+        dcnm_net.normalize_attachment_torports_for_payload(attachment)
+
+        self.assertNotIn("torports", attachment)
+        self.assertEqual(
+            attachment["torPorts"],
+            "dt-n9k6(Ethernet1/13,Ethernet1/14) dt-n9k7(Ethernet1/15,Ethernet1/16)",
+        )
+
+    def test_dcnm_net_network_serial_payload_transform_for_deploy(self):
+        dcnm_net = self._build_diff_network({})
+        dcnm_net.network_sn_attach_map = {
+            "net-a": {"SERIAL-1"},
+            "net-b": {"SERIAL-2"},
+        }
+        dcnm_net.network_sn_detach_map = {
+            "net-a": {"SERIAL-2"},
+            "net-c": {"SERIAL-3"},
+        }
+
+        payload = {"networkNames": "net-a,net-b,net-c"}
+        result = dcnm_net.network_serial_payload_transform_for_deploy(payload)
+
+        self.assertEqual(set(result.keys()), {"SERIAL-1", "SERIAL-2", "SERIAL-3"})
+        self.assertEqual(result["SERIAL-1"], "net-a")
+        self.assertEqual(set(result["SERIAL-2"].split(",")), {"net-a", "net-b"})
+        self.assertEqual(result["SERIAL-3"], "net-c")
+
+    def test_dcnm_net_format_diff_torports_from_detach_have(self):
+        dcnm_net = self._build_diff_network(
+            {},
+            {"10.10.10.217": "9NN7E41N16A"},
+        )
+        dcnm_net.dcnm_version = 12
+        dcnm_net.diff_create = []
+        dcnm_net.diff_create_quick = []
+        dcnm_net.diff_create_update = []
+        dcnm_net.diff_attach = [
+            {
+                "networkName": "test_network",
+                "lanAttachList": [
+                    {
+                        "serialNumber": "9NN7E41N16A",
+                        "networkName": "test_network",
+                        "switchPorts": "Ethernet1/13,Ethernet1/14",
+                        "detachSwitchPorts": "",
+                        "deployment": False,
+                        "torports": [
+                            {"switch": "dt-n9k6", "torPorts": "Ethernet1/13,Ethernet1/14"},
+                        ],
+                    },
+                ],
+            }
+        ]
+        dcnm_net.diff_detach = []
+        dcnm_net.diff_deploy = {}
+        dcnm_net.diff_undeploy = {}
+
+        dcnm_net.format_diff()
+
+        self.assertEqual(
+            dcnm_net.diff_input_format[0]["attach"][0]["tor_ports"],
+            "dt-n9k6(Ethernet1/13,Ethernet1/14)",
+        )
+
     def test_dcnm_net_replace_tor_ports(self):
         self.version = 12
         set_module_args(


### PR DESCRIPTION
## Summary

New PR https://github.com/CiscoDevNet/ansible-dcnm/pull/694 replaces this PR

---
Note: This PR needs to be rebased against `develop` after https://github.com/CiscoDevNet/ansible-dcnm/pull/682 is merged
---

- Fixed multicluster parent network deployment so `deploy: true` uses the NDFC top-down network deploy endpoint instead of switch config-deploy. **(Not sure this is needed, try and remove for re-test)**

- Added resource deploy payload generation for multicluster parent fabrics using `{serial: "network1,network2"}` format.
- Updated the action plugin to honor `deploy_mode` from the module’s `deploy_payload` wrapper.
- Fixed `torPorts` payload handling by converting internal ToR attachment data into the string format NDFC expects.
- Hardened NDFC error handling so string `DATA` responses do not mask the real controller error.
- Added unit coverage for ToR port normalization, diff output, and combined serial-to-network deploy payload generation.

## Validation

- `python3 -m py_compile` passed for:
  - `plugins/modules/dcnm_network.py`
  - `plugins/action/dcnm_network.py`
- Targeted unit tests passed:
  - `18 passed, 36 deselected`

## Live NDFC Tests

### Deploy false

- Ran one-network attachment add/remove scenarios with `deploy: false`.
- Ran three-network attachment add/remove scenarios with `deploy: false`.
- Covered full attachment payloads:
  - leaf `10.122.84.181` ports `Ethernet1/21,Ethernet1/22`
  - leaf `10.122.84.182` ports `Ethernet1/21,Ethernet1/22`
  - ToR `10.122.84.197` ports `Ethernet1/6,Ethernet1/7`
  - ToR `10.122.84.198` ports `Ethernet1/6,Ethernet1/7`
- Covered subset attachment payloads:
  - leaf ports reduced to `Ethernet1/21`
  - ToR attachment reduced to `10.122.84.197` port `Ethernet1/6`
- Covered removal scenarios:
  - remove subset of ports/attachments
  - remove all attachments by omitting `attach`
- Confirmed no `torPorts` JSON unmarshalling error.
- Confirmed idempotency checks returned clean after expected changes.
- Final deploy-false state had no attachments.

### Deploy true

- Ran three-network detach/no-attach scenario with `deploy: true`.
- Ran three-network full attach scenario with `deploy: true`.
- Confirmed both paths used `/onemanage/.../top-down/networks/deploy`.
- Confirmed networks moved from `IN PROGRESS` to `DEPLOYED`.
- Confirmed check-mode idempotency for full desired state returned `changed=0`.
- Ran full delete retry successfully after an initial transient NDFC proxy `500`.

### Performance Impact Analysis

NOTE: Double check **BOLD** Section below

Mostly the same concerns. The new code does not add a worse algorithmic pattern like repeated full attachment scans.

What the new code adds is small:

Builds {serial: "net1,net2,..."} from already-populated serial maps.
Dedupes networks/serials.
Adds a little memory/CPU for the transformed payload.
Logs the transformed payload, which could get noisy at very high scale.
The bigger scale concerns already existed:

NDFC deploy operations are controller-heavy and asynchronous.
Attachment polling/wait loops can take a long time.
Large attachment state queries can hit proxy/controller instability.
Very large network deploy requests may need batching.

**One nuance: the old multicluster parent path sent only switch serials to config-deploy, so it was smaller, but it also did not actually move networks to DEPLOYED. The new resource payload is larger because it includes network names per serial, but that is the endpoint/format NDFC actually needs.**

So: the new code introduces only minor payload/log overhead. The real performance risks are mostly pre-existing NDFC/controller and module batching concerns.