### PR TITLE
Release Candidate 3.12.0rc1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,9 +6,9 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the develop branch
   push:
-    branches: [develop, main]
+    branches: [develop, main, int_perf_updates]
   pull_request:
-    branches: [develop, main]
+    branches: [develop, main, int_perf_updates]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,9 +6,9 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the develop branch
   push:
-    branches: [develop, main, int_perf_updates]
+    branches: [develop, main]
   pull_request:
-    branches: [develop, main, int_perf_updates]
+    branches: [develop, main]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/plugins/action/dcnm_network.py
+++ b/plugins/action/dcnm_network.py
@@ -547,6 +547,17 @@ class ActionModule(ActionBase):
                 if 'vrf_name' in net_config:
                     child_net_config['vrf_name'] = net_config['vrf_name']
 
+                # Secondary gateway values are parent-level inputs in MSD workflows.
+                # For merged, keep them parent-only so omitted child fields preserve
+                # controller state after NDFC propagates the parent update.
+                for key in ['secondary_ip_gw1', 'secondary_ip_gw2', 'secondary_ip_gw3', 'secondary_ip_gw4']:
+                    if state == 'merged':
+                        continue
+                    if key in net_config:
+                        child_net_config[key] = net_config[key]
+                    elif state in ['replaced', 'overridden']:
+                        child_net_config[key] = ''
+
                 # Always inherit deploy flag from parent level (default to True if not specified)
                 if 'deploy' in net_config:
                     child_net_config['deploy'] = net_config['deploy']

--- a/plugins/action/dcnm_network.py
+++ b/plugins/action/dcnm_network.py
@@ -670,7 +670,8 @@ class ActionModule(ActionBase):
         # Track fabric results for new output structure
         parent_fabric_result = None
         child_fabric_results = []
-        deploy_payload = {}
+        deploy_payload_wrapper = {}
+        deploy_payload = None
         parent_fabric_name = None
         parent_fabric_type = None
 
@@ -745,28 +746,57 @@ class ActionModule(ActionBase):
                 }
                 # Collect deploy_payload only from multicluster_parent for deployment at the end
                 if fabric_type == 'multicluster_parent':
-                    deploy_payload = fabric_result.get('deploy_payload', {})
+                    deploy_payload_wrapper = fabric_result.get('deploy_payload', None)
                     parent_fabric_name = fabric_config['fabric']
                     parent_fabric_type = fabric_type
-                display.vvv("=" * 80)
-                display.vvv(f"Deploy payload collected from parent fabric '{parent_fabric_name}':")
-                display.vvv(json.dumps(deploy_payload, indent=2))
-                display.vvv("=" * 80)
-                # Additional vvvv logging for deploy_payload
-                if display.verbosity >= 4:
-                    display.vvvv(f"[ACTION PLUGIN] deploy_payload details for fabric '{parent_fabric_name}':")
-                    display.vvvv(json.dumps(deploy_payload, indent=4))
-                    display.vvvv(f"deploy_payload type: {type(deploy_payload)}")
-                    display.vvvv(f"deploy_payload keys: {list(deploy_payload.keys()) if isinstance(deploy_payload, dict) else 'N/A'}")
 
-                # Write deploy_payload to dcnm.log file
+                    # Validate deploy_payload wrapper structure
+                    if deploy_payload_wrapper:
+                        if not isinstance(deploy_payload_wrapper, dict) or "payload" not in deploy_payload_wrapper:
+                            error_msg = f"Expected deploy_payload wrapper dict with 'payload' key for fabric '{parent_fabric_name}'. "
+                            error_msg += f"Got type: {type(deploy_payload_wrapper)}"
+                            result['failed'] = True
+                            result['msg'] = error_msg
+                            return result
+
+                        # Extract actual payload and validate type based on deploy_mode
+                        deploy_payload = deploy_payload_wrapper.get("payload", None)
+                        deploy_mode = fabric_module_args.get("deploy_mode", "switch")
+
+                        if deploy_mode == "switch":
+                            if not isinstance(deploy_payload, list):
+                                error_msg = f"Expected list payload for deploy_mode='switch' in fabric '{parent_fabric_name}'. "
+                                error_msg += f"Got type: {type(deploy_payload)}"
+                                result['failed'] = True
+                                result['msg'] = error_msg
+                                return result
+                        else:  # resource mode
+                            if not isinstance(deploy_payload, dict):
+                                error_msg = f"Expected dict payload for deploy_mode='resource' in fabric '{parent_fabric_name}'. "
+                                error_msg += f"Got type: {type(deploy_payload)}"
+                                result['failed'] = True
+                                result['msg'] = error_msg
+                                return result
+
+                display.vvv("=" * 80)
+                display.vvv(f"Deploy payload wrapper collected from parent fabric '{parent_fabric_name}':")
+                display.vvv(json.dumps(deploy_payload_wrapper, indent=2))
+                display.vvv("=" * 80)
+                # Additional vvvv logging for deploy_payload_wrapper
+                if display.verbosity >= 4:
+                    display.vvvv(f"[ACTION PLUGIN] deploy_payload_wrapper details for fabric '{parent_fabric_name}':")
+                    display.vvvv(json.dumps(deploy_payload_wrapper, indent=4))
+                    display.vvvv(f"deploy_payload_wrapper type: {type(deploy_payload_wrapper)}")
+                    display.vvvv(f"deploy_payload_wrapper keys: {list(deploy_payload_wrapper.keys()) if isinstance(deploy_payload_wrapper, dict) else 'N/A'}")
+
+                # Write deploy_payload_wrapper to dcnm.log file
                 try:
                     with open("/tmp/dcnm.log", "a") as f:
                         f.write("\n" + "=" * 80 + "\n")
-                        f.write(f"[ACTION PLUGIN] deploy_payload collected from parent fabric '{parent_fabric_name}':\n")
-                        f.write(json.dumps(deploy_payload, indent=4))
-                        f.write(f"\ndeploy_payload type: {type(deploy_payload)}\n")
-                        f.write(f"deploy_payload keys: {list(deploy_payload.keys()) if isinstance(deploy_payload, dict) else 'N/A'}\n")
+                        f.write(f"[ACTION PLUGIN] deploy_payload_wrapper collected from parent fabric '{parent_fabric_name}':\n")
+                        f.write(json.dumps(deploy_payload_wrapper, indent=4))
+                        f.write(f"\deploy_payload_wrapper type: {type(deploy_payload_wrapper)}\n")
+                        f.write(f"deploy_payload_wrapper keys: {list(deploy_payload_wrapper.keys()) if isinstance(deploy_payload_wrapper, dict) else 'N/A'}\n")
                         f.write("=" * 80 + "\n")
                 except Exception as e:
                     pass  # Silently ignore file write errors
@@ -779,15 +809,22 @@ class ActionModule(ActionBase):
                     'diff': fabric_result.get('diff', [])
                 })
 
-        # Deploy networks on parent fabric if deploy_payload is present
-        if deploy_payload and parent_fabric_name:
+        # Deploy networks on parent fabric if deploy_payload is not None
+        # Note: deploy_payload can be an empty list [] or empty dict {} which are valid for deployment
+        if deploy_payload is not None and parent_fabric_name:
             display.vvv("=" * 80)
             display.vvv(f"Calling deploy_fabric for parent fabric '{parent_fabric_name}'")
             display.vvv(f"Fabric type: {parent_fabric_type}")
             display.vvv("Deploy payload being sent:")
             display.vvv(json.dumps(deploy_payload, indent=2))
             display.vvv("=" * 80)
-            deployment_result = deploy_fabric(self, task_vars, tmp, parent_fabric_name, parent_fabric_type, deploy_payload, "network")
+            # Extract actual payload from wrapper
+
+            deployment_result = deploy_fabric(
+                self, task_vars, tmp, parent_fabric_name,
+                parent_fabric_type, deploy_payload,
+                deploy_mode, "network"
+            )
             display.vvv("=" * 80)
             display.vvv(f"Deployment result from fabric '{parent_fabric_name}':")
             display.vvv(json.dumps(deployment_result, indent=2))

--- a/plugins/action/dcnm_network.py
+++ b/plugins/action/dcnm_network.py
@@ -745,8 +745,8 @@ class ActionModule(ActionBase):
                     'response': fabric_result.get('response', []),
                     'diff': fabric_result.get('diff', [])
                 }
-                # Collect deploy_payload only from multicluster_parent for deployment at the end
-                if fabric_type == 'multicluster_parent':
+                # Collect deploy_payload for multisite/multicluster parent fabrics to use for deployment at the end
+                if fabric_type in ['multicluster_parent', 'multisite_parent']:
                     deploy_payload_wrapper = fabric_result.get('deploy_payload', None)
                     parent_fabric_name = fabric_config['fabric']
                     parent_fabric_type = fabric_type

--- a/plugins/action/dcnm_network.py
+++ b/plugins/action/dcnm_network.py
@@ -672,6 +672,7 @@ class ActionModule(ActionBase):
         child_fabric_results = []
         deploy_payload_wrapper = {}
         deploy_payload = None
+        deploy_mode = None
         parent_fabric_name = None
         parent_fabric_type = None
 

--- a/plugins/action/dcnm_network.py
+++ b/plugins/action/dcnm_network.py
@@ -801,17 +801,6 @@ class ActionModule(ActionBase):
                     display.vvvv(f"deploy_payload_wrapper type: {type(deploy_payload_wrapper)}")
                     display.vvvv(f"deploy_payload_wrapper keys: {list(deploy_payload_wrapper.keys()) if isinstance(deploy_payload_wrapper, dict) else 'N/A'}")
 
-                # Write deploy_payload_wrapper to dcnm.log file
-                try:
-                    with open("/tmp/dcnm.log", "a") as f:
-                        f.write("\n" + "=" * 80 + "\n")
-                        f.write(f"[ACTION PLUGIN] deploy_payload_wrapper collected from parent fabric '{parent_fabric_name}':\n")
-                        f.write(json.dumps(deploy_payload_wrapper, indent=4))
-                        f.write(f"\deploy_payload_wrapper type: {type(deploy_payload_wrapper)}\n")
-                        f.write(f"deploy_payload_wrapper keys: {list(deploy_payload_wrapper.keys()) if isinstance(deploy_payload_wrapper, dict) else 'N/A'}\n")
-                        f.write("=" * 80 + "\n")
-                except Exception as e:
-                    pass  # Silently ignore file write errors
             elif fabric_type in ['multisite_child', 'multicluster_child']:
                 child_fabric_results.append({
                     'fabric_name': fabric_config['fabric'],

--- a/plugins/action/dcnm_network.py
+++ b/plugins/action/dcnm_network.py
@@ -551,12 +551,7 @@ class ActionModule(ActionBase):
                 # For merged, keep them parent-only so omitted child fields preserve
                 # controller state after NDFC propagates the parent update.
                 for key in ['secondary_ip_gw1', 'secondary_ip_gw2', 'secondary_ip_gw3', 'secondary_ip_gw4']:
-                    if state == 'merged':
-                        continue
-                    if key in net_config:
-                        child_net_config[key] = net_config[key]
-                    elif state in ['replaced', 'overridden']:
-                        child_net_config[key] = ''
+                    continue
 
                 # Always inherit deploy flag from parent level (default to True if not specified)
                 if 'deploy' in net_config:

--- a/plugins/action/dcnm_vrf.py
+++ b/plugins/action/dcnm_vrf.py
@@ -451,7 +451,7 @@ class ActionModule(ActionNetworkModule):
             # Step 1: Validate and split parent/child configurations
             config = module_args.get("config")
             state = module_args.get("state")
-            deploy_mode = module_args.get("deploy_mode")
+            deploy_mode = module_args.get("deploy_mode", "switch")  # Default to "switch" mode for VRF deployments
             parent_config = []
             child_tasks_dict = {}
             child_fabric_associations = []
@@ -549,7 +549,20 @@ class ActionModule(ActionNetworkModule):
             deploy_payload_wrapper = parent_result.get("deploy_payload", None)
 
             # Step 5: Deploy VRF(s) on parent fabric, if applicable
+            self.logger.debug(
+                f"Checking deployment eligibility: deploy_payload_wrapper={deploy_payload_wrapper}, "
+                f"deploy_mode={deploy_mode}",
+                fabric=parent_fabric,
+                operation="parent_deploy"
+            )
+            
             if deploy_payload_wrapper and deploy_mode:
+                self.logger.info(
+                    f"Starting VRF deployment on parent fabric with deploy_mode={deploy_mode}",
+                    fabric=parent_fabric,
+                    operation="parent_deploy"
+                )
+                
                 # Type check and extract payload
                 if not isinstance(deploy_payload_wrapper, dict) or "payload" not in deploy_payload_wrapper:
                     error_msg = f"Invalid deploy_payload structure. Expected dict with 'payload' key, got: {type(deploy_payload_wrapper)}"
@@ -557,6 +570,12 @@ class ActionModule(ActionNetworkModule):
                     return self.error_handler.handle_failure(error_msg)
 
                 deploy_payload = deploy_payload_wrapper.get("payload", None)
+                
+                self.logger.debug(
+                    f"Extracted deploy_payload: type={type(deploy_payload)}, content={deploy_payload}",
+                    fabric=parent_fabric,
+                    operation="parent_deploy"
+                )
 
                 # Validate payload type based on deploy_mode
                 if deploy_mode == "switch":
@@ -564,15 +583,42 @@ class ActionModule(ActionNetworkModule):
                         error_msg = f"Invalid deploy_payload for switch mode. Expected list, got: {type(deploy_payload)}"
                         self.logger.error(error_msg, fabric=parent_fabric, operation="parent_deploy")
                         return self.error_handler.handle_failure(error_msg)
+                    self.logger.debug(
+                        f"Switch mode deployment: {len(deploy_payload)} serial number(s) to deploy",
+                        fabric=parent_fabric,
+                        operation="parent_deploy"
+                    )
                 else:  # resource mode
                     if not isinstance(deploy_payload, dict):
                         error_msg = f"Invalid deploy_payload for resource mode. Expected dict, got: {type(deploy_payload)}"
                         self.logger.error(error_msg, fabric=parent_fabric, operation="parent_deploy")
                         return self.error_handler.handle_failure(error_msg)
+                    self.logger.debug(
+                        f"Resource mode deployment: {len(deploy_payload)} serial->VRF mapping(s)",
+                        fabric=parent_fabric,
+                        operation="parent_deploy"
+                    )
 
                 if deploy_payload is not None:
-                    self.logger.info("Deploying VRF on parent fabric", fabric=parent_fabric, operation="parent_deploy")
-                    parent_result["deployment"] = deploy_fabric(self, task_vars, tmp, parent_fabric, fabric_type, deploy_payload, deploy_mode, "vrf")
+                    self.logger.info(
+                        f"Invoking deploy_fabric: fabric={parent_fabric}, fabric_type={fabric_type}, "
+                        f"deploy_mode={deploy_mode}, resource_type=vrf",
+                        fabric=parent_fabric,
+                        operation="parent_deploy"
+                    )
+                    deployment_result = deploy_fabric(self, task_vars, tmp, parent_fabric, fabric_type, deploy_payload, deploy_mode, "vrf")
+                    parent_result["deployment"] = deployment_result
+                    self.logger.info(
+                        f"Deployment completed: result={deployment_result}",
+                        fabric=parent_fabric,
+                        operation="parent_deploy"
+                    )
+                else:
+                    self.logger.warning(
+                        "deploy_payload is None, skipping deployment",
+                        fabric=parent_fabric,
+                        operation="parent_deploy"
+                    )
 
             # Step 6: Create structured results
             result = self.create_structured_results(parent_result, child_results, parent_fabric, log_type)

--- a/plugins/action/dcnm_vrf.py
+++ b/plugins/action/dcnm_vrf.py
@@ -451,6 +451,7 @@ class ActionModule(ActionNetworkModule):
             # Step 1: Validate and split parent/child configurations
             config = module_args.get("config")
             state = module_args.get("state")
+            deploy_mode = module_args.get("deploy_mode")
             parent_config = []
             child_tasks_dict = {}
             child_fabric_associations = []
@@ -545,11 +546,33 @@ class ActionModule(ActionNetworkModule):
 
             # Step 4: Retrieve deployment payload from parent module
             # result, if any
-            deploy_payload = parent_result.get("deploy_payload", {})
+            deploy_payload_wrapper = parent_result.get("deploy_payload", None)
 
             # Step 5: Deploy VRF(s) on parent fabric, if applicable
-            if deploy_payload:
-                parent_result["deployment"] = deploy_fabric(self, task_vars, tmp, parent_fabric, fabric_type, deploy_payload, "vrf")
+            if deploy_payload_wrapper and deploy_mode:
+                # Type check and extract payload
+                if not isinstance(deploy_payload_wrapper, dict) or "payload" not in deploy_payload_wrapper:
+                    error_msg = f"Invalid deploy_payload structure. Expected dict with 'payload' key, got: {type(deploy_payload_wrapper)}"
+                    self.logger.error(error_msg, fabric=parent_fabric, operation="parent_deploy")
+                    return self.error_handler.handle_failure(error_msg)
+
+                deploy_payload = deploy_payload_wrapper.get("payload", None)
+
+                # Validate payload type based on deploy_mode
+                if deploy_mode == "switch":
+                    if not isinstance(deploy_payload, list):
+                        error_msg = f"Invalid deploy_payload for switch mode. Expected list, got: {type(deploy_payload)}"
+                        self.logger.error(error_msg, fabric=parent_fabric, operation="parent_deploy")
+                        return self.error_handler.handle_failure(error_msg)
+                else:  # resource mode
+                    if not isinstance(deploy_payload, dict):
+                        error_msg = f"Invalid deploy_payload for resource mode. Expected dict, got: {type(deploy_payload)}"
+                        self.logger.error(error_msg, fabric=parent_fabric, operation="parent_deploy")
+                        return self.error_handler.handle_failure(error_msg)
+
+                if deploy_payload is not None:
+                    self.logger.info("Deploying VRF on parent fabric", fabric=parent_fabric, operation="parent_deploy")
+                    parent_result["deployment"] = deploy_fabric(self, task_vars, tmp, parent_fabric, fabric_type, deploy_payload, deploy_mode, "vrf")
 
             # Step 6: Create structured results
             result = self.create_structured_results(parent_result, child_results, parent_fabric, log_type)

--- a/plugins/action/dcnm_vrf.py
+++ b/plugins/action/dcnm_vrf.py
@@ -555,14 +555,14 @@ class ActionModule(ActionNetworkModule):
                 fabric=parent_fabric,
                 operation="parent_deploy"
             )
-            
+
             if deploy_payload_wrapper and deploy_mode:
                 self.logger.info(
                     f"Starting VRF deployment on parent fabric with deploy_mode={deploy_mode}",
                     fabric=parent_fabric,
                     operation="parent_deploy"
                 )
-                
+
                 # Type check and extract payload
                 if not isinstance(deploy_payload_wrapper, dict) or "payload" not in deploy_payload_wrapper:
                     error_msg = f"Invalid deploy_payload structure. Expected dict with 'payload' key, got: {type(deploy_payload_wrapper)}"
@@ -570,7 +570,7 @@ class ActionModule(ActionNetworkModule):
                     return self.error_handler.handle_failure(error_msg)
 
                 deploy_payload = deploy_payload_wrapper.get("payload", None)
-                
+
                 self.logger.debug(
                     f"Extracted deploy_payload: type={type(deploy_payload)}, content={deploy_payload}",
                     fabric=parent_fabric,

--- a/plugins/module_utils/network/dcnm/dcnm.py
+++ b/plugins/module_utils/network/dcnm/dcnm.py
@@ -1589,7 +1589,7 @@ def obtain_fabric_associations(action_module, task_vars, tmp):
         return action_module.error_handler.handle_exception(e, "fabric_discovery")
 
 
-def deploy_fabric(action_module, task_vars, tmp, fabric, fabric_type, deploy_payload, entity_type):
+def deploy_fabric(action_module, task_vars, tmp, fabric, fabric_type, deploy_payload, deploy_mode, entity_type):
     """
     Deploy VRF or Network configurations to fabric on ND controller.
 
@@ -1620,8 +1620,11 @@ def deploy_fabric(action_module, task_vars, tmp, fabric, fabric_type, deploy_pay
         tmp (str): Temporary directory path for module operations
         fabric (str): Fabric name to deploy to
         fabric_type (str): Fabric type (standard, multicluster_parent, multicluster_child, etc.)
-        deploy_payload (list): List of VRFs/Networks or deployment payload to deploy
-        entity_type (str): Type of entity to deploy ("vrfs" or "networks")
+        deploy_payload (list|dict): Deployment payload whose type depends on deploy_mode:
+            - list: When deploy_mode="switch", contains serial numbers of switches
+            - dict: When deploy_mode="resource", maps serial numbers to comma-separated VRF/Network names
+        deploy_mode (str): Deployment mode ("switch" or "resource")
+        entity_type (str): Type of entity to deploy ("vrf" or "network")
 
     Returns:
         dict: Deployment response from NDFC:
@@ -1635,6 +1638,7 @@ def deploy_fabric(action_module, task_vars, tmp, fabric, fabric_type, deploy_pay
             }
 
     Raises:
+        TypeError: If deploy_payload type doesn't match deploy_mode requirements
         ActionError: On API failure or invalid response structure
     """
     # Log deployment initiation
@@ -1643,25 +1647,51 @@ def deploy_fabric(action_module, task_vars, tmp, fabric, fabric_type, deploy_pay
         operation=f"{entity_type}_deployment"
     )
 
+    # Type check deploy_payload based on deploy_mode
+    if deploy_mode == "switch":
+        if not isinstance(deploy_payload, list):
+            error_msg = f"Invalid deploy_payload for switch mode. Expected list, got: {type(deploy_payload).__name__}"
+            action_module.logger.error(error_msg, fabric=fabric, operation=f"{entity_type}_deployment")
+            raise TypeError(error_msg)
+    else:  # resource mode
+        if not isinstance(deploy_payload, dict):
+            error_msg = f"Invalid deploy_payload for resource mode. Expected dict, got: {type(deploy_payload).__name__}"
+            action_module.logger.error(error_msg, fabric=fabric, operation=f"{entity_type}_deployment")
+            raise TypeError(error_msg)
+
     # Ensure entity_type is pluralized for API paths
     entity_type_plural = entity_type + "s" if not entity_type.endswith("s") else entity_type
 
     # Get fabric type and build appropriate path
-    base_path = f"/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{fabric}/{entity_type_plural}"
-
-    # Determine deployment path and payload based on fabric type
-    if fabric_type == "multicluster_parent":
-        # Multicluster parent always uses /onemanage prefix and special endpoint
-        if action_module.ndfc_version >= 12.2:
-            # NDFC 12.4+: /onemanage/appcenter/cisco/ndfc/api/v1/onemanage/top-down/{entity_type}/deploy
-            deploy_path = f"/onemanage/appcenter/cisco/ndfc/api/v1/onemanage/top-down/{entity_type_plural}/deploy"
-        else:
-            deploy_path = f"/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/{entity_type_plural}/deploy"
-    else:
-        # Standard fabric or MSD fabric deployment
-        deploy_path = base_path + "/deployments"
+    base_path = "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest"
 
     try:
+        # Determine deployment path and payload based on fabric type
+        if fabric_type == "multicluster_parent":
+            # Multicluster parent always uses /onemanage prefix and special endpoint
+            if action_module.ndfc_version >= 12.2:
+                # NDFC 12.4+: /onemanage/appcenter/cisco/ndfc/api/v1/onemanage/top-down/{entity_type}/deploy
+                if deploy_mode == "switch":
+                    deploy_path = f"/onemanage/appcenter/cisco/ndfc/api/v1/onemanage/fabrics/{fabric}/config-deploy/{','.join(deploy_payload)}?forceShowRun=false"
+                    deploy_payload = None  # Payload is not needed for switch-based deployment
+                else:
+                    deploy_path = f"/onemanage/appcenter/cisco/ndfc/api/v1/onemanage/top-down/{entity_type_plural}/deploy"
+            else:
+                if deploy_mode == "switch":
+                    deploy_path = f"/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/fabrics/{fabric}/config-deploy/{','.join(deploy_payload)}?forceShowRun=false"
+                    deploy_payload = None  # Payload is not needed for switch-based deployment
+                else:
+                    deploy_path = f"/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/{entity_type_plural}/deploy"
+        else:
+            if action_module.ndfc_version >= 12:
+                if deploy_mode == "switch":
+                    deploy_path = base_path + f"/control/fabrics/{fabric}" f"/config-deploy/{','.join(deploy_payload)}?forceShowRun=false"
+                    deploy_payload = None  # Payload is not needed for switch-based deployment
+                else:
+                    deploy_path = f"/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/{entity_type_plural}/deploy"
+            else:
+                deploy_path = base_path + f"/top-down/fabrics/{fabric}/{entity_type_plural}" + "/deployments"
+
         # Execute NDFC REST API call to deploy configurations
         deployment_response = action_module._execute_module(
             module_name="cisco.dcnm.dcnm_rest",

--- a/plugins/module_utils/network/dcnm/dcnm.py
+++ b/plugins/module_utils/network/dcnm/dcnm.py
@@ -1708,7 +1708,10 @@ def deploy_fabric(action_module, task_vars, tmp, fabric, fabric_type, deploy_pay
             if action_module.ndfc_version >= 12.2:
                 # NDFC 12.4+: /onemanage/appcenter/cisco/ndfc/api/v1/onemanage/top-down/{entity_type}/deploy
                 if deploy_mode == "switch":
-                    deploy_path = f"/onemanage/appcenter/cisco/ndfc/api/v1/onemanage/fabrics/{fabric}/config-deploy/{','.join(deploy_payload)}?forceShowRun=false"
+                    deploy_path = (
+                        f"/onemanage/appcenter/cisco/ndfc/api/v1/onemanage/fabrics/{fabric}"
+                        f"/config-deploy/{','.join(deploy_payload)}?forceShowRun=false"
+                    )
                     deploy_payload = None  # Payload is not needed for switch-based deployment
                 else:
                     deploy_path = f"/onemanage/appcenter/cisco/ndfc/api/v1/onemanage/top-down/{entity_type_plural}/deploy"

--- a/plugins/module_utils/network/dcnm/dcnm.py
+++ b/plugins/module_utils/network/dcnm/dcnm.py
@@ -697,6 +697,42 @@ def dcnm_version_supported(module):
     return supported
 
 
+def dcnm_get_bulk_api_support(module):
+    """
+    Check if NDFC bulk API endpoints are available.
+
+    Tests for the presence of v2 bulk-update APIs by sending a POST
+    request to the bulk-update endpoint. This API was introduced in
+    NDFC 12.x with specific patches and may not be present in all
+    NDFC 12.x installations.
+
+    Parameters:
+        module: Ansible module instance
+
+    Returns:
+        bool: True if bulk API is supported, False otherwise
+    """
+
+    method = "POST"
+    path = "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/v2/bulk-update/networks"
+    data = {}
+
+    try:
+        response = dcnm_send(module, method, path, data)
+
+        # 404 means endpoint doesn't exist (bulk API not available)
+        if response.get("RETURN_CODE") == 404:
+            return False
+
+        # 405 (Method Not Allowed) or any other response means endpoint exists
+        # Even errors indicate the endpoint is present, just not called correctly
+        return True
+
+    except Exception:
+        # If there's an exception, assume bulk API is not available
+        return False
+
+
 def parse_response(response):
 
     if response.get("ERROR") == "Not Found" and response["RETURN_CODE"] == 404:

--- a/plugins/module_utils/network/dcnm/dcnm_vpc_pair_utils.py
+++ b/plugins/module_utils/network/dcnm/dcnm_vpc_pair_utils.py
@@ -33,7 +33,6 @@ def dcnm_vpc_pair_utils_get_paths(version):
     return dcnm_vpc_pair_paths[version]
 
 
-
 def dcnm_vpc_pair_utils_update_common_spec(self, common_spec):
     if (
         self.src_fabric_info["fabricTechnology"] == "LANClassic"

--- a/plugins/module_utils/network/dcnm/dcnm_vpc_pair_utils.py
+++ b/plugins/module_utils/network/dcnm/dcnm_vpc_pair_utils.py
@@ -4,6 +4,7 @@ __metaclass__ = type
 
 import json
 import time
+import copy
 
 from ansible_collections.cisco.dcnm.plugins.module_utils.network.dcnm.dcnm import (
     dcnm_send,
@@ -32,8 +33,8 @@ def dcnm_vpc_pair_utils_get_paths(version):
     return dcnm_vpc_pair_paths[version]
 
 
-def dcnm_vpc_pair_utils_update_common_spec(self, common_spec):
 
+def dcnm_vpc_pair_utils_update_common_spec(self, common_spec):
     if (
         self.src_fabric_info["fabricTechnology"] == "LANClassic"
         or self.src_fabric_info["fabricTechnology"] == "External"
@@ -44,7 +45,6 @@ def dcnm_vpc_pair_utils_update_common_spec(self, common_spec):
 
 
 def dcnm_vpc_pair_utils_validate_profile(self, profile, arg_spec):
-
     vpc_pair_profile_info = []
 
     # Only LANClassic/External fabrics require profile information.
@@ -53,7 +53,6 @@ def dcnm_vpc_pair_utils_validate_profile(self, profile, arg_spec):
         self.src_fabric_info["fabricTechnology"] == "LANClassic"
         or self.src_fabric_info["fabricTechnology"] == "External"
     ):
-
         vpc_pair_profile_info, invalid_params = validate_list_of_dicts(
             [profile], arg_spec
         )
@@ -66,7 +65,6 @@ def dcnm_vpc_pair_utils_validate_profile(self, profile, arg_spec):
 
 
 def dcnm_vpc_pair_utils_translate_config(self, cfg):
-
     if cfg.get("peerOneId", "") != "":
         cfg["peerOneId"] = dcnm_get_ip_addr_info(
             self.module, cfg["peerOneId"], self.ip_sn, self.hn_sn
@@ -90,7 +88,6 @@ def dcnm_vpc_pair_utils_translate_config(self, cfg):
 
 
 def dcnm_vpc_pair_utils_update_other_information(self):
-
     """
     Routine to update 'self' with serial number to switch DB Id translation information.
 
@@ -100,6 +97,9 @@ def dcnm_vpc_pair_utils_update_other_information(self):
     Returns:
         None
     """
+
+    self._vpc_pair_info_cache = {}
+    self._vpc_sync_status_cache = None
 
     sn_swid = {}
 
@@ -113,7 +113,6 @@ def dcnm_vpc_pair_utils_update_other_information(self):
 
 
 def dcnm_vpc_pair_utils_translate_vpc_pair_info(self, elem):
-
     elem["peerOneId"] = self.ip_sn[elem.get("peerOneId", None)]
     elem["peerTwoId"] = self.ip_sn[elem.get("peerTwoId", None)]
 
@@ -121,7 +120,6 @@ def dcnm_vpc_pair_utils_translate_vpc_pair_info(self, elem):
 
 
 def dcnm_vpc_pair_utils_update_have(self, have):
-
     """
     Routine to update vertain keys in the given 'have' object to be consistent with 'want.
 
@@ -143,7 +141,6 @@ def dcnm_vpc_pair_utils_update_have(self, have):
 
 
 def dcnm_vpc_pair_utils_get_vpc_pair_info_from_dcnm(self, swid):
-
     """
     Routine to get existing information from DCNM with serial number and switch DB id.
 
@@ -155,6 +152,13 @@ def dcnm_vpc_pair_utils_get_vpc_pair_info_from_dcnm(self, swid):
         resp["DATA"] (dict): VPC information obtained from the DCNM server if it exists
         [] otherwise
     """
+
+    if swid is None:
+        return []
+
+    cache = getattr(self, "_vpc_pair_info_cache", None)
+    if cache is not None and swid in cache:
+        return copy.deepcopy(cache[swid])
 
     # Get the Peer information first
     path = self.paths["VPC_PAIR_GET_PATH"]
@@ -173,6 +177,12 @@ def dcnm_vpc_pair_utils_get_vpc_pair_info_from_dcnm(self, swid):
         peerOneDbId = resp["DATA"].get("peerOneDbId", None)
         peerTwoDbId = resp["DATA"].get("peerTwoDbId", None)
     else:
+        return []
+
+    # Guard: skip recommendation call if serial number is None (switch has no pair)
+    if peerOneId is None:
+        if cache is not None:
+            cache[swid] = []
         return []
 
     # Get useVirtualPeerlink information
@@ -214,13 +224,26 @@ def dcnm_vpc_pair_utils_get_vpc_pair_info_from_dcnm(self, swid):
         # fields,if any, so that all keys are consistent between 'want' and 'have'. This will be necessary for compare function to
         # work properly.
         dcnm_vpc_pair_utils_update_have(self, resp["DATA"])
-        return resp["DATA"]
+        if cache is not None:
+            result = copy.deepcopy(resp["DATA"])
+            cache[swid] = result
+            # Cache under both peer switchIds to avoid duplicate lookups
+            # when iterating all switches in overridden/delete/query states
+            peer_one_dbid = resp["DATA"].get("peerOneDbId", None)
+            peer_two_dbid = resp["DATA"].get("peerTwoDbId", None)
+            if peer_one_dbid is not None and peer_one_dbid != swid:
+                cache[peer_one_dbid] = copy.deepcopy(result)
+            if peer_two_dbid is not None and peer_two_dbid != swid:
+                cache[peer_two_dbid] = copy.deepcopy(result)
+            return copy.deepcopy(result)
+        return copy.deepcopy(resp["DATA"])
     else:
+        if cache is not None:
+            cache[swid] = []
         return []
 
 
 def dcnm_vpc_pair_utils_get_vpc_pair_info(self, wobj):
-
     """
     Routine to get existing information from DCNM which matches the given object.
 
@@ -238,7 +261,6 @@ def dcnm_vpc_pair_utils_get_vpc_pair_info(self, wobj):
 
 
 def dcnm_vpc_pair_utils_get_vpc_pair_payload(self, vpc_pair_info):
-
     vpc_pair_payload = {}
 
     for key in vpc_pair_info:
@@ -258,18 +280,13 @@ def dcnm_vpc_pair_utils_get_vpc_pair_payload(self, vpc_pair_info):
             )
 
     # VPC payload carries serial numbers for peerOneId and peerTwoId fields. Translate then approriatley now
-    vpc_pair_payload["peerOneId"] = self.ip_sn[
-        vpc_pair_info.get("peerOneId", None)
-    ]
-    vpc_pair_payload["peerTwoId"] = self.ip_sn[
-        vpc_pair_info.get("peerTwoId", None)
-    ]
+    vpc_pair_payload["peerOneId"] = self.ip_sn[vpc_pair_info.get("peerOneId", None)]
+    vpc_pair_payload["peerTwoId"] = self.ip_sn[vpc_pair_info.get("peerTwoId", None)]
 
     return vpc_pair_payload
 
 
 def dcnm_vpc_pair_utils_get_matching_want(self, vpc_pair_info):
-
     match_want = [
         want
         for want in self.want
@@ -283,7 +300,6 @@ def dcnm_vpc_pair_utils_get_matching_want(self, vpc_pair_info):
 
 
 def dcnm_vpc_pair_utils_get_matching_have(self, want):
-
     match_have = [
         have
         for have in self.have
@@ -297,7 +313,6 @@ def dcnm_vpc_pair_utils_get_matching_have(self, want):
 
 
 def dcnm_vpc_pair_utils_get_matching_cfg(self, want):
-
     match_cfg = [
         cfg
         for cfg in self.config
@@ -311,7 +326,6 @@ def dcnm_vpc_pair_utils_get_matching_cfg(self, want):
 
 
 def dcnm_vpc_pair_utils_merge_want_and_have(self, want, have, key):
-
     if want.get(key, "") == "":
         want[key] = have.get(key)
     elif have.get(key, "") == "":
@@ -326,7 +340,6 @@ def dcnm_vpc_pair_utils_merge_want_and_have(self, want, have, key):
 
 
 def dcnm_vpc_pair_utils_update_vpc_pair_information(self, want, have, cfg):
-
     # Some fields like Member interfaces and Freefrom config are mergeable i.e. information from 'want' must be merged with
     # whatever is existing in 'have' if the state is 'merged'
     mergeable_fields = [
@@ -339,7 +352,6 @@ def dcnm_vpc_pair_utils_update_vpc_pair_information(self, want, have, cfg):
     ]
 
     for key in list(want.keys()):
-
         if key == "nvPairs":
             continue
 
@@ -360,7 +372,6 @@ def dcnm_vpc_pair_utils_update_vpc_pair_information(self, want, have, cfg):
     if want.get("nvPairs", None) is not None:
         # compare the keys here and update appropriately
         for nv_key in list(want["nvPairs"].keys()):
-
             if (cfg.get("profile", None) is None) or (
                 cfg["profile"].get(nv_key, None) is None
             ):
@@ -373,7 +384,6 @@ def dcnm_vpc_pair_utils_update_vpc_pair_information(self, want, have, cfg):
 
 
 def dcnm_vpc_pair_compare_vpc_pair_objects(self, wobj, hobj):
-
     """
     Routine to compare have and want objects and update mismatch information.
 
@@ -418,13 +428,19 @@ def dcnm_vpc_pair_compare_vpc_pair_objects(self, wobj, hobj):
                 hval = bool(hobj["nvPairs"].get(key, False))
                 wval = bool(wobj["nvPairs"][key])
                 if hval != wval:
-                    mismatch_reasons.append(
-                        {key.upper() + "_MISMATCH": [wval, hval]}
-                    )
+                    mismatch_reasons.append({key.upper() + "_MISMATCH": [wval, hval]})
             else:
-                if str(hobj["nvPairs"].get(key, False)).lower() != str(wobj["nvPairs"][key]).lower():
+                if (
+                    str(hobj["nvPairs"].get(key, False)).lower()
+                    != str(wobj["nvPairs"][key]).lower()
+                ):
                     mismatch_reasons.append(
-                        {key.upper() + "_MISMATCH": [wobj["nvPairs"][key], hobj["nvPairs"].get(key, None)]}
+                        {
+                            key.upper() + "_MISMATCH": [
+                                wobj["nvPairs"][key],
+                                hobj["nvPairs"].get(key, None),
+                            ]
+                        }
                     )
 
     if mismatch_reasons != []:
@@ -434,7 +450,6 @@ def dcnm_vpc_pair_compare_vpc_pair_objects(self, wobj, hobj):
 
 
 def dcnm_vpc_pair_utils_compare_want_and_have(self, want):
-
     """
     This routine finds an object in self.have that matches the given information. If the given
     object already exist then it is not added to the object list to be created on
@@ -458,12 +473,10 @@ def dcnm_vpc_pair_utils_compare_want_and_have(self, want):
 
 
 def dcnm_vpc_pair_utils_get_delete_payload(self, elem):
-
     return {"peerOneId": elem["peerOneId"], "peerTwoId": elem["peerTwoId"]}
 
 
 def dcnm_vpc_pair_utils_get_delete_deploy_payload(self, elem):
-
     # VPC pairing uses switch level deploy to deploy the changes. This requires a 'fabric' name
     # and switches details. Fetch the 'fabric' from the 'elem' or 'self' and thr switches from
     # 'elem'
@@ -476,7 +489,6 @@ def dcnm_vpc_pair_utils_get_delete_deploy_payload(self, elem):
 
 
 def dcnm_vpc_pair_utils_get_vpc_pair_deploy_payload(self, elem):
-
     # VPC pairing uses switch level deploy to deploy the changes. This requires a 'fabric' name
     # and switches details. Fetch the 'fabric' from the 'elem' or 'self' and thr switches from
     # 'elem'
@@ -489,7 +501,6 @@ def dcnm_vpc_pair_utils_get_vpc_pair_deploy_payload(self, elem):
 
 
 def dcnm_vpc_pair_utils_delete_from_deploy_list(self, elem, deploy_list):
-
     """
     Routine to delete the given element from the deploy_list
 
@@ -508,8 +519,11 @@ def dcnm_vpc_pair_utils_delete_from_deploy_list(self, elem, deploy_list):
             del deploy_list[ind]
 
 
-def dcnm_vpc_pair_utils_process_delete_payloads(self):
+def dcnm_vpc_pair_utils_invalidate_sync_cache(self):
+    self._vpc_sync_status_cache = None
 
+
+def dcnm_vpc_pair_utils_process_delete_payloads(self):
     """
     Routine to push delete payloads to DCNM server. This routine implements required error checks and retry mechanisms to handle
     transient errors.
@@ -526,7 +540,6 @@ def dcnm_vpc_pair_utils_process_delete_payloads(self):
     deploy_flag = False
 
     for elem in self.diff_delete:
-
         path = self.paths["VPC_PAIR_DELETE_PATH"]
         path = path.format(elem["peerOneId"])
 
@@ -545,9 +558,7 @@ def dcnm_vpc_pair_utils_process_delete_payloads(self):
 
             if isinstance(resp["DATA"], str):
                 if "VPC Pair could not be deleted" in resp["DATA"]:
-                    sync_state = dcnm_vpc_pair_utils_get_sync_status(
-                        self, elem
-                    )
+                    sync_state = dcnm_vpc_pair_utils_get_sync_status(self, elem)
                     if sync_state == "In-Sync":
                         # No need to deploy for this pair
                         dcnm_vpc_pair_utils_delete_from_deploy_list(
@@ -567,7 +578,6 @@ def dcnm_vpc_pair_utils_process_delete_payloads(self):
 
 
 def dcnm_vpc_pair_utils_process_create_payloads(self):
-
     """
     Routine to push create payloads to DCNM server. This routine implements required error checks and retry mechanisms to handle
     transient errors.
@@ -585,7 +595,6 @@ def dcnm_vpc_pair_utils_process_create_payloads(self):
     path = self.paths["VPC_PAIR_CREATE_PATH"]
 
     for elem in self.diff_create:
-
         json_payload = json.dumps(elem)
         resp = dcnm_send(self.module, "POST", path, json_payload)
 
@@ -600,7 +609,6 @@ def dcnm_vpc_pair_utils_process_create_payloads(self):
 
 
 def dcnm_vpc_pair_utils_process_modify_payloads(self):
-
     """
     Routine to push modify payloads to DCNM server. This routine implements required error checks and retry mechanisms to handle
     transient errors.
@@ -616,7 +624,6 @@ def dcnm_vpc_pair_utils_process_modify_payloads(self):
     modify_flag = False
 
     for elem in self.diff_modify:
-
         path = self.paths["VPC_PAIR_UPDATE_PATH"]
 
         json_payload = json.dumps(elem)
@@ -637,7 +644,6 @@ def dcnm_vpc_pair_utils_process_modify_payloads(self):
 
 
 def dcnm_vpc_pair_utils_get_sync_status(self, elem):
-
     """
     Routine to get switch status information for a given fabric. This information can be processed to get
     the "In-Sync" status for the required switches.
@@ -651,21 +657,24 @@ def dcnm_vpc_pair_utils_get_sync_status(self, elem):
     """
 
     switches = [self.sn_ip[elem["peerOneId"]], self.sn_ip[elem["peerTwoId"]]]
-    resp = None
 
-    path = self.paths["VPC_PAIR_GET_SYNC_STATUS"].format(self.fabric)
+    if getattr(self, "_vpc_sync_status_cache", None) is None:
+        path = self.paths["VPC_PAIR_GET_SYNC_STATUS"].format(self.fabric)
+        resp = dcnm_send(self.module, "GET", path)
 
-    resp = dcnm_send(self.module, "GET", path)
+        if resp and (resp["RETURN_CODE"] != 200):
+            resp["CHANGED"] = self.changed_dict[0]
+            self.module.fail_json(msg=resp)
 
-    if resp and (resp["RETURN_CODE"] != 200):
-        resp["CHANGED"] = self.changed_dict[0]
-        self.module.fail_json(msg=resp)
+        self._vpc_sync_status_cache = resp
+
+    resp = self._vpc_sync_status_cache
 
     # Check if all switches reached the "In-Sync" state
-    for elem in resp["DATA"]:
-        if elem["ipAddress"] in switches:
-            if elem["ccStatus"] == "In-Sync":
-                switches.remove(elem["ipAddress"])
+    for switch_info in resp["DATA"]:
+        if switch_info["ipAddress"] in switches:
+            if switch_info["ccStatus"] == "In-Sync":
+                switches.remove(switch_info["ipAddress"])
     if switches:
         # There are some switches which were deployed during this run but did not reach "In-Sync" state. Retry
         # after a delay
@@ -675,7 +684,6 @@ def dcnm_vpc_pair_utils_get_sync_status(self, elem):
 
 
 def dcnm_vpc_pair_utils_save_config_changes(self):
-
     """
     Routine to save configuration changes for the given fabric.
 
@@ -701,7 +709,6 @@ def dcnm_vpc_pair_utils_save_config_changes(self):
 
 
 def dcnm_vpc_pair_utils_deploy_elem(self, elem):
-
     """
     Routine to deploy a VPC switch pair to DCNM server.
 
@@ -716,12 +723,10 @@ def dcnm_vpc_pair_utils_deploy_elem(self, elem):
     deploy_flag = False
 
     for peer in ["peerOneId", "peerTwoId"]:
-
-        path = self.paths["VPC_PAIR_DEPLOY_PATH"].format(
-            elem["fabric"], elem[peer]
-        )
+        path = self.paths["VPC_PAIR_DEPLOY_PATH"].format(elem["fabric"], elem[peer])
 
         resp = dcnm_send(self.module, "POST", path)
+        dcnm_vpc_pair_utils_invalidate_sync_cache(self)
 
         if resp != []:
             self.result["response"].append(resp)
@@ -736,7 +741,6 @@ def dcnm_vpc_pair_utils_deploy_elem(self, elem):
 
 
 def dcnm_vpc_pair_utils_process_deploy_payloads(self, deploy_list):
-
     """
     Routine to push deploy payloads to DCNM server. This routine implements required error checks and retry mechanisms to handle
     transient errors.
@@ -754,6 +758,7 @@ def dcnm_vpc_pair_utils_process_deploy_payloads(self, deploy_list):
     if deploy_list:
         # Perform a config-save first before config-deploy
         dcnm_vpc_pair_utils_save_config_changes(self)
+        dcnm_vpc_pair_utils_invalidate_sync_cache(self)
     else:
         return deploy_flag
 
@@ -766,6 +771,7 @@ def dcnm_vpc_pair_utils_process_deploy_payloads(self, deploy_list):
         for elem in deploy_list:
             retries = 0
             while retries < 10:
+                dcnm_vpc_pair_utils_invalidate_sync_cache(self)
                 sync_state = dcnm_vpc_pair_utils_get_sync_status(self, elem)
                 if sync_state != "In-Sync":
                     # Sometimes a deploy retry may be required. Retry deploy to see if things get normal
@@ -784,15 +790,11 @@ def dcnm_vpc_pair_utils_process_deploy_payloads(self, deploy_list):
 
 
 def dcnm_vpc_pair_utils_get_delete_list(self):
-
     del_list = []
     swid_list = self.sn_swid.values()
     for swid in swid_list:
-
         # Get the VPC inventory using the swid.
-        vpc_pair_info = dcnm_vpc_pair_utils_get_vpc_pair_info_from_dcnm(
-            self, swid
-        )
+        vpc_pair_info = dcnm_vpc_pair_utils_get_vpc_pair_info_from_dcnm(self, swid)
 
         if vpc_pair_info == []:
             continue
@@ -808,16 +810,13 @@ def dcnm_vpc_pair_utils_get_delete_list(self):
 
 
 def dcnm_vpc_pair_utils_get_all_filtered_vpc_pair_pairs(self):
-
     vpc_pair_list = []
 
     # If filters are provided, use the values to build the appropriate list.
     if self.vpc_pair_info == []:
         swid_list = self.sn_swid.values()
         for swid in swid_list:
-            vpc_pair_info = dcnm_vpc_pair_utils_get_vpc_pair_info_from_dcnm(
-                self, swid
-            )
+            vpc_pair_info = dcnm_vpc_pair_utils_get_vpc_pair_info_from_dcnm(self, swid)
 
             if vpc_pair_info == []:
                 continue
@@ -826,19 +825,14 @@ def dcnm_vpc_pair_utils_get_all_filtered_vpc_pair_pairs(self):
                 vpc_pair_list.append(vpc_pair_info)
     else:
         for elem in self.vpc_pair_info:
-
             if (elem.get("peerOneId", None) is not None) and (
                 self.ip_sn.get(elem["peerOneId"], None) is not None
             ):
-                swid = self.sn_swid.get(
-                    self.ip_sn.get(elem["peerOneId"], None), None
-                )
+                swid = self.sn_swid.get(self.ip_sn.get(elem["peerOneId"], None), None)
             elif (elem.get("peerTwoId", None) is not None) and (
                 self.ip_sn.get(elem["peerTwoId"], None) is not None
             ):
-                swid = self.sn_swid.get(
-                    self.ip_sn.get(elem["peerTwoId"], None), None
-                )
+                swid = self.sn_swid.get(self.ip_sn.get(elem["peerTwoId"], None), None)
             else:
                 swid = None
 
@@ -846,9 +840,7 @@ def dcnm_vpc_pair_utils_get_all_filtered_vpc_pair_pairs(self):
                 continue
 
             # Get the VPC inventory using the swid.
-            vpc_pair_info = dcnm_vpc_pair_utils_get_vpc_pair_info_from_dcnm(
-                self, swid
-            )
+            vpc_pair_info = dcnm_vpc_pair_utils_get_vpc_pair_info_from_dcnm(self, swid)
 
             if vpc_pair_info == []:
                 continue

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -1960,6 +1960,8 @@ class DcnmIntf:
         # performance bottleneck when managing many interfaces.
         self.intf_detail_cache = {}
         self.intf_detail_cached_snos = set()
+        self._replace_have_lookup = {}
+        self._replace_pb_input_lookup = {}
 
         self.changed_dict = [
             {
@@ -4375,6 +4377,17 @@ class DcnmIntf:
             t_e1 = str(t_e1).lower()
             t_e2 = str(t_e2).lower()
 
+        numeric_keys = ["LACP_PORT_PRIO"]
+        if k in numeric_keys:
+            # Controller responses may return numeric nvPairs as strings while
+            # desired state keeps them as integers. Normalize both sides so
+            # default-valued port-channel/vPC settings remain idempotent.
+            try:
+                t_e1 = int(t_e1)
+                t_e2 = int(t_e2)
+            except (TypeError, ValueError):
+                pass
+
         if t_e1 != t_e2:
 
             if (state == "replaced") or (state == "overridden"):
@@ -4594,14 +4607,19 @@ class DcnmIntf:
             intf_changed = False
 
             want.pop("deploy")
-            match_have = [
-                d
-                for d in self.have
-                if (
-                    (name.lower() == d["interfaces"][0]["ifName"].lower())
-                    and (sno == d["interfaces"][0]["serialNumber"])
+            if state == "replaced" and self._replace_have_lookup:
+                match_have = self._replace_have_lookup.get(
+                    (name.lower(), str(sno)), []
                 )
-            ]
+            else:
+                match_have = [
+                    d
+                    for d in self.have
+                    if (
+                        (name.lower() == d["interfaces"][0]["ifName"].lower())
+                        and (sno == d["interfaces"][0]["serialNumber"])
+                    )
+                ]
             if not match_have:
                 changed_dict = copy.deepcopy(want)
 
@@ -4625,15 +4643,20 @@ class DcnmIntf:
                     if "skipResourceCheck" in changed_dict.keys():
                         changed_dict.pop("skipResourceCheck")
 
-                    match_pb = [
-                        pb
-                        for pb in self.pb_input
-                        if (
-                            (name.lower() == pb["ifname"].lower())
-                            and (sno == pb["sno"])
-                            and (fabric == pb["fabric"])
+                    if state == "replaced" and self._replace_pb_input_lookup:
+                        match_pb = self._replace_pb_input_lookup.get(
+                            (name.lower(), str(sno), fabric), []
                         )
-                    ]
+                    else:
+                        match_pb = [
+                            pb
+                            for pb in self.pb_input
+                            if (
+                                (name.lower() == pb["ifname"].lower())
+                                and (sno == pb["sno"])
+                                and (fabric == pb["fabric"])
+                            )
+                        ]
                     pb_keys = list(match_pb[0].keys()) if match_pb else []
 
                     # First check if the policies are same for want and have. If they are different, we cannot compare
@@ -4842,6 +4865,8 @@ class DcnmIntf:
 
         for cfg in self.config:
             self.dcnm_intf_process_config(cfg)
+
+        self.dcnm_intf_build_replace_lookups()
 
         # Compare want[] and have[] and build a list of dicts containing interface information that
         # should be sent to DCNM for updation. The list can include information on interfaces which
@@ -5075,6 +5100,38 @@ class DcnmIntf:
             return False, self._pb_peer_member_lookup[have_ifname]
 
         return True, None
+
+    def dcnm_intf_build_replace_lookups(self):
+        """Pre-build lookup structures for replaced-state comparisons.
+
+        Replaces repeated linear scans of self.have and self.pb_input during
+        dcnm_intf_compare_want_and_have("replaced") with dictionary lookups.
+        """
+
+        self._replace_have_lookup = {}
+        self._replace_pb_input_lookup = {}
+
+        for item in self.have:
+            interfaces = item.get("interfaces") or []
+            if not interfaces:
+                continue
+
+            intf = interfaces[0]
+            ifname = intf.get("ifName")
+            sno = intf.get("serialNumber")
+
+            if ifname and sno:
+                key = (ifname.lower(), str(sno))
+                self._replace_have_lookup.setdefault(key, []).append(item)
+
+        for item in self.pb_input:
+            ifname = item.get("ifname")
+            sno = item.get("sno")
+            fabric = item.get("fabric")
+
+            if ifname and sno and fabric:
+                key = (ifname.lower(), str(sno), fabric)
+                self._replace_pb_input_lookup.setdefault(key, []).append(item)
 
     def dcnm_intf_process_config(self, cfg):
 
@@ -6409,6 +6466,15 @@ class DcnmIntf:
             index = 0
             if cfg.get("switch", None) is None:
                 continue
+
+            cfg_name = cfg.get("name", "")
+            need_vpc_pair_lookup = cfg.get("type") in ("vpc", "aa_fex")
+            if not need_vpc_pair_lookup and isinstance(cfg_name, str):
+                # Deleted/query-style entries may omit type. Keep supporting
+                # vPC names without paying the VPC lookup cost for every
+                # non-vPC interface in the playbook.
+                need_vpc_pair_lookup = cfg_name.lower().startswith("vpc")
+
             for sw_elem in cfg["switch"][:]:
                 if sw_elem in self.ip_sn or sw_elem in self.hn_sn:
                     addr_info = dcnm_get_ip_addr_info(
@@ -6416,8 +6482,12 @@ class DcnmIntf:
                     )
                     cfg["switch"][index] = addr_info
 
-                    # Check if the VPC serial number information is already present. If not fetch that
-                    if self.vpc_ip_sn.get(addr_info, None) is None:
+                    # Fetch VPC pair serials only for interface types that
+                    # actually need them.
+                    if (
+                        need_vpc_pair_lookup
+                        and self.vpc_ip_sn.get(addr_info, None) is None
+                    ):
                         sno = self.dcnm_intf_get_vpc_serial_number(addr_info)
                         if "~" in sno:
                             # This switch is part of VPC pair. Populate the VPC serial number DB

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -6502,7 +6502,7 @@ class DcnmIntf:
             if self.has_bulk_api:
                 # Bulk update API for bulk-capable controllers
                 path = self.paths["UPDATE_INTERFACE_BULK"]
-                
+
                 json_payload = json.dumps(self.diff_replace)
                 resp = dcnm_send(self.module, "POST", path, json_payload)
                 self.result["response"].append(resp)

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -6504,11 +6504,12 @@ class DcnmIntf:
                 path = self.paths["UPDATE_INTERFACE_BULK"]
                 
                 json_payload = json.dumps(self.diff_replace)
-                resp = self.dcnm_send_with_logging("POST", path, json_payload)
+                resp = dcnm_send(self.module, "POST", path, json_payload)
                 self.result["response"].append(resp)
 
+                # Accept both 200 (OK) and 207 (Multi-Status) for bulk operations
                 if (resp.get("MESSAGE") != "OK") or (
-                    resp.get("RETURN_CODE") != 200
+                    resp.get("RETURN_CODE") not in [200, 207]
                 ):
                     resp["CHANGED"] = self.changed_dict
                     self.module.fail_json(msg=resp)

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -4734,43 +4734,43 @@ class DcnmIntf:
                                             )
                                             if res == "dont_add":
                                                 break
-                                    if res == "copy_and_add":
-                                        want[k][0][ik][nk] = d[k][0][ik][
-                                            nk
-                                        ]
-                                        continue
-                                    if res == "merge_and_add":
-                                        merged_value = self.dcnm_intf_merge_want_and_have(
-                                            nk,
-                                            want[k][0][ik][nk],
-                                            d[k][0][ik][nk],
-                                        )
-                                        # A merged aggregate key can resolve back to the
-                                        # exact current controller value, for example
-                                        # CONF="" merged with CONF="no shutdown". Skip
-                                        # the update when the merged result is already in
-                                        # sync.
-                                        if (
-                                            self.dcnm_intf_compare_elements(
-                                                name,
-                                                sno,
-                                                fabric,
-                                                merged_value,
-                                                d[k][0][ik].get(nk),
-                                                nk,
-                                                "replaced",
-                                            )
-                                            == "dont_add"
-                                        ):
-                                            changed_dict[k][0][ik].pop(nk)
+                                        if res == "copy_and_add":
+                                            want[k][0][ik][nk] = d[k][0][ik][
+                                                nk
+                                            ]
                                             continue
-                                        want[k][0][ik][nk] = merged_value
-                                        changed_dict[k][0][ik][nk] = merged_value
-                                    if res != "dont_add":
-                                        action = "update"
-                                    else:
-                                        # Keys and values match. Remove from changed_dict
-                                        changed_dict[k][0][ik].pop(nk)
+                                        if res == "merge_and_add":
+                                            merged_value = self.dcnm_intf_merge_want_and_have(
+                                                nk,
+                                                want[k][0][ik][nk],
+                                                d[k][0][ik][nk],
+                                            )
+                                            # A merged aggregate key can resolve back to the
+                                            # exact current controller value, for example
+                                            # CONF="" merged with CONF="no shutdown". Skip
+                                            # the update when the merged result is already in
+                                            # sync.
+                                            if (
+                                                self.dcnm_intf_compare_elements(
+                                                    name,
+                                                    sno,
+                                                    fabric,
+                                                    merged_value,
+                                                    d[k][0][ik].get(nk),
+                                                    nk,
+                                                    "replaced",
+                                                )
+                                                == "dont_add"
+                                            ):
+                                                changed_dict[k][0][ik].pop(nk)
+                                                continue
+                                            want[k][0][ik][nk] = merged_value
+                                            changed_dict[k][0][ik][nk] = merged_value
+                                        if res != "dont_add":
+                                            action = "update"
+                                        else:
+                                            # Keys and values match. Remove from changed_dict
+                                            changed_dict[k][0][ik].pop(nk)
                                 else:
                                     # HAVE may have an entry with a list # of interfaces. Check all the
                                     # interface entries for a match.  Even if one entry matches do not

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -1900,6 +1900,7 @@ class DcnmIntf:
         11: {
             "VPC_SNO": "/rest/interface/vpcpair_serial_number?serial_number={}",
             "IF_WITH_SNO_IFNAME": "/rest/interface?serialNumber={}&ifName={}",
+            "IF_WITH_SNO": "/rest/interface?serialNumber={}",
             "IF_DETAIL_WITH_SNO": "/rest/interface/detail?serialNumber={}",
             "GLOBAL_IF": "/rest/globalInterface",
             "GLOBAL_IF_DEPLOY": "/rest/globalInterface/deploy",
@@ -1911,6 +1912,7 @@ class DcnmIntf:
         12: {
             "VPC_SNO": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/interface/vpcpair_serial_number?serial_number={}",
             "IF_WITH_SNO_IFNAME": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/interface?serialNumber={}&ifName={}",
+            "IF_WITH_SNO": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/interface?serialNumber={}",
             "IF_DETAIL_WITH_SNO": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/interface/detail?serialNumber={}",
             "GLOBAL_IF": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface",
             "GLOBAL_IF_DEPLOY": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface/deploy",
@@ -1951,6 +1953,13 @@ class DcnmIntf:
         self.ip_sn = {}
         self.hn_sn = {}
         self.monitoring = []
+
+        # Cache for bulk-fetched interface policy details.
+        # Keyed by (serialNumber, ifName_lower) -> interface detail dict.
+        # This avoids per-interface HTTP GETs which are the primary
+        # performance bottleneck when managing many interfaces.
+        self.intf_detail_cache = {}
+        self.intf_detail_cached_snos = set()
 
         self.changed_dict = [
             {
@@ -4070,6 +4079,66 @@ class DcnmIntf:
                             else:
                                 self.want.append(intf_payload)
 
+    def dcnm_intf_bulk_fetch_intf_info(self, serialNumber):
+        """Bulk-fetch all interface policy details for a switch and populate the cache.
+
+        Instead of making one HTTP GET per interface via IF_WITH_SNO_IFNAME,
+        this fetches ALL interfaces for a serial number in a single call and
+        caches the results.  Subsequent calls to dcnm_intf_get_intf_info()
+        will resolve from the cache in O(1) instead of making a network
+        round-trip.
+
+        Parameters:
+            serialNumber (str): The serial number of the switch. For VPC/AA_FEX
+                                combined serial numbers pass only one side.
+        """
+
+        sno = serialNumber.split("~")[0] if "~" in serialNumber else serialNumber
+
+        if sno in self.intf_detail_cached_snos:
+            return
+
+        path = self.paths["IF_WITH_SNO"].format(sno)
+
+        retry_count = 0
+        resp = []
+        while retry_count < 3:
+            retry_count += 1
+            resp = dcnm_send(self.module, "GET", path)
+
+            if resp == [] or (isinstance(resp, dict) and resp.get("RETURN_CODE") == 200):
+                break
+            time.sleep(1)
+
+        if (
+            resp
+            and isinstance(resp, dict)
+            and "DATA" in resp
+            and resp["DATA"]
+            and resp["RETURN_CODE"] == 200
+        ):
+            for item in resp["DATA"]:
+                # The bulk endpoint may group multiple interfaces under the
+                # same policy in a single DATA element.  We must iterate ALL
+                # interfaces in the group — not just [0] — and create a
+                # separate cache entry for each one that looks identical to
+                # what the individual endpoint would return (i.e. a single
+                # interface in the "interfaces" list).
+                for intf in item.get("interfaces", []):
+                    if_name = intf.get("ifName", "")
+                    if if_name:
+                        # Build a per-interface entry that mirrors the
+                        # individual-GET response structure.
+                        single_item = {}
+                        for key in item:
+                            if key != "interfaces":
+                                single_item[key] = item[key]
+                        single_item["interfaces"] = [intf]
+                        cache_key = (sno, if_name.lower())
+                        self.intf_detail_cache[cache_key] = single_item
+
+        self.intf_detail_cached_snos.add(sno)
+
     def dcnm_intf_get_intf_info(self, ifName, serialNumber, ifType):
 
         # For VPC and AA_FEX interfaces the serialNumber will be a combined one. But GET on interface cannot
@@ -4080,6 +4149,21 @@ class DcnmIntf:
         else:
             sno = serialNumber
 
+        # Check the bulk-fetched cache first to avoid a per-interface HTTP GET
+        cache_key = (sno, ifName.lower())
+        cached = self.intf_detail_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        # If we already bulk-fetched all interfaces for this serial number
+        # and this interface was not in the response, it does not exist on
+        # the controller.  Return empty without an additional HTTP call.
+        if sno in self.intf_detail_cached_snos:
+            return []
+
+        # No bulk fetch done for this serial number — fall back to
+        # individual GET (this path is taken when bulk pre-population
+        # was not triggered, e.g. for states other than overridden).
         path = self.paths["IF_WITH_SNO_IFNAME"].format(sno, ifName)
 
         retry_count = 0
@@ -4097,6 +4181,8 @@ class DcnmIntf:
             and resp["DATA"]
             and resp["RETURN_CODE"] == 200
         ):
+            # Store in cache so subsequent lookups for this interface are free
+            self.intf_detail_cache[cache_key] = resp["DATA"][0]
             return resp["DATA"][0]
         else:
             return []
@@ -4980,6 +5066,18 @@ class DcnmIntf:
 
         del_list = []
         defer_list = []
+
+        # Bulk pre-populate the interface detail cache for every switch
+        # present in have_all.  This replaces N per-interface HTTP GETs
+        # (inside dcnm_intf_get_intf_info) with at most S bulk GETs
+        # (one per unique serial number), dramatically speeding up the
+        # overridden diff computation for large interface counts.
+        prefetched_snos = set()
+        for h in self.have_all:
+            sno = h["serialNo"]
+            if sno not in prefetched_snos:
+                prefetched_snos.add(sno)
+                self.dcnm_intf_bulk_fetch_intf_info(sno)
 
         for have in self.have_all:
 

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -6069,14 +6069,17 @@ class DcnmIntf:
         resp = None
 
         path = self.paths["GLOBAL_IF_DEPLOY"]
-        index = -1
+        # Flatten all diff_delete_deploy sublists into a single list and
+        # send one POST instead of up to 9 separate calls (one per
+        # interface type).  The deploy endpoint only needs serialNumber,
+        # ifName, and fabricName — interface type grouping is irrelevant.
+        flat_delete_deploy = []
         for delem in self.diff_delete_deploy:
+            if delem:
+                flat_delete_deploy.extend(delem)
 
-            # index = index + 1
-            if delem == []:
-                continue
-
-            json_payload = json.dumps(delem)
+        if flat_delete_deploy:
+            json_payload = json.dumps(flat_delete_deploy)
 
             resp = dcnm_send(self.module, "POST", path, json_payload)
 
@@ -6197,10 +6200,14 @@ class DcnmIntf:
 
         resp = None
 
-        if self.diff_deploy:
-            # Do a second deploy. Sometimes even if interfaces are created, they are
-            # not being deployed. A second deploy solves the same. Don't worry about
-            # the return values
+        if self.diff_deploy and self.module.params["check_deploy"]:
+            # Safety re-deploy: only when check_deploy is True.
+            # Sometimes NDFC does not deploy all interfaces on the first
+            # attempt.  A second deploy covers those stragglers before
+            # the deployment-status polling loop below verifies In-Sync.
+            # When check_deploy is False (default), the extra round-trip
+            # is skipped because the caller does not require deployment
+            # verification anyway.
 
             resp = dcnm_send(self.module, "POST", path, json_payload)
 

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -1873,6 +1873,7 @@ import time
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.dcnm.plugins.module_utils.network.dcnm.dcnm import (
+    dcnm_get_bulk_api_support,
     dcnm_send,
     get_fabric_inventory_details,
     dcnm_get_ip_addr_info,
@@ -1917,6 +1918,7 @@ class DcnmIntf:
             "GLOBAL_IF": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface",
             "GLOBAL_IF_DEPLOY": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface/deploy",
             "INTERFACE": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/interface",
+            "UPDATE_INTERFACE_BULK": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/interface/modify",
             "IF_MARK_DELETE": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/interface/markdelete",
             "FABRIC_ACCESS_MODE": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{}/accessmode",
             "BREAKOUT": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/interface/breakout",
@@ -1981,6 +1983,9 @@ class DcnmIntf:
         ]
 
         self.dcnm_version = dcnm_version_supported(self.module)
+
+        # Check for bulk API support
+        self.has_bulk_api = dcnm_get_bulk_api_support(self.module)
 
         self.inventory_data = {}
         self.manageable = []
@@ -6492,21 +6497,40 @@ class DcnmIntf:
                 create = True
 
         # Update interfaces
-        path = self.paths["INTERFACE"]
-        for payload in self.diff_replace:
-            json_payload = json.dumps(payload)
+        # For bulk API support, use bulk update API. For other versions, use individual update API.
+        if self.diff_replace:
+            if self.has_bulk_api:
+                # Bulk update API for bulk-capable controllers
+                path = self.paths["UPDATE_INTERFACE_BULK"]
+                
+                json_payload = json.dumps(self.diff_replace)
+                resp = self.dcnm_send_with_logging("POST", path, json_payload)
+                self.result["response"].append(resp)
 
-            resp = dcnm_send(self.module, "PUT", path, json_payload)
-
-            self.result["response"].append(resp)
-
-            if (resp.get("MESSAGE") != "OK") or (
-                resp.get("RETURN_CODE") != 200
-            ):
-                resp["CHANGED"] = self.changed_dict
-                self.module.fail_json(msg=resp)
+                if (resp.get("MESSAGE") != "OK") or (
+                    resp.get("RETURN_CODE") != 200
+                ):
+                    resp["CHANGED"] = self.changed_dict
+                    self.module.fail_json(msg=resp)
+                else:
+                    replace = True
             else:
-                replace = True
+                # Individual update API for versions 11 and 12
+                path = self.paths["INTERFACE"]
+                for payload in self.diff_replace:
+                    json_payload = json.dumps(payload)
+
+                    resp = dcnm_send(self.module, "PUT", path, json_payload)
+
+                    self.result["response"].append(resp)
+
+                    if (resp.get("MESSAGE") != "OK") or (
+                        resp.get("RETURN_CODE") != 200
+                    ):
+                        resp["CHANGED"] = self.changed_dict
+                        self.module.fail_json(msg=resp)
+                    else:
+                        replace = True
 
         resp = None
 

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -6508,7 +6508,7 @@ class DcnmIntf:
                 self.result["response"].append(resp)
 
                 # Accept both 200 (OK) and 207 (Multi-Status) for bulk operations
-                if (resp.get("MESSAGE") != "OK") or (
+                if (resp.get("MESSAGE") not in ["OK", "Multi-Status"]) or (
                     resp.get("RETURN_CODE") not in [200, 207]
                 ):
                     resp["CHANGED"] = self.changed_dict

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -4625,6 +4625,17 @@ class DcnmIntf:
                     if "skipResourceCheck" in changed_dict.keys():
                         changed_dict.pop("skipResourceCheck")
 
+                    match_pb = [
+                        pb
+                        for pb in self.pb_input
+                        if (
+                            (name.lower() == pb["ifname"].lower())
+                            and (sno == pb["sno"])
+                            and (fabric == pb["fabric"])
+                        )
+                    ]
+                    pb_keys = list(match_pb[0].keys()) if match_pb else []
+
                     # First check if the policies are same for want and have. If they are different, we cannot compare
                     # the profiles because each profile will have different elements. As per PRD, if policies are different
                     # we should not merge the information. For now we will assume we will overwrite the same. Don't compare
@@ -4668,8 +4679,18 @@ class DcnmIntf:
                                     ]
 
                                     for key in keys_to_check:
-                                        # Remove the key from nv_keys only if it exists and is not present in 'have'
-                                        if key in nv_keys and d[k][index][ik].get(key, None) is None:
+                                        # Some GET payloads omit optional keys altogether. Keep comparing keys that were
+                                        # explicitly requested in the playbook so merged state can correct drift when
+                                        # the current payload is incomplete.
+                                        key_missing_in_have = all(
+                                            intf.get(ik, {}).get(key, None) is None
+                                            for intf in d[k]
+                                        )
+                                        if (
+                                            key in nv_keys
+                                            and key_missing_in_have
+                                            and self.keymap.get(key) not in pb_keys
+                                        ):
                                             nv_keys.remove(key)
 
                                     for nk in nv_keys:
@@ -4682,7 +4703,7 @@ class DcnmIntf:
                                                 sno,
                                                 fabric,
                                                 want[k][0][ik][nk],
-                                                d[k][index][ik][nk],
+                                                d[k][index][ik].get(nk),
                                                 nk,
                                                 state,
                                             )

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -1962,6 +1962,8 @@ class DcnmIntf:
         self.intf_detail_cached_snos = set()
         self._replace_have_lookup = {}
         self._replace_pb_input_lookup = {}
+        self.deferred_delete_member_defaults = []
+        self._deferred_delete_member_default_keys = set()
 
         self.changed_dict = [
             {
@@ -4732,27 +4734,43 @@ class DcnmIntf:
                                             )
                                             if res == "dont_add":
                                                 break
-                                        if res == "copy_and_add":
-                                            want[k][0][ik][nk] = d[k][0][ik][
-                                                nk
-                                            ]
-                                            continue
-                                        if res == "merge_and_add":
-                                            want[k][0][ik][
-                                                nk
-                                            ] = self.dcnm_intf_merge_want_and_have(
+                                    if res == "copy_and_add":
+                                        want[k][0][ik][nk] = d[k][0][ik][
+                                            nk
+                                        ]
+                                        continue
+                                    if res == "merge_and_add":
+                                        merged_value = self.dcnm_intf_merge_want_and_have(
+                                            nk,
+                                            want[k][0][ik][nk],
+                                            d[k][0][ik][nk],
+                                        )
+                                        # A merged aggregate key can resolve back to the
+                                        # exact current controller value, for example
+                                        # CONF="" merged with CONF="no shutdown". Skip
+                                        # the update when the merged result is already in
+                                        # sync.
+                                        if (
+                                            self.dcnm_intf_compare_elements(
+                                                name,
+                                                sno,
+                                                fabric,
+                                                merged_value,
+                                                d[k][0][ik].get(nk),
                                                 nk,
-                                                want[k][0][ik][nk],
-                                                d[k][0][ik][nk],
+                                                "replaced",
                                             )
-                                            changed_dict[k][0][ik][nk] = want[
-                                                k
-                                            ][0][ik][nk]
-                                        if res != "dont_add":
-                                            action = "update"
-                                        else:
-                                            # Keys and values match. Remove from changed_dict
+                                            == "dont_add"
+                                        ):
                                             changed_dict[k][0][ik].pop(nk)
+                                            continue
+                                        want[k][0][ik][nk] = merged_value
+                                        changed_dict[k][0][ik][nk] = merged_value
+                                    if res != "dont_add":
+                                        action = "update"
+                                    else:
+                                        # Keys and values match. Remove from changed_dict
+                                        changed_dict[k][0][ik].pop(nk)
                                 else:
                                     # HAVE may have an entry with a list # of interfaces. Check all the
                                     # interface entries for a match.  Even if one entry matches do not
@@ -4773,12 +4791,25 @@ class DcnmIntf:
                                         want[k][0][ik] = d[k][0][ik]
                                         continue
                                     if res == "merge_and_add":
-                                        want[k][0][
-                                            ik
-                                        ] = self.dcnm_intf_merge_want_and_have(
+                                        merged_value = self.dcnm_intf_merge_want_and_have(
                                             ik, want[k][0][ik], d[k][0][ik]
                                         )
-                                        changed_dict[k][0][ik] = want[k][0][ik]
+                                        if (
+                                            self.dcnm_intf_compare_elements(
+                                                name,
+                                                sno,
+                                                fabric,
+                                                merged_value,
+                                                d[k][0][ik],
+                                                ik,
+                                                "replaced",
+                                            )
+                                            == "dont_add"
+                                        ):
+                                            changed_dict[k][0].pop(ik)
+                                            continue
+                                        want[k][0][ik] = merged_value
+                                        changed_dict[k][0][ik] = merged_value
                                     if res != "dont_add":
                                         action = "update"
                                     else:
@@ -4901,60 +4932,134 @@ class DcnmIntf:
         intf_nv = intf.get("interfaces")[0].get("nvPairs")
         have_nv = have.get("interfaces")[0].get("nvPairs")
 
+        def normalize_default_compare_value(key, value):
+            if value is None:
+                value = ""
+
+            sval = str(value).strip().lower()
+
+            if key == "CONF":
+                # NDFC may omit explicit default CLI from stored interface
+                # intent while the module's generated default payload includes
+                # "no shutdown". Treat them as equivalent for deleted-state
+                # idempotence checks.
+                if sval in ("", "no shutdown"):
+                    return ""
+                return sval
+
+            if key in (
+                "ADMIN_STATE",
+                "BPDUGUARD_ENABLED",
+                "PORTTYPE_FAST_ENABLED",
+            ):
+                if sval in ("true", "yes"):
+                    return "true"
+                if sval in ("false", "no"):
+                    return "false"
+                return sval
+
+            return sval
+
         if (
-            str(intf_nv.get("SPEED")).lower()
-            != str(have_nv.get("SPEED")).lower()
+            normalize_default_compare_value("SPEED", intf_nv.get("SPEED"))
+            != normalize_default_compare_value("SPEED", have_nv.get("SPEED"))
         ):
             return "DCNM_INTF_NOT_MATCH"
-        if intf_nv.get("DESC") != have_nv.get("DESC"):
-            return "DCNM_INTF_NOT_MATCH"
-        if intf_nv.get("CONF") != have_nv.get("CONF"):
-            return "DCNM_INTF_NOT_MATCH"
         if (
-            str(intf_nv.get("ADMIN_STATE")).lower()
-            != str(have_nv.get("ADMIN_STATE")).lower()
+            normalize_default_compare_value("DESC", intf_nv.get("DESC"))
+            != normalize_default_compare_value("DESC", have_nv.get("DESC"))
         ):
             return "DCNM_INTF_NOT_MATCH"
-        if str(intf_nv.get("MTU")).lower() != str(have_nv.get("MTU")).lower():
+        if (
+            normalize_default_compare_value("CONF", intf_nv.get("CONF"))
+            != normalize_default_compare_value("CONF", have_nv.get("CONF"))
+        ):
+            return "DCNM_INTF_NOT_MATCH"
+        if (
+            normalize_default_compare_value(
+                "ADMIN_STATE", intf_nv.get("ADMIN_STATE")
+            )
+            != normalize_default_compare_value(
+                "ADMIN_STATE", have_nv.get("ADMIN_STATE")
+            )
+        ):
+            return "DCNM_INTF_NOT_MATCH"
+        if (
+            normalize_default_compare_value("MTU", intf_nv.get("MTU"))
+            != normalize_default_compare_value("MTU", have_nv.get("MTU"))
+        ):
             return "DCNM_INTF_NOT_MATCH"
 
         if intf.get("policy") == "int_routed_host":
-            if intf_nv.get("INTF_VRF") != have_nv.get("INTF_VRF"):
-                return "DCNM_INTF_NOT_MATCH"
             if (
-                str(intf_nv.get("IP")).lower()
-                != str(have_nv.get("IP")).lower()
+                normalize_default_compare_value(
+                    "INTF_VRF", intf_nv.get("INTF_VRF")
+                )
+                != normalize_default_compare_value(
+                    "INTF_VRF", have_nv.get("INTF_VRF")
+                )
             ):
                 return "DCNM_INTF_NOT_MATCH"
             if (
-                str(intf_nv.get("PREFIX")).lower()
-                != str(have_nv.get("PREFIX")).lower()
+                normalize_default_compare_value("IP", intf_nv.get("IP"))
+                != normalize_default_compare_value("IP", have_nv.get("IP"))
             ):
                 return "DCNM_INTF_NOT_MATCH"
             if (
-                str(intf_nv.get("ROUTING_TAG")).lower()
-                != str(have_nv.get("ROUTING_TAG")).lower()
+                normalize_default_compare_value(
+                    "PREFIX", intf_nv.get("PREFIX")
+                )
+                != normalize_default_compare_value(
+                    "PREFIX", have_nv.get("PREFIX")
+                )
+            ):
+                return "DCNM_INTF_NOT_MATCH"
+            if (
+                normalize_default_compare_value(
+                    "ROUTING_TAG", intf_nv.get("ROUTING_TAG")
+                )
+                != normalize_default_compare_value(
+                    "ROUTING_TAG", have_nv.get("ROUTING_TAG")
+                )
             ):
                 return "DCNM_INTF_NOT_MATCH"
         elif intf.get("policy") == "int_trunk_host":
             if (
-                str(intf_nv.get("BPDUGUARD_ENABLED")).lower()
-                != str(have_nv.get("BPDUGUARD_ENABLED")).lower()
+                normalize_default_compare_value(
+                    "BPDUGUARD_ENABLED", intf_nv.get("BPDUGUARD_ENABLED")
+                )
+                != normalize_default_compare_value(
+                    "BPDUGUARD_ENABLED", have_nv.get("BPDUGUARD_ENABLED")
+                )
             ):
                 return "DCNM_INTF_NOT_MATCH"
             if (
-                str(intf_nv.get("PORTTYPE_FAST_ENABLED")).lower()
-                != str(have_nv.get("PORTTYPE_FAST_ENABLED")).lower()
+                normalize_default_compare_value(
+                    "PORTTYPE_FAST_ENABLED",
+                    intf_nv.get("PORTTYPE_FAST_ENABLED"),
+                )
+                != normalize_default_compare_value(
+                    "PORTTYPE_FAST_ENABLED",
+                    have_nv.get("PORTTYPE_FAST_ENABLED"),
+                )
             ):
                 return "DCNM_INTF_NOT_MATCH"
             if (
-                str(intf_nv.get("ALLOWED_VLANS")).lower()
-                != str(have_nv.get("ALLOWED_VLANS")).lower()
+                normalize_default_compare_value(
+                    "ALLOWED_VLANS", intf_nv.get("ALLOWED_VLANS")
+                )
+                != normalize_default_compare_value(
+                    "ALLOWED_VLANS", have_nv.get("ALLOWED_VLANS")
+                )
             ):
                 return "DCNM_INTF_NOT_MATCH"
             if (
-                str(intf_nv.get("NATIVE_VLAN")).lower()
-                != str(have_nv.get("NATIVE_VLAN")).lower()
+                normalize_default_compare_value(
+                    "NATIVE_VLAN", intf_nv.get("NATIVE_VLAN")
+                )
+                != normalize_default_compare_value(
+                    "NATIVE_VLAN", have_nv.get("NATIVE_VLAN")
+                )
             ):
                 return "DCNM_INTF_NOT_MATCH"
         return "DCNM_INTF_MATCH"
@@ -5045,6 +5150,8 @@ class DcnmIntf:
         self._pb_override_lookup = set()
         self._pb_member_lookup = {}
         self._pb_peer_member_lookup = {}
+        self._pb_deleted_parent_lookup = set()
+        self._pb_deleted_peer_parent_lookup = set()
 
         for item in self.pb_input:
             ifname = item.get("ifname")
@@ -5056,6 +5163,7 @@ class DcnmIntf:
 
             # Members (port-channel style)
             if item.get("members"):
+                self._pb_deleted_parent_lookup.add((ifname, sno))
                 for mem in item["members"]:
                     expanded_name = self.dcnm_intf_get_if_name(mem, "eth")[0]
                     if expanded_name not in self._pb_member_lookup:
@@ -5064,6 +5172,8 @@ class DcnmIntf:
 
             # Peer members (VPC style)
             elif item.get("peer1_members") or item.get("peer2_members"):
+                self._pb_deleted_parent_lookup.add((ifname, sno))
+                self._pb_deleted_peer_parent_lookup.add(ifname)
                 for mem in (item.get("peer1_members") or []):
                     expanded_name = self.dcnm_intf_get_if_name(mem, "eth")[0]
                     self._pb_peer_member_lookup[expanded_name] = ifname
@@ -5089,6 +5199,13 @@ class DcnmIntf:
         # Check 2: Check if this interface is a member of a port-channel.
         if have_ifname in self._pb_member_lookup:
             for parent_ifname, parent_sno in self._pb_member_lookup[have_ifname]:
+                # Deleted state needs one extra reconciliation pass for member
+                # Ethernet defaults after parent PC/vPC delete. Execution order
+                # already sends parent deletes before member replacements, so it
+                # is safe to queue the member default in the same module run.
+                if self.module.params["state"] == "deleted":
+                    if (parent_ifname, parent_sno) in self._pb_deleted_parent_lookup:
+                        return True, parent_ifname
                 # Compare have serial_number to item serial_number return if they don't match
                 if have_sno != parent_sno:
                     return True, None
@@ -5097,9 +5214,171 @@ class DcnmIntf:
 
         # Check 3: Check if this interface is a peer member of a VPC.
         if have_ifname in self._pb_peer_member_lookup:
+            if self.module.params["state"] == "deleted":
+                parent_ifname = self._pb_peer_member_lookup[have_ifname]
+                if parent_ifname in self._pb_deleted_peer_parent_lookup:
+                    return True, parent_ifname
             return False, self._pb_peer_member_lookup[have_ifname]
 
         return True, None
+
+    def dcnm_intf_parent_present_in_have_all(self, parent_ifname, parent_sno=None):
+
+        parent_ifname = parent_ifname.lower()
+
+        for have in self.have_all:
+            if have.get("ifName", "").lower() != parent_ifname:
+                continue
+            if parent_sno is None or have.get("serialNo") == parent_sno:
+                return True
+
+        return False
+
+    def dcnm_intf_should_defer_deleted_member_default(self, have, parent_ifname):
+
+        if self.module.params["state"] != "deleted" or not parent_ifname:
+            return False
+
+        if not hasattr(self, "_pb_member_lookup"):
+            self.dcnm_intf_build_can_be_replaced_lookups()
+
+        have_ifname = have["ifName"]
+
+        if have_ifname in self._pb_member_lookup:
+            for candidate_parent_ifname, candidate_parent_sno in self._pb_member_lookup[have_ifname]:
+                if candidate_parent_ifname != parent_ifname:
+                    continue
+                if (
+                    (candidate_parent_ifname, candidate_parent_sno)
+                    in self._pb_deleted_parent_lookup
+                ):
+                    return self.dcnm_intf_parent_present_in_have_all(
+                        candidate_parent_ifname, candidate_parent_sno
+                    )
+
+        if have_ifname in self._pb_peer_member_lookup:
+            if (
+                self._pb_peer_member_lookup[have_ifname] == parent_ifname
+                and parent_ifname in self._pb_deleted_peer_parent_lookup
+            ):
+                return self.dcnm_intf_parent_present_in_have_all(parent_ifname)
+
+        return False
+
+    def dcnm_intf_defer_deleted_member_default(
+        self, ifname, sno, fabric, deploy, parent_ifname
+    ):
+
+        key = (str(sno), ifname.lower(), parent_ifname.lower())
+
+        if key in self._deferred_delete_member_default_keys:
+            return
+
+        self._deferred_delete_member_default_keys.add(key)
+        self.deferred_delete_member_defaults.append(
+            {
+                "ifName": ifname,
+                "serialNumber": str(sno),
+                "fabricName": fabric,
+                "deploy": deploy,
+                "parentIfName": parent_ifname,
+            }
+        )
+
+    def dcnm_intf_refresh_deferred_deleted_member_defaults(self):
+
+        if not self.deferred_delete_member_defaults:
+            return
+
+        affected_snos = sorted(
+            {
+                item["serialNumber"].split("~")[0]
+                for item in self.deferred_delete_member_defaults
+            }
+        )
+
+        max_retries = 10
+        retry_sleep = 2
+
+        for retry in range(max_retries):
+            # Refresh only the impacted switches so same-run parent deletes are
+            # reflected before we calculate default replacements for former members.
+            self.have_all = [
+                have
+                for have in self.have_all
+                if have.get("serialNo") not in affected_snos
+            ]
+
+            for sno in affected_snos:
+                stale_cache_keys = [
+                    key for key in self.intf_detail_cache if key[0] == sno
+                ]
+                for key in stale_cache_keys:
+                    self.intf_detail_cache.pop(key, None)
+                self.intf_detail_cached_snos.discard(sno)
+                self.dcnm_intf_get_have_all_with_sno(sno)
+                self.dcnm_intf_bulk_fetch_intf_info(sno)
+
+            parent_still_present = False
+            for item in self.deferred_delete_member_defaults:
+                if self.dcnm_intf_parent_present_in_have_all(item["parentIfName"]):
+                    parent_still_present = True
+                    break
+
+            if not parent_still_present:
+                break
+
+            if retry < (max_retries - 1):
+                time.sleep(retry_sleep)
+
+        for item in self.deferred_delete_member_defaults:
+            intf = {
+                "ifName": item["ifName"],
+                "serialNumber": item["serialNumber"],
+                "interfaceType": "INTERFACE_ETHERNET",
+            }
+
+            match_have = [
+                have
+                for have in self.have_all
+                if (
+                    (intf["ifName"].lower() == have["ifName"].lower())
+                    and (intf["serialNumber"] == have["serialNo"])
+                )
+            ]
+
+            if not match_have:
+                continue
+
+            if str(match_have[0].get("isPhysical")).lower() != "true":
+                continue
+
+            uelem = self.dcnm_intf_get_default_eth_payload(
+                intf["ifName"], intf["serialNumber"], item["fabricName"]
+            )
+            intf_payload = self.dcnm_intf_get_intf_info_from_dcnm(intf)
+
+            if intf_payload != []:
+                if (
+                    self.dcnm_compare_default_payload(uelem, intf_payload)
+                    == "DCNM_INTF_MATCH"
+                ):
+                    continue
+
+            self.dcnm_intf_merge_intf_info(uelem, self.diff_replace)
+            self.changed_dict[0]["replaced"].append(copy.deepcopy(uelem))
+
+            if str(item.get("deploy", "true")).lower() == "true":
+                delem = {
+                    "serialNumber": intf["serialNumber"],
+                    "ifName": intf["ifName"],
+                    "fabricName": item["fabricName"],
+                }
+                self.diff_deploy.append(delem)
+                self.changed_dict[0]["deploy"].append(copy.deepcopy(delem))
+
+        self.deferred_delete_member_defaults = []
+        self._deferred_delete_member_default_keys = set()
 
     def dcnm_intf_build_replace_lookups(self):
         """Pre-build lookup structures for replaced-state comparisons.
@@ -5590,6 +5869,8 @@ class DcnmIntf:
         self.diff_delete_deploy = [[], [], [], [], [], [], [], [], []]
         self.diff_deploy = []
         self.diff_replace = []
+        self.deferred_delete_member_defaults = []
+        self._deferred_delete_member_default_keys = set()
 
         if self.config == []:
             # Now that we have all the interface information we can run override
@@ -5752,6 +6033,17 @@ class DcnmIntf:
                                         match_have
                                     )
                                     if rc is True:
+                                        if self.dcnm_intf_should_defer_deleted_member_default(
+                                            match_have, iface
+                                        ):
+                                            self.dcnm_intf_defer_deleted_member_default(
+                                                intf["ifName"],
+                                                intf["serialNumber"],
+                                                self.fabric,
+                                                cfg.get("deploy", "true"),
+                                                iface,
+                                            )
+                                            continue
                                         self.dcnm_intf_merge_intf_info(
                                             uelem, self.diff_replace
                                         )
@@ -6181,6 +6473,9 @@ class DcnmIntf:
             self.result["response"].append(resp)
 
         resp = None
+
+        if self.deferred_delete_member_defaults:
+            self.dcnm_intf_refresh_deferred_deleted_member_defaults()
 
         # Add Breakout creation from self.want_breakout
         path = self.paths["BREAKOUT"]

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -4242,6 +4242,22 @@ class DcnmIntf:
         if not self.want:
             return
 
+        # Bulk-prefetch interface details for all switches referenced in self.want.
+        # This populates the cache so that individual dcnm_intf_get_intf_info calls
+        # below become O(1) lookups instead of individual HTTP GETs.
+        prefetched_snos = set()
+        for elem in self.want:
+            for intf in elem["interfaces"]:
+                sno = intf.get("serialNumber", "")
+                if not sno:
+                    continue
+                # For VPC/AA_FEX, use the first part of the ~-separated pair
+                if intf.get("interfaceType") in ("INTERFACE_VPC", "AA_FEX"):
+                    sno = sno.split("~")[0]
+                if sno not in prefetched_snos:
+                    prefetched_snos.add(sno)
+                    self.dcnm_intf_bulk_fetch_intf_info(sno)
+
         # We have all the requested interface config in self.want. Interfaces are grouped together based on the
         # policy string and the interface name in a single dict entry.
 
@@ -4965,44 +4981,78 @@ class DcnmIntf:
 
         return eth_payload
 
-    def dcnm_intf_can_be_replaced(self, have):
+    def dcnm_intf_build_can_be_replaced_lookups(self):
+        """Pre-build lookup structures for O(1) dcnm_intf_can_be_replaced() checks.
+
+        Replaces the O(n) linear scan of self.pb_input that was performed
+        for every interface in have_all, turning the overall O(n*m) cost
+        into O(n+m).
+
+        Populates three instance-level lookup structures:
+          _pb_override_lookup  – set of (ifname, sno) for overridden-state match
+          _pb_member_lookup    – dict mapping expanded member ifName
+                                 to list of (parent_ifname, parent_sno)
+          _pb_peer_member_lookup – dict mapping expanded peer member ifName
+                                   to parent_ifname
+        """
+
+        self._pb_override_lookup = set()
+        self._pb_member_lookup = {}
+        self._pb_peer_member_lookup = {}
 
         for item in self.pb_input:
-            # For overridden state, we will not touch anything that is present in incoming config,
-            # because those interfaces will anyway be modified in the current run
-            # Must check both interface name AND serial number to ensure we're comparing the same
-            # interface on the same switch (not just the same interface name on different switches)
-            if (self.module.params["state"] == "overridden") and (
-                item["ifname"] == have["ifName"]
-            ) and (
-                item.get("sno") == have.get("serialNo")
-            ):
-                return False, item["ifname"]
+            ifname = item.get("ifname")
+            sno = item.get("sno")
+
+            # Override entries: (ifname, sno) pairs for direct match
+            if ifname and sno:
+                self._pb_override_lookup.add((ifname, sno))
+
+            # Members (port-channel style)
             if item.get("members"):
-                if have["ifName"] in [
-                    self.dcnm_intf_get_if_name(mem, "eth")[0]
-                    for mem in item["members"]
-                ]:
-                    # Compare have serial_number to item serial_number return if they don't match
-                    if have.get('serialNo') != item.get('sno'):
-                        return True, None
-                    else:
-                        return False, item["ifname"]
-            elif (item.get("peer1_members")) or (item.get("peer2_members")):
-                if (
-                    have["ifName"]
-                    in [
-                        self.dcnm_intf_get_if_name(mem, "eth")[0]
-                        for mem in item["peer1_members"]
-                    ]
-                ) or (
-                    have["ifName"]
-                    in [
-                        self.dcnm_intf_get_if_name(mem, "eth")[0]
-                        for mem in item["peer2_members"]
-                    ]
-                ):
-                    return False, item["ifname"]
+                for mem in item["members"]:
+                    expanded_name = self.dcnm_intf_get_if_name(mem, "eth")[0]
+                    if expanded_name not in self._pb_member_lookup:
+                        self._pb_member_lookup[expanded_name] = []
+                    self._pb_member_lookup[expanded_name].append((ifname, sno))
+
+            # Peer members (VPC style)
+            elif item.get("peer1_members") or item.get("peer2_members"):
+                for mem in (item.get("peer1_members") or []):
+                    expanded_name = self.dcnm_intf_get_if_name(mem, "eth")[0]
+                    self._pb_peer_member_lookup[expanded_name] = ifname
+                for mem in (item.get("peer2_members") or []):
+                    expanded_name = self.dcnm_intf_get_if_name(mem, "eth")[0]
+                    self._pb_peer_member_lookup[expanded_name] = ifname
+
+    def dcnm_intf_can_be_replaced(self, have):
+
+        # Build lookup structures on first call if not already built
+        if not hasattr(self, '_pb_member_lookup'):
+            self.dcnm_intf_build_can_be_replaced_lookups()
+
+        have_ifname = have["ifName"]
+        have_sno = have.get("serialNo")
+
+        # Check 1: For overridden state, skip interfaces present in incoming
+        # config — they will be modified in the current run anyway.
+        if self.module.params["state"] == "overridden":
+            if (have_ifname, have_sno) in self._pb_override_lookup:
+                return False, have_ifname
+
+        # Check 2: Check if this interface is a member of a port-channel.
+        if have_ifname in self._pb_member_lookup:
+            for parent_ifname, parent_sno in self._pb_member_lookup[have_ifname]:
+                # Compare have serial_number to item serial_number return if they don't match
+                if have_sno != parent_sno:
+                    return True, None
+                else:
+                    return False, parent_ifname
+
+        # Check 3: Check if this interface is a peer member of a VPC.
+        if have_ifname in self._pb_peer_member_lookup:
+            return False, self._pb_peer_member_lookup[have_ifname]
+
         return True, None
 
     def dcnm_intf_process_config(self, cfg):
@@ -5078,6 +5128,20 @@ class DcnmIntf:
             if sno not in prefetched_snos:
                 prefetched_snos.add(sno)
                 self.dcnm_intf_bulk_fetch_intf_info(sno)
+
+        # Pre-build O(1) lookup structures to replace linear scans.
+        # want_set:  replaces match_want list comprehension over self.want
+        # can_be_replaced lookups: replaces linear scan of self.pb_input
+        want_set = set()
+        for d in self.want:
+            intf0 = d["interfaces"][0]
+            want_set.add((
+                intf0["ifName"].lower(),
+                str(intf0["serialNumber"]),
+                intf0["fabricName"],
+            ))
+
+        self.dcnm_intf_build_can_be_replaced_lookups()
 
         for have in self.have_all:
 
@@ -5191,21 +5255,10 @@ class DcnmIntf:
                     # If yes, ignore the interface, because configuration from want will be applied anyway.
                     # This ensures that Ethernet interfaces removed from the playbook config are reset to default,
                     # while those still in the config are left alone to be configured later.
-                    match_want = [
-                        d
-                        for d in self.want
-                        if (
-                            (
-                                name.lower()
-                                == d["interfaces"][0]["ifName"].lower()
-                            )
-                            and (str(sno) == str(d["interfaces"][0]["serialNumber"]))
-                            and (fabric == d["interfaces"][0]["fabricName"])
-                        )
-                    ]
+                    in_want = (name.lower(), str(sno), fabric) in want_set
 
                     # Only default/reset this interface if it's NOT in the playbook config
-                    if not match_want:
+                    if not in_want:
                         # Before defaulting ethernet interfaces, check if they are
                         # member of any port-channel. If so, do not default that
                         rc, intf = self.dcnm_intf_can_be_replaced(have)
@@ -5383,19 +5436,8 @@ class DcnmIntf:
                     # Check if this interface is present in want. If yes, ignore the interface, because all
                     # configuration from want will be added to create anyway
 
-                    match_want = [
-                        d
-                        for d in self.want
-                        if (
-                            (
-                                name.lower()
-                                == d["interfaces"][0]["ifName"].lower()
-                            )
-                            and (sno == d["interfaces"][0]["serialNumber"])
-                            and (fabric == d["interfaces"][0]["fabricName"])
-                        )
-                    ]
-                    if not match_want:
+                    in_want = (name.lower(), str(sno), fabric) in want_set
+                    if not in_want:
 
                         delem = {}
 
@@ -5476,6 +5518,35 @@ class DcnmIntf:
             # and delete or reset interfaces.
             self.dcnm_intf_get_diff_overridden(self.config)
         elif self.config:
+            # Bulk pre-populate the interface detail cache for every switch
+            # referenced in the config.  This replaces N per-interface HTTP
+            # GETs (inside dcnm_intf_get_intf_info) with at most S bulk GETs
+            # (one per unique serial number), dramatically speeding up the
+            # deleted diff computation for large interface counts.
+            prefetched_snos = set()
+            for cfg in self.config:
+                if cfg.get("name") is None:
+                    continue
+                switches = cfg.get("switch", None)
+                if switches is None:
+                    switches = list(self.ip_sn.keys())
+                for sw in switches:
+                    if sw in self.ip_sn:
+                        sno = self.ip_sn[sw]
+                        if sno not in prefetched_snos:
+                            prefetched_snos.add(sno)
+                            self.dcnm_intf_bulk_fetch_intf_info(sno)
+                    # VPC/AA_FEX interfaces use vpc_ip_sn for lookups.
+                    # Pre-split the combined serial (e.g. "FOX~SAL") and
+                    # prefetch the first part so those lookups hit cache.
+                    name_lower = cfg.get("name", "")[0:3].lower()
+                    if name_lower == "vpc" and sw in self.vpc_ip_sn:
+                        vpc_sno = self.vpc_ip_sn[sw]
+                        vpc_sno_first = vpc_sno.split("~")[0] if "~" in vpc_sno else vpc_sno
+                        if vpc_sno_first not in prefetched_snos:
+                            prefetched_snos.add(vpc_sno_first)
+                            self.dcnm_intf_bulk_fetch_intf_info(vpc_sno_first)
+
             for cfg in self.config:
                 if cfg.get("name", None) is not None and cfg.get("type") == "breakout":
                     self.dcnm_intf_get_have_all(cfg["switch"][0])

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -2616,9 +2616,9 @@ class DcnmIntf:
         sub_prof_spec = dict(
             mode=dict(required=True, type="str"),
             vlan=dict(required=True, type="int", range_min=2, range_max=3967),
-            ipv4_addr=dict(required=True, type="ipv4"),
+            ipv4_addr=dict(required=False, type="ipv4"),
             ipv4_mask_len=dict(
-                required=True, type="int", range_min=8, range_max=31
+                required=False, type="int", range_min=8, range_max=31
             ),
             int_vrf=dict(type="str", default="default"),
             ipv6_addr=dict(type="ipv6", default=""),
@@ -3428,11 +3428,13 @@ class DcnmIntf:
         intf["interfaces"][0]["nvPairs"]["INTF_VRF"] = delem[profile][
             "int_vrf"
         ]
-        intf["interfaces"][0]["nvPairs"]["IP"] = str(
-            delem[profile]["ipv4_addr"]
+        ipv4_addr = delem[profile].get("ipv4_addr")
+        ipv4_mask_len = delem[profile].get("ipv4_mask_len")
+        intf["interfaces"][0]["nvPairs"]["IP"] = (
+            "" if ipv4_addr is None else str(ipv4_addr)
         )
-        intf["interfaces"][0]["nvPairs"]["PREFIX"] = str(
-            delem[profile]["ipv4_mask_len"]
+        intf["interfaces"][0]["nvPairs"]["PREFIX"] = (
+            "" if ipv4_mask_len is None else str(ipv4_mask_len)
         )
         intf["interfaces"][0]["nvPairs"]["ROUTING_TAG"] = delem[profile][
             "route_tag"

--- a/plugins/modules/dcnm_inventory.py
+++ b/plugins/modules/dcnm_inventory.py
@@ -513,6 +513,7 @@ class DcnmInventory:
         self.check_mode = False
         self.validated = []
         self.have_create = []
+        self.have_create_by_ip = {}
         self.want_create = []
         self.want_create_poap = []
         self.want_create_rma = []
@@ -524,6 +525,9 @@ class DcnmInventory:
         self.nd_prefix = "/appcenter/cisco/ndfc/api/v1/lan-fabric"
         self.switch_snos = []
         self.diff_input_format = []
+        self.poap_inventory = []
+        self.poap_inventory_by_serial = {}
+        self.poap_inventory_loaded = False
 
         self.result = dict(changed=False, diff=[], response=[])
 
@@ -536,34 +540,15 @@ class DcnmInventory:
 
         self.nd = True if self.controller_version >= 12 else False
 
-    def discover_poap_params(self, poap_upd, poap):
-
-        for have_c in self.have_create:
-            # Idempotence - Bootstrap but already in inventory
-            if poap_upd["serialNumber"]:
-                if (
-                    poap_upd["ipAddress"] == have_c["switches"][0]["ipaddr"]
-                    and poap_upd["serialNumber"] == have_c["switches"][0]["serialNumber"]
-                ):
-                    return {}
-
-            # Idempotence - Preprovision but already in inventory
-            if poap_upd["preprovisionSerial"] and not poap_upd["serialNumber"]:
-                if (
-                    poap_upd["ipAddress"] == have_c["switches"][0]["ipaddr"]
-                ):
-                    return {}
-
-        # Preprovision case
-        if poap_upd["preprovisionSerial"] and not poap_upd["serialNumber"]:
-            return poap_upd
+    def get_poap_inventory(self):
+        if self.poap_inventory_loaded:
+            return self.poap_inventory_by_serial
 
         method = "GET"
-        path = "/rest/control/fabrics/{0}/inventory/poap".format(
-            self.fabric
-        )
+        path = "/rest/control/fabrics/{0}/inventory/poap".format(self.fabric)
         if self.nd:
             path = self.nd_prefix + path
+
         response = dcnm_send(self.module, method, path)
         self.result["response"].append(response)
         fail, self.result["changed"] = self.handle_response(response, "query")
@@ -571,29 +556,56 @@ class DcnmInventory:
         if fail:
             self.module.fail_json(msg=response)
 
-        if "DATA" in response:
-            for resp in response["DATA"]:
-                if (resp["serialNumber"] == poap["serial_number"]):
-                    if self.nd:
-                        poap_upd.update({"publicKey": resp["publicKey"]})
-                        poap_upd.update({"reAdd": resp["reAdd"]})
-                        poap_upd.update({"fingerprint": resp["fingerprint"]})
-                        if poap["image_policy"]:
-                            poap_upd.update({"imagePolicy": poap["image_policy"]})
-                        else:
-                            poap_upd.update({"imagePolicy": ""})
-                        # poap_upd.update({"role": "leaf"})
-                    return poap_upd
+        self.poap_inventory = response.get("DATA") or []
+        self.poap_inventory_by_serial = {}
+        for poap_switch in self.poap_inventory:
+            serial_number = poap_switch.get("serialNumber")
+            if serial_number:
+                self.poap_inventory_by_serial[serial_number] = poap_switch
+
+        self.poap_inventory_loaded = True
+        return self.poap_inventory_by_serial
+
+    def discover_poap_params(self, poap_upd, poap):
+        have_c = self.have_create_by_ip.get(poap_upd["ipAddress"])
+        if have_c is not None:
+            # Idempotence - Bootstrap but already in inventory
+            if (
+                poap_upd["serialNumber"]
+                and poap_upd["serialNumber"] == have_c["switches"][0]["serialNumber"]
+            ):
+                return {}
+
+            # Idempotence - Preprovision but already in inventory
+            if poap_upd["preprovisionSerial"] and not poap_upd["serialNumber"]:
+                return {}
+
+        # Preprovision case
+        if poap_upd["preprovisionSerial"] and not poap_upd["serialNumber"]:
+            return poap_upd
+
+        resp = self.get_poap_inventory().get(poap["serial_number"])
+        if resp is not None:
+            if self.nd:
+                poap_upd.update({"publicKey": resp["publicKey"]})
+                poap_upd.update({"reAdd": resp["reAdd"]})
+                poap_upd.update({"fingerprint": resp["fingerprint"]})
+                if poap["image_policy"]:
+                    poap_upd.update({"imagePolicy": poap["image_policy"]})
+                else:
+                    poap_upd.update({"imagePolicy": ""})
+                # poap_upd.update({"role": "leaf"})
+            return poap_upd
 
         msg = "Specified switch {0}".format(
-            poap["serial_number"] + " is not listed in bootstrap devices or inventory. " +
-            "If you are trying to pre-provision, please set " +
-            "'preprovision_serial' instead of 'serial_number' in your task")
+            poap["serial_number"] + " is not listed in bootstrap devices or inventory. "
+            + "If you are trying to pre-provision, please set "
+            + "'preprovision_serial' instead of 'serial_number' in your task"
+        )
 
         self.module.fail_json(msg)
 
     def update_poap_params(self, inv, poap):
-
         s_ip = "None"
         if inv["seed_ip"]:
             s_ip = dcnm_get_ip_addr_info(self.module, inv["seed_ip"], None, None)
@@ -627,31 +639,16 @@ class DcnmInventory:
         return poap_upd
 
     def discover_rma_params(self, rma_upd, rma):
-
-        method = "GET"
-        path = "/rest/control/fabrics/{0}/inventory/poap".format(
-            self.fabric
-        )
-        if self.nd:
-            path = self.nd_prefix + path
-        response = dcnm_send(self.module, method, path)
-        self.result["response"].append(response)
-        fail, self.result["changed"] = self.handle_response(response, "query")
-
-        if fail:
-            self.module.fail_json(msg=response)
-
-        if "DATA" in response:
-            for resp in response["DATA"]:
-                if (resp["serialNumber"] == rma["serial_number"]):
-                    if self.nd:
-                        rma_upd.update({"publicKey": resp["publicKey"]})
-                        if rma["image_policy"]:
-                            rma_upd.update({"imagePolicy": rma["image_policy"]})
-                        else:
-                            rma_upd.update({"imagePolicy": ""})
-                    rma_upd.update({"hostname": list(self.hn_sn.keys())[list(self.hn_sn.values()).index(rma_upd["oldSerialNumber"])]})
-                    return rma_upd
+        resp = self.get_poap_inventory().get(rma["serial_number"])
+        if resp is not None:
+            if self.nd:
+                rma_upd.update({"publicKey": resp["publicKey"]})
+                if rma["image_policy"]:
+                    rma_upd.update({"imagePolicy": rma["image_policy"]})
+                else:
+                    rma_upd.update({"imagePolicy": ""})
+            rma_upd.update({"hostname": list(self.hn_sn.keys())[list(self.hn_sn.values()).index(rma_upd["oldSerialNumber"])]})
+            return rma_upd
 
         msg = "Specified switch {0}".format(
             rma["serial_number"] + " is not listed in bootstrap devices.")
@@ -659,7 +656,6 @@ class DcnmInventory:
         self.module.fail_json(msg)
 
     def update_rma_params(self, inv, rma):
-
         s_ip = "None"
         if inv["seed_ip"]:
             s_ip = dcnm_get_ip_addr_info(self.module, inv["seed_ip"], None, None)
@@ -691,7 +687,6 @@ class DcnmInventory:
         return rma_upd
 
     def update_discover_params(self, inv):
-
         # with the inv parameters perform the test-reachability (discover)
         method = "POST"
         path = "/rest/control/fabrics/{0}/inventory/test-reachability".format(
@@ -717,7 +712,6 @@ class DcnmInventory:
             return 0
 
     def update_create_params(self, inv):
-
         s_ip = "None"
         if inv["seed_ip"]:
             s_ip = dcnm_get_ip_addr_info(self.module, inv["seed_ip"], None, None)
@@ -758,14 +752,64 @@ class DcnmInventory:
                 "discoveryCredForLan": "true",
             }
 
-            resp = self.update_discover_params(inv_upd)
+            # V2-OPTIMIZATION: Skip expensive POST /test-reachability for switches
+            # already discovered and present in have_create. Build the want entry
+            # directly from the existing have data instead.
+            # This eliminates ~50 API calls (each 2-3s) in the no-op scenario.
+            have_match = self.have_create_by_ip.get(s_ip)
 
-            inv_upd["switches"] = resp
+            if have_match is not None:
+                # Switch already exists in fabric — reuse have data as the
+                # discovery response, no need to call test-reachability
+                inv_upd["switches"] = have_match["switches"]
+            else:
+                # Switch is new — must call test-reachability to discover it
+                resp = self.update_discover_params(inv_upd)
+                inv_upd["switches"] = resp
 
         return inv_upd
 
-    def get_have(self):
+    def iter_create_switches(self, create):
+        for switch in create.get("switches", []):
+            if switch:
+                yield switch
 
+    def group_diff_create_by_role(self):
+        grouped_create = []
+        grouped_by_key = {}
+
+        for create in self.diff_create:
+            group_fields = copy.deepcopy(create)
+            group_fields.pop("seedIP", None)
+            group_fields.pop("switches", None)
+            group_key = tuple(sorted(group_fields.items()))
+
+            if group_key not in grouped_by_key:
+                grouped_create.append(copy.deepcopy(create))
+                grouped_by_key[group_key] = grouped_create[-1]
+            else:
+                grouped = grouped_by_key[group_key]
+                grouped["switches"].extend(copy.deepcopy(create.get("switches", [])))
+
+            current_group = grouped_by_key[group_key]
+            seed_ips = []
+            for switch in self.iter_create_switches(current_group):
+                ip_addr = switch.get("ipaddr")
+                if ip_addr and ip_addr not in seed_ips:
+                    seed_ips.append(ip_addr)
+
+            if (
+                not seed_ips
+                and current_group.get("seedIP")
+                and current_group["seedIP"] != "None"
+            ):
+                seed_ips.append(current_group["seedIP"])
+
+            current_group["seedIP"] = ",".join(seed_ips)
+
+        self.diff_create = grouped_create
+
+    def get_have(self):
         method = "GET"
         path = "/rest/control/fabrics/{0}/inventory/switchesByFabric".format(self.fabric)
         if self.nd:
@@ -792,6 +836,7 @@ class DcnmInventory:
             return
 
         have_switch = []
+        have_switch_by_ip = {}
 
         for inv in inv_objects["DATA"]:
             get_switch = {}
@@ -811,11 +856,12 @@ class DcnmInventory:
             switchlst.append(get_switch)
             switchdict["switches"] = switchlst
             have_switch.append(switchdict)
+            have_switch_by_ip[get_switch["ipaddr"]] = switchdict
 
         self.have_create = have_switch
+        self.have_create_by_ip = have_switch_by_ip
 
     def get_want(self):
-
         want_create = []
         want_create_poap = []
         want_create_rma = []
@@ -843,7 +889,6 @@ class DcnmInventory:
         self.want_create_rma = want_create_rma
 
     def get_diff_override(self):
-
         self.get_diff_replace()
         self.get_diff_replace_delete()
 
@@ -854,14 +899,12 @@ class DcnmInventory:
         self.diff_delete = diff_delete
 
     def get_diff_replace(self):
-
         self.get_diff_merge()
         diff_create = self.diff_create
 
         self.diff_create = diff_create
 
     def get_diff_replace_delete(self):
-
         diff_delete = []
 
         def check_have_c_in_want_list(have_c):
@@ -914,7 +957,6 @@ class DcnmInventory:
         self.diff_delete = diff_delete
 
     def get_diff_delete(self):
-
         diff_delete = []
         if self.config:
             for want_c in self.want_create:
@@ -930,7 +972,6 @@ class DcnmInventory:
         self.diff_delete = diff_delete
 
     def get_diff_merge(self):
-
         diff_create = []
 
         for want_c in self.want_create:
@@ -965,7 +1006,6 @@ class DcnmInventory:
                     == have_c["switches"][0]["sysName"]
                     and want_c["role"] == have_c["switches"][0]["role"]
                 ):
-
                     found = True
 
                     if have_c["switches"][0]["mode"] == "Migration":
@@ -979,7 +1019,7 @@ class DcnmInventory:
                         # Assign Role
                         self.assign_role()
 
-                        for check in range(1, 300):
+                        for check in range(1, 120):
                             if not self.all_switches_ok():
                                 time.sleep(5)
                             else:
@@ -1006,13 +1046,10 @@ class DcnmInventory:
         query_poap = self.params["query_poap"]
 
         if query_poap is True and state != "query":
-            msg = "query_poap: should not be set 'True' for state {0}".format(
-                state
-            )
+            msg = "query_poap: should not be set 'True' for state {0}".format(state)
             self.module.fail_json(msg=msg)
 
         if state == "merged" or state == "overridden":
-
             inv_spec = dict(
                 seed_ip=dict(required=True, type="str"),
                 auth_proto=dict(
@@ -1156,7 +1193,6 @@ class DcnmInventory:
                     self.module.fail_json(msg=msg)
 
         elif state == "deleted":
-
             inv_spec = dict(seed_ip=dict(required=True, type="str"))
 
             msg = None
@@ -1186,7 +1222,6 @@ class DcnmInventory:
                     self.module.fail_json(msg=msg)
 
         else:
-
             inv_spec = dict(
                 seed_ip=dict(type="str"),
                 role=dict(
@@ -1226,7 +1261,6 @@ class DcnmInventory:
                     self.module.fail_json(msg=msg)
 
     def import_switches(self):
-
         method = "POST"
         path = "/rest/control/fabrics/{0}".format(self.fabric)
         if self.nd:
@@ -1247,7 +1281,6 @@ class DcnmInventory:
                     self.failure(import_response)
 
     def rediscover_switch(self, serial_num):
-
         method = "POST"
         path = "/rest/control/fabrics/{0}/inventory/rediscover/{1}".format(
             self.fabric, serial_num
@@ -1261,10 +1294,15 @@ class DcnmInventory:
             self.failure(response)
 
     def rediscover_all_switches(self):
+        # V2 OPTIMIZATION: Use set-based lookups instead of O(N*M) nested loops
+        # throughout the polling sections. This converts O(N*M) per poll iteration
+        # to O(N) where N = number of switches in fabric inventory.
 
         # Get Fabric Inventory Details
         method = "GET"
-        path = "/rest/control/fabrics/{0}/inventory/switchesByFabric".format(self.fabric)
+        path = "/rest/control/fabrics/{0}/inventory/switchesByFabric".format(
+            self.fabric
+        )
         if self.nd:
             path = self.nd_prefix + path
         get_inv = dcnm_send(self.module, method, path)
@@ -1278,6 +1316,9 @@ class DcnmInventory:
         if not get_inv.get("DATA"):
             return
 
+        # V2: Pre-build a set for O(1) serial number lookups
+        target_snos = set(self.switch_snos)
+
         def ready_to_continue(inv_data):
             # This is a helper function to wait for certain events to complete
             # as part of the switch rediscovery step before moving on.
@@ -1286,12 +1327,15 @@ class DcnmInventory:
             # First check migration mode.  Switches will enter migration mode
             # even if the GRFIELD_DEBUG_FLAG is enabled so this needs to be
             # checked first.
+            # V2: O(N) with set lookup instead of O(N*M) nested loop
             for switch in inv_data.get("DATA"):
-                for snos in self.switch_snos:
-                    if snos == switch["serialNumber"] and switch["mode"].lower() == "migration":
-                        # At least one switch is still in migration mode
-                        # so not ready to continue
-                        return False
+                if (
+                    switch["serialNumber"] in target_snos
+                    and switch["mode"].lower() == "migration"
+                ):
+                    # At least one switch is still in migration mode
+                    # so not ready to continue
+                    return False
 
             # Check # 2
             # The fabric has a setting to prevent reload for greenfield
@@ -1305,26 +1349,23 @@ class DcnmInventory:
             # the switch will show up as managable for a period of time before it
             # moves to unmanagable but we need to wait for this to allow enough time
             # for the reload to completed.
+            # V2: O(N) with set lookup instead of O(N*M) nested loop
             for switch in inv_data.get("DATA"):
-                for snos in self.switch_snos:
-                    if snos == switch["serialNumber"] and not switch["managable"]:
-                        # We found our first switch that changed state to
-                        # unmanageable because it's reloading.  Now we can
-                        # continue
-                        return True
+                if switch["serialNumber"] in target_snos and not switch["managable"]:
+                    # We found our first switch that changed state to
+                    # unmanageable because it's reloading.  Now we can
+                    # continue
+                    return True
 
             # We still have not detected a switch is reloading so return False
             return False
 
         def switches_managable(inv_data):
-            managable = True
+            # V2: O(N) with set lookup instead of O(N*M) nested loop
             for switch in inv_data["DATA"]:
-                for snos in self.switch_snos:
-                    if snos == switch["serialNumber"] and not switch["managable"]:
-                        managable = False
-                        break
-
-            return managable
+                if switch["serialNumber"] in target_snos and not switch["managable"]:
+                    return False
+            return True
 
         # It can take a while to rediscover switches if they are reloading
         # while importing them into the fabric.
@@ -1338,7 +1379,6 @@ class DcnmInventory:
                 all_brownfield_switches = False
 
         while attempt < total_attempts and not all_brownfield_switches and self.switch_snos:
-
             # Don't error out.  We might miss the status change so worst case
             # scenario is that we loop 300 times and then bail out.
             if attempt == 1:
@@ -1374,17 +1414,26 @@ class DcnmInventory:
 
             break
 
+        # V2: Collect all matching serials first, then rediscover
+        # Uses set lookup O(N) instead of O(N*M) nested loop
+        rediscover_serials = []
         for inv in get_inv["DATA"]:
-            for snos in self.switch_snos:
-                if snos == inv["serialNumber"]:
-                    self.rediscover_switch(inv["serialNumber"])
+            if inv["serialNumber"] in target_snos:
+                rediscover_serials.append(inv["serialNumber"])
+
+        for sn in rediscover_serials:
+            self.rediscover_switch(sn)
 
     def all_switches_ok(self):
-
         all_ok = True
+        # V2: Pre-build set for O(1) lookups instead of O(N*M) nested loop
+        target_snos = set(self.switch_snos)
+
         # Get Fabric Inventory Details
         method = "GET"
-        path = "/rest/control/fabrics/{0}/inventory/switchesByFabric".format(self.fabric)
+        path = "/rest/control/fabrics/{0}/inventory/switchesByFabric".format(
+            self.fabric
+        )
         if self.nd:
             path = self.nd_prefix + path
         get_inv = dcnm_send(self.module, method, path)
@@ -1395,11 +1444,11 @@ class DcnmInventory:
             msg2 = "Unable to find inventories under fabric: {0}".format(self.fabric)
             self.module.fail_json(msg=msg1 if missing_fabric else msg2)
 
+        # V2: Single pass O(N) with set lookup instead of O(N*M) nested loop
         for inv in get_inv["DATA"]:
-            for snos in self.switch_snos:
-                if snos == inv["serialNumber"] and inv["status"] != "ok":
-                    all_ok = False
-                    self.rediscover_switch(inv["serialNumber"])
+            if inv["serialNumber"] in target_snos and inv["status"] != "ok":
+                all_ok = False
+                self.rediscover_switch(inv["serialNumber"])
 
         # If the switches added through discovery itself has issues, then there is no
         # point in checking rma switch status, so return false here.
@@ -1417,7 +1466,6 @@ class DcnmInventory:
         return all_ok
 
     def set_lancred_switch(self, set_lan):
-
         method = "POST"
         path = "/fm/fmrest/lanConfig/saveSwitchCredentials"
         if self.nd:
@@ -1430,7 +1478,6 @@ class DcnmInventory:
             self.failure(response)
 
     def lancred_all_switches(self):
-
         # Get Fabric Inventory Details
         method = "GET"
         path = "/fm/fmrest/lanConfig/getLanSwitchCredentials"
@@ -1450,26 +1497,31 @@ class DcnmInventory:
         if not get_lan.get("DATA"):
             return
 
+        # V2: Build IP-to-lancred dict for O(1) lookup instead of O(N*M) nested loop
+        lan_by_ip = {}
+        for lan in get_lan["DATA"]:
+            if not lan["switchDbID"]:
+                msg = "Unable to SWITCHDBID using getLanSwitchCredentials under fabric: {0}".format(
+                    self.fabric
+                )
+                self.module.fail_json(msg=msg)
+            lan_by_ip[lan["ipAddress"]] = lan
+
         for create in self.want_create:
-            for lan in get_lan["DATA"]:
-                if not lan["switchDbID"]:
-                    msg = "Unable to SWITCHDBID using getLanSwitchCredentials under fabric: {0}".format(
-                        self.fabric
-                    )
-                    self.module.fail_json(msg=msg)
-                if lan["ipAddress"] == create["switches"][0]["ipaddr"]:
-                    set_lan = {
-                        "switchIds": lan["switchDbID"],
-                        "userName": create["username"],
-                        "password": create["password"],
-                        "v3Protocol": "0",
-                    }
-                    # TODO: Remove this check later.. should work on ND but does not for some reason
-                    if not self.nd:
-                        self.set_lancred_switch(set_lan)
+            ip = create["switches"][0]["ipaddr"]
+            if ip in lan_by_ip:
+                lan = lan_by_ip[ip]
+                set_lan = {
+                    "switchIds": lan["switchDbID"],
+                    "userName": create["username"],
+                    "password": create["password"],
+                    "v3Protocol": "0",
+                }
+                # TODO: Remove this check later.. should work on ND but does not for some reason
+                if not self.nd:
+                    self.set_lancred_switch(set_lan)
 
     def assign_role(self):
-
         method = "GET"
         path = "/rest/control/fabrics/{0}/inventory/switchesByFabric".format(self.fabric)
         if self.nd:
@@ -1485,73 +1537,85 @@ class DcnmInventory:
         if not get_role.get("DATA"):
             return
 
-        for create in self.diff_create:
-            for role in get_role["DATA"]:
-                if not role["switchDbID"]:
-                    msg = "Unable to get SWITCHDBID using getLanSwitchCredentials under fabric: {0}".format(
-                        self.fabric
-                    )
-                    self.module.fail_json(msg=msg)
-                if not role.get("serialNumber"):
-                    msg = "Unable to get serial number using getLanSwitchCredentials under fabric: {0}".format(
-                        self.fabric
-                    )
-                    self.module.fail_json(msg=msg)
-                if role["ipAddress"] == create["switches"][0]["ipaddr"]:
-                    method = "PUT"
-                    path = "/fm/fmrest/topology/role/{0}?newRole={1}".format(
-                        role["switchDbID"], create["role"].replace("_", "%20")
-                    )
-                    data = None
-                    if self.nd:
-                        method = "POST"
-                        path = f"{self.nd_prefix}/rest/control/switches/roles"
-                        data = json.dumps(
-                            [
-                                {
-                                    "serialNumber": role["serialNumber"],
-                                    "role": create["role"].replace("_", " "),
-                                }
-                            ]
-                        )
-                    response = dcnm_send(self.module, method, path, data)
-                    self.result["response"].append(response)
-                    fail, self.result["changed"] = self.handle_response(
-                        response, "create"
-                    )
-                    if fail:
-                        self.failure(response)
+        # V2: Build IP-to-inventory dict for O(1) lookups instead of O(N*M) nested loops
+        inv_by_ip = {}
+        for role in get_role["DATA"]:
+            if not role["switchDbID"]:
+                msg = "Unable to get SWITCHDBID using getLanSwitchCredentials under fabric: {0}".format(
+                    self.fabric
+                )
+                self.module.fail_json(msg=msg)
+            if not role.get("serialNumber"):
+                msg = "Unable to get serial number using getLanSwitchCredentials under fabric: {0}".format(
+                    self.fabric
+                )
+                self.module.fail_json(msg=msg)
+            inv_by_ip[role["ipAddress"]] = role
 
-        for create in self.want_create_poap:
-            for role in get_role["DATA"]:
-                if not role["switchDbID"]:
-                    msg = "Unable to get SWITCHDBID using getLanSwitchCredentials under fabric: {0}".format(
-                        self.fabric
-                    )
-                    self.module.fail_json(msg=msg)
-                if not role.get("serialNumber"):
-                    msg = "Unable to get serial number using getLanSwitchCredentials under fabric: {0}".format(
-                        self.fabric
-                    )
-                    self.module.fail_json(msg=msg)
-                if role["ipAddress"] == create["ipAddress"]:
-                    method = "PUT"
-                    path = "/fm/fmrest/topology/role/{0}?newRole={1}".format(
-                        role["switchDbID"], create["role"].replace("_", "%20")
-                    )
-                    data = None
-                    if self.nd:
-                        method = "POST"
-                        path = f"{self.nd_prefix}/rest/control/switches/roles"
-                        data = json.dumps(
-                            [
-                                {
-                                    "serialNumber": role["serialNumber"],
-                                    "role": create["role"].replace("_", " "),
-                                }
-                            ]
+        if self.nd:
+            # V2: Batch all role assignments into a single POST for ND
+            # The /rest/control/switches/roles API accepts an array
+            batch_roles = []
+            for create in self.diff_create:
+                for switch in self.iter_create_switches(create):
+                    ip = switch["ipaddr"]
+                    if ip in inv_by_ip:
+                        role_data = inv_by_ip[ip]
+                        batch_roles.append(
+                            {
+                                "serialNumber": role_data["serialNumber"],
+                                "role": create["role"].replace("_", " "),
+                            }
                         )
-                    response = dcnm_send(self.module, method, path, data)
+            for create in self.want_create_poap:
+                ip = create["ipAddress"]
+                if ip in inv_by_ip:
+                    role_data = inv_by_ip[ip]
+                    batch_roles.append(
+                        {
+                            "serialNumber": role_data["serialNumber"],
+                            "role": create["role"].replace("_", " "),
+                        }
+                    )
+
+            if batch_roles:
+                nd_method = "POST"
+                nd_path = f"{self.nd_prefix}/rest/control/switches/roles"
+                response = dcnm_send(
+                    self.module, nd_method, nd_path, json.dumps(batch_roles)
+                )
+                self.result["response"].append(response)
+                fail, self.result["changed"] = self.handle_response(response, "create")
+                if fail:
+                    self.failure(response)
+        else:
+            # Non-ND (DCNM): per-switch PUT with dict lookup
+            for create in self.diff_create:
+                for switch in self.iter_create_switches(create):
+                    ip = switch["ipaddr"]
+                    if ip in inv_by_ip:
+                        role_data = inv_by_ip[ip]
+                        put_method = "PUT"
+                        put_path = "/fm/fmrest/topology/role/{0}?newRole={1}".format(
+                            role_data["switchDbID"], create["role"].replace("_", "%20")
+                        )
+                        response = dcnm_send(self.module, put_method, put_path)
+                        self.result["response"].append(response)
+                        fail, self.result["changed"] = self.handle_response(
+                            response, "create"
+                        )
+                        if fail:
+                            self.failure(response)
+
+            for create in self.want_create_poap:
+                ip = create["ipAddress"]
+                if ip in inv_by_ip:
+                    role_data = inv_by_ip[ip]
+                    put_method = "PUT"
+                    put_path = "/fm/fmrest/topology/role/{0}?newRole={1}".format(
+                        role_data["switchDbID"], create["role"].replace("_", "%20")
+                    )
+                    response = dcnm_send(self.module, put_method, put_path)
                     self.result["response"].append(response)
                     fail, self.result["changed"] = self.handle_response(
                         response, "create"
@@ -1560,9 +1624,9 @@ class DcnmInventory:
                         self.failure(response)
 
     def config_save(self):
-
         success = False
-        no_of_tries = 3
+        # V2: 10 retries x 60s = 10min max instead of 3 retries x 600s = 20min max
+        no_of_tries = 10
 
         # NDFC/DCNM return error when we config-save a fabric with just Pre-provisioned switches.
         if not self.want_create:
@@ -1600,7 +1664,6 @@ class DcnmInventory:
                 self.failure(response)
 
             if response["RETURN_CODE"] != 200:
-
                 # Get Fabric Errors
                 method = "GET"
                 path = "/rest/control/fabrics/{0}/errors".format(fabric_id)
@@ -1622,10 +1685,10 @@ class DcnmInventory:
                 break
 
             if not success and x in range(0, no_of_tries - 1):
-                time.sleep(600)
+                # V2: 60s retry interval instead of 600s (10min)
+                time.sleep(60)
 
     def config_deploy(self):
-
         # config-deploy
         method = "POST"
         path = "/rest/control/fabrics/{0}".format(self.fabric)
@@ -1644,7 +1707,6 @@ class DcnmInventory:
                 self.failure(response)
 
     def delete_switch(self):
-
         if self.diff_delete:
             method = "DELETE"
             for sn in self.diff_delete:
@@ -1659,12 +1721,13 @@ class DcnmInventory:
                     self.failure(response)
 
     def get_diff_query(self):
-
         query = []
         query_poap = self.params["query_poap"]
 
         method = "GET"
-        path = "/rest/control/fabrics/{0}/inventory/switchesByFabric".format(self.fabric)
+        path = "/rest/control/fabrics/{0}/inventory/switchesByFabric".format(
+            self.fabric
+        )
         if self.nd:
             path = self.nd_prefix + path
         inv_objects = dcnm_send(self.module, method, path)
@@ -1737,7 +1800,6 @@ class DcnmInventory:
         self.query = query
 
     def swap_serial(self, poap):
-
         method = "POST"
         swap_path = "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{0}/swapSN/{1}/{2}".format(
                     self.fabric, poap["preprovisionSerial"], poap["serialNumber"]
@@ -1750,9 +1812,7 @@ class DcnmInventory:
             self.failure(response)
 
         method = "GET"
-        path = "/rest/control/fabrics/{0}/inventory/poap".format(
-            self.fabric
-        )
+        path = "/rest/control/fabrics/{0}/inventory/poap".format(self.fabric)
         if self.nd:
             path = self.nd_prefix + path
         response = dcnm_send(self.module, method, path)
@@ -1764,21 +1824,20 @@ class DcnmInventory:
 
         if "DATA" in response:
             for resp in response["DATA"]:
-                if (resp["serialNumber"] == poap["serialNumber"]):
+                if resp["serialNumber"] == poap["serialNumber"]:
                     resp.update({"password": poap["password"]})
                     resp.update({"discoveryAuthProtocol": "0"})
                     resp.pop("seedSwitchFlag")
                     return resp
 
         msg = "Specified switch {0}".format(
-            poap["serial_number"] + " is not listed in bootstrap devices or inventory. " +
-            "If you are trying to pre-provision, please set " +
-            "'preprovision_serial' instead of 'serial_number' in your task")
+            poap["serial_number"] + " is not listed in bootstrap devices or inventory. "
+            + "If you are trying to pre-provision, please set "
+            + "'preprovision_serial' instead of 'serial_number' in your task")
 
         self.module.fail_json(msg=response)
 
     def poap_config(self):
-
         method = "POST"
         path = "/rest/control/fabrics/{0}/inventory/poap".format(self.fabric)
         if self.nd:
@@ -1803,7 +1862,6 @@ class DcnmInventory:
                 self.failure(response)
 
     def rma_config(self):
-
         method = "POST"
         path = "/rest/control/fabrics/{0}/rma".format(self.fabric)
         if self.nd:
@@ -1818,7 +1876,6 @@ class DcnmInventory:
                     self.failure(response)
 
     def handle_response(self, res, op):
-
         fail = False
         changed = True
 
@@ -1843,7 +1900,6 @@ class DcnmInventory:
         return fail, changed
 
     def failure(self, resp):
-
         res = copy.deepcopy(resp)
 
         if not resp.get("DATA"):
@@ -1869,8 +1925,7 @@ class DcnmInventory:
 
         # Add created switches to the diff
         for create in self.diff_create:
-            if create.get("switches") and len(create["switches"]) > 0:
-                switch = create["switches"][0]
+            for switch in self.iter_create_switches(create):
                 item = {
                     "ip_address": switch.get("ipaddr"),
                     "serial_number": switch.get("serialNumber"),
@@ -1878,15 +1933,12 @@ class DcnmInventory:
                     "platform": switch.get("platform"),
                     "version": switch.get("version"),
                     "hostname": switch.get("sysName"),
-                    "preserve_config": create.get("preserveConfig", False)
+                    "preserve_config": create.get("preserveConfig", False),
                 }
                 create_list.append(item)
 
         if create_list:
-            create_item = {
-                "action": "create",
-                "switches": create_list
-            }
+            create_item = {"action": "create", "switches": create_list}
             diff.append(create_item)
 
         # Add POAP switches to the diff
@@ -1906,15 +1958,9 @@ class DcnmInventory:
                 preprovision_list.append(item)
 
         if bootstrap_list:
-            diff.append({
-                "action": "bootstrap",
-                "bootstrap_switches": bootstrap_list
-            })
+            diff.append({"action": "bootstrap", "bootstrap_switches": bootstrap_list})
         if preprovision_list:
-            diff.append({
-                "action": "preprovision",
-                "preprovision_switches": preprovision_list
-            })
+            diff.append({"action": "preprovision", "preprovision_switches": preprovision_list})
 
         # Add RMA switches to the diff
         for rma in self.want_create_rma:
@@ -1928,10 +1974,7 @@ class DcnmInventory:
             rma_list.append(item)
 
         if rma_list:
-            diff.append({
-                "action": "rma",
-                "rma_switches": rma_list
-            })
+            diff.append({"action": "rma", "rma_switches": rma_list})
 
         # Add deleted switches to the diff
         for serial in self.diff_delete:
@@ -1946,9 +1989,7 @@ class DcnmInventory:
                     version = have_c["switches"][0]["version"]
                     break
 
-            item = {
-                "serial_number": serial
-            }
+            item = {"serial_number": serial}
             if ip_address:
                 item["ip_address"] = ip_address
             if hostname:
@@ -1963,10 +2004,7 @@ class DcnmInventory:
             delete_list.append(item)
 
         if delete_list:
-            diff.append({
-                "action": "delete",
-                "switches": delete_list
-            })
+            diff.append({"action": "delete", "switches": delete_list})
 
         self.diff_input_format = diff
 
@@ -1998,6 +2036,9 @@ def main():
     if module.params["state"] == "overridden":
         dcnm_inv.get_diff_override()
 
+    if module.params["state"] in ["merged", "overridden"]:
+        dcnm_inv.group_diff_create_by_role()
+
     if module.params["state"] == "deleted":
         dcnm_inv.get_diff_delete()
 
@@ -2008,15 +2049,31 @@ def main():
 
     if not dcnm_inv.diff_delete and module.params["state"] == "deleted":
         dcnm_inv.result["changed"] = False
-        dcnm_inv.result[
-            "response"
-        ] = "The switch provided is not part of the fabric and cannot be deleted"
+        dcnm_inv.result["response"] = "The switch provided is not part of the fabric and cannot be deleted"
 
-    if not dcnm_inv.diff_create and module.params["state"] == "merged" and not dcnm_inv.want_create_poap and not dcnm_inv.want_create_rma:
-        dcnm_inv.result["changed"] = False
-        dcnm_inv.result[
-            "response"
-        ] = "The switch provided is already part of the fabric and cannot be created again"
+    if (
+        not dcnm_inv.diff_create
+        and module.params["state"] == "merged"
+        and not dcnm_inv.want_create_poap
+        and not dcnm_inv.want_create_rma
+    ):
+        # V2-OPTIMIZATION: Fast-path for save/deploy-only re-calls.
+        # When all switches already exist (diff_create empty), still honor
+        # save/deploy flags instead of just exiting. This makes the second
+        # NAC call (save=true) complete in seconds instead of being a no-op.
+        if module.params["save"]:
+            dcnm_inv.config_save()
+            dcnm_inv.result["changed"] = True
+        if module.params["deploy"]:
+            dcnm_inv.config_deploy()
+            dcnm_inv.result["changed"] = True
+        if not dcnm_inv.result["changed"]:
+            dcnm_inv.result["response"] = (
+                "The switch provided is already part of the fabric and cannot be created again"
+            )
+        dcnm_inv.format_diff()
+        dcnm_inv.result["diff"] = dcnm_inv.diff_input_format
+        module.exit_json(**dcnm_inv.result)
 
     if (
         not dcnm_inv.diff_create
@@ -2024,17 +2081,18 @@ def main():
         and module.params["state"] == "overridden"
     ):
         dcnm_inv.result["changed"] = False
-        dcnm_inv.result[
-            "response"
-        ] = "The switch provided is already part of the fabric and there is no more device to delete in the fabric"
+        dcnm_inv.result["response"] = "The switch provided is already part of the fabric and there is no more device to delete in the fabric"
 
     if not dcnm_inv.query and module.params["state"] == "query":
         dcnm_inv.result["changed"] = False
-        dcnm_inv.result[
-            "response"
-        ] = "The queried switch is not part of the fabric configured"
+        dcnm_inv.result["response"] = "The queried switch is not part of the fabric configured"
 
-    if dcnm_inv.diff_create or dcnm_inv.diff_delete or dcnm_inv.want_create_poap or dcnm_inv.want_create_rma:
+    if (
+        dcnm_inv.diff_create
+        or dcnm_inv.diff_delete
+        or dcnm_inv.want_create_poap
+        or dcnm_inv.want_create_rma
+    ):
         dcnm_inv.result["changed"] = True
     else:
         module.exit_json(**dcnm_inv.result)
@@ -2051,8 +2109,11 @@ def main():
 
     # Discover & Register Switch
     if not dcnm_inv.node_migration:
-        if dcnm_inv.diff_create or dcnm_inv.want_create_poap or dcnm_inv.want_create_rma:
-
+        if (
+            dcnm_inv.diff_create
+            or dcnm_inv.want_create_poap
+            or dcnm_inv.want_create_rma
+        ):
             # Step 1
             # Import all switches
             dcnm_inv.import_switches()
@@ -2069,7 +2130,8 @@ def main():
 
             # Step 3
             # Check all devices are up
-            for check in range(1, 300):
+            # V2: Reduced from 300 to 120 max iterations (120 x 5s = 10min max)
+            for check in range(1, 120):
                 if not dcnm_inv.all_switches_ok():
                     time.sleep(5)
                     continue

--- a/plugins/modules/dcnm_links.py
+++ b/plugins/modules/dcnm_links.py
@@ -880,7 +880,7 @@ class DcnmLinks:
             "LINKS_CREATE": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/links",
             "LINKS_DELETE": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/links/",
             "LINKS_UPDATE": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/links/",
-            "LINKS_UPDATE_BULK": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/links/",
+            "LINKS_UPDATE_BULK": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/links/modify",
             "LINKS_GET_BY_FABRIC": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/links/fabrics/{}",
             "LINKS_CFG_DEPLOY": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{}/config-deploy/",
             "CONFIG_PREVIEW": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{}/config-preview/",
@@ -3659,7 +3659,7 @@ class DcnmLinks:
             if self.has_bulk_api:
                 path = self.paths["LINKS_UPDATE_BULK"]
                 json_payload = json.dumps(self.diff_modify)
-                resp = dcnm_send(self.module, "POST", path, json_payload)
+                resp = dcnm_send(self.module, "PUT", path, json_payload)
                 if resp != []:
                     self.result["response"].append(resp)
                 # Accept both 200 (OK) and 207 (Multi-Status) for bulk operations

--- a/plugins/modules/dcnm_links.py
+++ b/plugins/modules/dcnm_links.py
@@ -3662,7 +3662,8 @@ class DcnmLinks:
                 resp = dcnm_send(self.module, "POST", path, json_payload)
                 if resp != []:
                     self.result["response"].append(resp)
-                if resp and resp.get("RETURN_CODE") != 200:
+                # Accept both 200 (OK) and 207 (Multi-Status) for bulk operations
+                if resp and resp.get("RETURN_CODE") not in [200, 207]:
                     resp["CHANGED"] = self.changed_dict[0]
                     self.module.fail_json(msg=resp)
                 else:

--- a/plugins/modules/dcnm_links.py
+++ b/plugins/modules/dcnm_links.py
@@ -851,6 +851,7 @@ import ipaddress
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.dcnm.plugins.module_utils.network.dcnm.dcnm import (
+    dcnm_get_bulk_api_support,
     dcnm_send,
     validate_list_of_dicts,
     dcnm_version_supported,
@@ -879,6 +880,7 @@ class DcnmLinks:
             "LINKS_CREATE": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/links",
             "LINKS_DELETE": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/links/",
             "LINKS_UPDATE": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/links/",
+            "LINKS_UPDATE_BULK": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/links/",
             "LINKS_GET_BY_FABRIC": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/links/fabrics/{}",
             "LINKS_CFG_DEPLOY": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{}/config-deploy/",
             "CONFIG_PREVIEW": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{}/config-preview/",
@@ -972,11 +974,18 @@ class DcnmLinks:
         ]
 
         self.dcnm_version = dcnm_version_supported(self.module)
+        # Check for bulk API support
+        self.has_bulk_api = dcnm_get_bulk_api_support(self.module)
+
         self.inventory_data = get_fabric_inventory_details(
             self.module, self.fabric
         )
 
         self.src_fabric_info = get_fabric_details(self.module, self.fabric)
+        if not self.src_fabric_info:
+            self.module.fail_json(
+                msg=f"Source fabric {self.fabric} is not found in ND."
+            )
 
         self.paths = self.dcnm_links_paths[self.dcnm_version]
         self.templates = self.dcnm_links_xlate_template[self.dcnm_version]
@@ -3644,21 +3653,37 @@ class DcnmLinks:
             else:
                 create_flag = True
 
-        for link in self.diff_modify:
-
-            path = self.paths["LINKS_UPDATE"] + link["link-uuid"]
-
-            json_payload = json.dumps(link)
-            resp = dcnm_send(self.module, "PUT", path, json_payload)
-
-            if resp != []:
-                self.result["response"].append(resp)
-
-            if resp and resp.get("RETURN_CODE") != 200:
-                resp["CHANGED"] = self.changed_dict[0]
-                self.module.fail_json(msg=resp)
+        # For bulk API support, use bulk update API. For other versions, use individual update API.
+        if self.diff_modify:
+            # Bulk update API for bulk-capable controllers
+            if self.has_bulk_api:
+                path = self.paths["LINKS_UPDATE_BULK"]
+                json_payload = json.dumps(self.diff_modify)
+                resp = dcnm_send(self.module, "POST", path, json_payload)
+                if resp != []:
+                    self.result["response"].append(resp)
+                if resp and resp.get("RETURN_CODE") != 200:
+                    resp["CHANGED"] = self.changed_dict[0]
+                    self.module.fail_json(msg=resp)
+                else:
+                    modified_flag = True
             else:
-                modified_flag = True
+                # Individual update API for versions 11 and 12
+                for link in self.diff_modify:
+
+                    path = self.paths["LINKS_UPDATE"] + link["link-uuid"]
+
+                    json_payload = json.dumps(link)
+                    resp = dcnm_send(self.module, "PUT", path, json_payload)
+
+                    if resp != []:
+                        self.result["response"].append(resp)
+
+                    if resp and resp.get("RETURN_CODE") != 200:
+                        resp["CHANGED"] = self.changed_dict[0]
+                        self.module.fail_json(msg=resp)
+                    else:
+                        modified_flag = True
 
         if self.diff_deploy != {}:
 

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -1079,6 +1079,8 @@ class DcnmNetwork:
         # cases like "check_mode" and to print diffs[] in the output of each task.
         self.diff_create_quick = []
         self.have_attach = []
+        # O(1) lookup dict populated by get_have()
+        self.have_attach_by_name = {}
         self.want_attach = []
         self.diff_attach = []
         self.validated = []
@@ -2629,15 +2631,6 @@ class DcnmNetwork:
                     dep_net = attach["networkName"]
 
                 sn = attach["switchSerialNo"]
-                
-                # Build network_sn_attach_map from have_attach (like VRF does)
-                # This ensures serials are available for networks with config-only changes
-                network_name = attach.get("networkName")
-                if network_name:
-                    if network_name not in self.network_sn_attach_map:
-                        self.network_sn_attach_map[network_name] = set()
-                    self.network_sn_attach_map[network_name].add(sn)
-                
                 vlan = attach.get("vlanId")
 
                 ports = ""
@@ -2732,6 +2725,7 @@ class DcnmNetwork:
 
         self.have_create = have_create
         self.have_attach = have_attach
+        self.have_attach_by_name = {a["networkName"]: a for a in have_attach}
         self.have_deploy = have_deploy
         self.network_to_sns = network_to_sns
 
@@ -2745,10 +2739,6 @@ class DcnmNetwork:
 
         msg = "self.have_deploy: "
         msg += f"{json.dumps(self.have_deploy, indent=4)}"
-        self.log.debug(msg)
-
-        msg = "self.network_sn_attach_map (built from have_attach in get_have): "
-        msg += f"{json.dumps({k: list(v) for k, v in self.network_sn_attach_map.items()}, indent=4)}"
         self.log.debug(msg)
 
     def get_want(self):
@@ -2783,12 +2773,6 @@ class DcnmNetwork:
                 result = self.update_attach_params(attach, net["net_name"], deploy)
 
                 networks.append(result)
-                
-                # Update network_sn_attach_map from want_attach (like VRF does)
-                network_name = net["net_name"]
-                if network_name not in self.network_sn_attach_map:
-                    self.network_sn_attach_map[network_name] = set()
-                self.network_sn_attach_map[network_name].add(result["serialNumber"])
                 
             if networks:
                 self.normalize_vpc_torports(networks)
@@ -2850,10 +2834,6 @@ class DcnmNetwork:
         msg += f"{json.dumps(self.want_deploy, indent=4)}"
         self.log.debug(msg)
 
-        msg = "self.network_sn_attach_map (updated from want_attach in get_want): "
-        msg += f"{json.dumps({k: list(v) for k, v in self.network_sn_attach_map.items()}, indent=4)}"
-        self.log.debug(msg)
-
     def get_diff_delete(self):
         caller = inspect.stack()[1][3]
 
@@ -2866,9 +2846,6 @@ class DcnmNetwork:
         diff_delete = {}
 
         all_nets = ""
-
-        # Clear detach map at start of delete processing
-        self.network_sn_detach_map.clear()
 
         if self.config:
 
@@ -2890,19 +2867,9 @@ class DcnmNetwork:
                 if not have_a:
                     continue
 
-                # Build detach map inline while processing delete
-                # Initialize network entry in detach map
-                if network_name not in self.network_sn_detach_map:
-                    self.network_sn_detach_map[network_name] = set()
-
                 to_del = []
                 atch_h = have_a["lanAttachList"]
                 for a_h in atch_h:
-                    # Add serial to detach map for all attachments (needed for undeploy)
-                    serial = a_h.get("serialNumber")
-                    if serial:
-                        self.network_sn_detach_map[network_name].add(serial)
-
                     # Only add to diff_detach if actually attached
                     if a_h["isAttached"]:
                         del a_h["isAttached"]
@@ -2921,19 +2888,9 @@ class DcnmNetwork:
                 network_name = have_a["networkName"]
                 diff_delete.update({network_name: "DEPLOYED"})
 
-                # Build detach map inline while processing delete
-                # Initialize network entry in detach map
-                if network_name not in self.network_sn_detach_map:
-                    self.network_sn_detach_map[network_name] = set()
-
                 to_del = []
                 atch_h = have_a["lanAttachList"]
                 for a_h in atch_h:
-                    # Add serial to detach map for all attachments (needed for undeploy)
-                    serial = a_h.get("serialNumber")
-                    if serial:
-                        self.network_sn_detach_map[network_name].add(serial)
-
                     # Only add to diff_detach if actually attached
                     if a_h["isAttached"]:
                         del a_h["isAttached"]
@@ -2962,10 +2919,6 @@ class DcnmNetwork:
 
         msg = "self.diff_delete: "
         msg += f"{json.dumps(self.diff_delete, indent=4)}"
-        self.log.debug(msg)
-        
-        msg = "self.network_sn_detach_map (built inline during DELETE processing): "
-        msg += f"{json.dumps({k: list(v) for k, v in self.network_sn_detach_map.items()}, indent=4)}"
         self.log.debug(msg)
 
     def get_diff_override(self):
@@ -3000,18 +2953,8 @@ class DcnmNetwork:
             if not found:
                 network_name = have_a["networkName"]
                 
-                # Build detach map inline for networks being deleted in override
-                # Initialize network entry in detach map
-                if network_name not in self.network_sn_detach_map:
-                    self.network_sn_detach_map[network_name] = set()
-                
                 atch_h = have_a["lanAttachList"]
                 for a_h in atch_h:
-                    # Add serial to detach map for all attachments (needed for undeploy)
-                    serial = a_h.get("serialNumber")
-                    if serial:
-                        self.network_sn_detach_map[network_name].add(serial)
-                    
                     # Only add to diff_detach if actually attached
                     if a_h["isAttached"]:
                         del a_h["isAttached"]
@@ -3036,10 +2979,6 @@ class DcnmNetwork:
         self.diff_undeploy = diff_undeploy
         self.diff_delete = diff_delete
         self.diff_detach = diff_detach
-        
-        msg = "self.network_sn_detach_map (built inline during OVERRIDE processing): "
-        msg += f"{json.dumps({k: list(v) for k, v in self.network_sn_detach_map.items()}, indent=4)}"
-        self.log.debug(msg)
 
         return warn_msg
 
@@ -3415,6 +3354,167 @@ class DcnmNetwork:
         # This ensures serials are available for networks with config-only changes.
 
         return warn_msg
+
+    def populate_sn_maps_from_diffs(self):
+        """
+        Populate network serial maps from diff structures after diff calculation.
+
+        This ensures maps contain ONLY switches that need deploy/undeploy operations:
+        - Switches in diff_attach → network_sn_attach_map (for deploy)
+        - Switches in diff_detach → network_sn_detach_map (for undeploy)
+        - Config-only changes (diff_create_update) → Add all attached switches from have_attach
+
+        This approach ensures:
+        - New attachments: Deploy only to newly attached switches
+        - Detachments: Undeploy only from detached switches
+        - Config changes: Deploy to all currently attached switches
+        - Mixed operations: Correct switch selection for each operation type
+        """
+        caller = inspect.stack()[1][3]
+
+        msg = "ENTERED. "
+        msg += f"caller: {caller}."
+        self.log.debug(msg)
+
+        # Clear existing maps to ensure clean state
+        self.network_sn_attach_map.clear()
+        self.network_sn_detach_map.clear()
+
+        msg = "Cleared network_sn_attach_map and network_sn_detach_map"
+        self.log.debug(msg)
+
+        # Step 2: Process diff_attach for attachments and detachments
+        for attach_entry in self.diff_attach:
+            network_name = attach_entry.get("networkName")
+            if not network_name:
+                continue
+
+            for attach in attach_entry.get("lanAttachList", []):
+                serial = attach.get("serialNumber")
+                if not serial:
+                    continue
+
+                deployment = attach.get("deployment", True)
+
+                if deployment:
+                    # Attachment or update operation
+                    if network_name not in self.network_sn_attach_map:
+                        self.network_sn_attach_map[network_name] = set()
+                    self.network_sn_attach_map[network_name].add(serial)
+
+                    msg = f"Added serial {serial} to network_sn_attach_map[{network_name}] from diff_attach (deployment:True)"
+                    self.log.debug(msg)
+                else:
+                    # Detachment operation
+                    if network_name not in self.network_sn_detach_map:
+                        self.network_sn_detach_map[network_name] = set()
+                    self.network_sn_detach_map[network_name].add(serial)
+
+                    msg = f"Added serial {serial} to network_sn_detach_map[{network_name}] from diff_attach (deployment:False)"
+                    self.log.debug(msg)
+
+        # Step 3: Process diff_detach (from DELETE/OVERRIDE states)
+        for detach_entry in self.diff_detach:
+            network_name = detach_entry.get("networkName")
+            if not network_name:
+                continue
+
+            if network_name not in self.network_sn_detach_map:
+                self.network_sn_detach_map[network_name] = set()
+
+            for attach in detach_entry.get("lanAttachList", []):
+                serial = attach.get("serialNumber")
+                if serial:
+                    self.network_sn_detach_map[network_name].add(serial)
+
+                    msg = f"Added serial {serial} to network_sn_detach_map[{network_name}] from diff_detach"
+                    self.log.debug(msg)
+
+        # Step 4: Handle config-only changes
+        # If there are network updates (config changes) but no attachment changes,
+        # we need to deploy to ALL currently attached switches
+
+        config_changed_networks = set()
+
+        # Check diff_create_update for network configuration changes
+        for network_update in self.diff_create_update:
+            network_name = network_update.get("networkName")
+            if network_name:
+                config_changed_networks.add(network_name)
+
+        # Also check networks in diff_deploy that aren't already in config_changed_networks
+        # This covers both config-only changes AND mixed operations (config + attachment changes)
+        if self.diff_deploy:
+            deploy_networks = self.diff_deploy.get("networkNames", "").split(",")
+            for network_name in deploy_networks:
+                network_name = network_name.strip()
+                if network_name:
+                    config_changed_networks.add(network_name)
+
+        # For each network with config changes, add all attached switches
+        for network_name in config_changed_networks:
+            # Find this network in have_attach using O(1) lookup
+            have_network = self.have_attach_by_name.get(network_name)
+            if not have_network:
+                continue
+
+            # Initialize map entry if needed
+            if network_name not in self.network_sn_attach_map:
+                self.network_sn_attach_map[network_name] = set()
+
+            # Add all attached switches, excluding any in detach_map
+            for attach in have_network.get("lanAttachList", []):
+                serial = attach.get("serialNumber")
+                is_attached = attach.get("isAttached", False)
+
+                if serial and is_attached:
+                    # Check if this switch is being detached
+                    if serial not in self.network_sn_detach_map.get(network_name, set()):
+                        self.network_sn_attach_map[network_name].add(serial)
+
+                        msg = f"Added serial {serial} to network_sn_attach_map[{network_name}] for config change (isAttached:True, not in detach_map)"
+                        self.log.debug(msg)
+
+        # Handle undeploy operations: Use diff_undeploy if available, or diff_delete for DELETE state
+        # This is critical for DELETE/OVERRIDE states where detachments may be in any state (not just isAttached)
+        # diff_detach only contains isAttached switches, but undeploy needs ALL (pending, failed, out-of-sync, etc.)
+
+        # Determine which networks need undeploy
+        undeploy_networks = []
+        if self.diff_undeploy:
+            # Normal case: networks in diff_undeploy
+            undeploy_networks = [n.strip() for n in self.diff_undeploy.get("networkNames", "").split(",") if n.strip()]
+        elif self.diff_delete:
+            # DELETE state with no isAttached attachments (all PENDING): use diff_delete
+            # This handles the case where attachments are in PENDING state and won't be in diff_undeploy
+            undeploy_networks = list(self.diff_delete.keys())
+
+        for network_name in undeploy_networks:
+            # Initialize detach_map if needed
+            if network_name not in self.network_sn_detach_map:
+                self.network_sn_detach_map[network_name] = set()
+
+            # Get ALL switches from have_attach using O(1) lookup
+            # This ensures undeploy happens for all attachment states
+            have_entry = self.have_attach_by_name.get(network_name)
+            if have_entry:
+                for attach in have_entry.get("lanAttachList", []):
+                    serial = attach.get("serialNumber")
+                    if serial:
+                        # Add ALL switches, regardless of isAttached state
+                        # This fixes the bug where pending/failed switches were excluded
+                        self.network_sn_detach_map[network_name].add(serial)
+
+                        msg = f"Added serial {serial} to network_sn_detach_map[{network_name}] from have_attach for undeploy (all states)"
+                        self.log.debug(msg)
+
+        msg = "Final network_sn_attach_map: "
+        msg += f"{json.dumps({k: list(v) for k, v in self.network_sn_attach_map.items()}, indent=4)}"
+        self.log.debug(msg)
+
+        msg = "Final network_sn_detach_map: "
+        msg += f"{json.dumps({k: list(v) for k, v in self.network_sn_detach_map.items()}, indent=4)}"
+        self.log.debug(msg)
 
     def format_diff(self):
 
@@ -3909,6 +4009,12 @@ class DcnmNetwork:
 
             # Process all pending networks
             networks_to_remove = []
+
+            # Batch collection for optimization: collect all networks needing detach/deploy
+            batch_detach_payload = []
+            batch_deploy_payload = {}
+            networks_needing_deploy = []
+
             for net in pending_networks:
                 net_data = networks_by_name.get(net)
 
@@ -3920,46 +4026,113 @@ class DcnmNetwork:
 
                 attach_list = net_data.get("lanAttachList", [])
 
-                # Check for PENDING state and trigger detach/deploy once per network
-                if net not in deploy_triggered:
-                    has_pending = any(
-                        attach.get("lanAttachState") == "PENDING"
-                        for attach in attach_list
-                    )
-                    if has_pending:
-                        # Convert response structure for detach_and_deploy_for_del
-                        adapted_net = {
-                            "networkName": net,
-                            "fabric": self.fabric,
-                            "switchList": attach_list
-                        }
-                        # Rename keys for compatibility
-                        for switch in adapted_net["switchList"]:
-                            if "lanAttachState" in switch:
-                                switch["lanAttachedState"] = switch["lanAttachState"]
-                            if "switchSerialNo" in switch:
-                                switch["serialNumber"] = switch["switchSerialNo"]
-
-                        self.detach_and_deploy_for_del(adapted_net)
-                        deploy_triggered.add(net)
-
-                # Check if all attachments are in terminal state
+                # Single pass optimization: collect all needed information in one loop
+                pending_attaches = []
                 all_terminal = True
                 has_out_of_sync = False
+
                 for attach in attach_list:
                     state = attach.get("lanAttachState", "")
-                    if state in ("OUT-OF-SYNC", "FAILED"):
+
+                    if state == "PENDING":
+                        pending_attaches.append(attach)
+                        all_terminal = False
+                    elif state in ("OUT-OF-SYNC", "FAILED"):
                         has_out_of_sync = True
                     elif state != "NA":
                         all_terminal = False
-                        break
 
+                # Process pending attachments for batch operations (only if not already triggered)
+                if pending_attaches and net not in deploy_triggered:
+                    # Build detach payload for this network
+                    payload_net = {
+                        "networkName": net,
+                        "lanAttachList": []
+                    }
+
+                    for attach in pending_attaches:
+                        payload_atch = {
+                            "serialNumber": attach.get("switchSerialNo"),
+                            "networkName": net,
+                            "fabric": self.fabric,
+                            "deployment": False
+                        }
+                        payload_net["lanAttachList"].append(payload_atch)
+
+                        # Add to deploy payload - accumulate network names per serial
+                        serial = attach.get("switchSerialNo")
+                        if serial:
+                            if serial not in batch_deploy_payload:
+                                batch_deploy_payload[serial] = net
+                            else:
+                                # Check for exact match in comma-separated list to avoid substring issues
+                                existing_networks = batch_deploy_payload[serial].split(",")
+                                if net not in existing_networks:
+                                    batch_deploy_payload[serial] += "," + net
+
+                    batch_detach_payload.append(payload_net)
+                    networks_needing_deploy.append(net)
+                    deploy_triggered.add(net)
+
+                # Update network state based on terminal status
                 if all_terminal:
                     final_state = "OUT-OF-SYNC" if has_out_of_sync else "NA"
                     self.diff_delete.update({net: final_state})
                     networks_to_remove.append(net)
                 else:
                     self.diff_delete.update({net: "DEPLOYED"})
+
+            # Execute batched detach operation once for all networks
+            if batch_detach_payload:
+                msg = f"Batch detaching {len(batch_detach_payload)} network(s) with PENDING attachments"
+                self.log.debug(msg)
+
+                # Update fabric names for multisite/multicluster
+                self.update_ms_fabric(batch_detach_payload)
+
+                path = self.paths["GET_NET"].format(self.fabric) + "/attachments"
+                resp = dcnm_send(self.module, "POST", path, json.dumps(batch_detach_payload))
+
+                if resp:
+                    self.result["response"].append(resp)
+                    fail, dummy_changed = self.handle_response(resp, "attach")
+                    if fail:
+                        msg = f"Batch detach failed for networks: {networks_needing_deploy}"
+                        self.log.debug(msg)
+
+            # Execute batched deploy operation once for all networks
+            if batch_deploy_payload:
+                msg = f"Batch deploying (undeploy) {len(batch_deploy_payload)} attachment(s)"
+                self.log.debug(msg)
+
+                if self.deploy_mode == "switch":
+                    # Use switch-level deploy (undeploy operation for delete)
+                    self.deploy_network_switches(
+                        network_names=networks_needing_deploy,
+                        is_rollback=False,
+                        is_undeploy=True
+                    )
+                elif self.dcnm_version >= 12:
+                    # Version 12+: use resource-level deploy with SN:networkNames payload
+                    path = self.paths["GET_NET"].format(self.fabric)
+                    deploy_path = path.replace(f"/fabrics/{self.fabric}/networks", "/networks/deploy")
+                    resp = dcnm_send(self.module, "POST", deploy_path, json.dumps(batch_deploy_payload))
+                    if resp:
+                        self.result["response"].append(resp)
+                        fail, dummy_changed = self.handle_response(resp, "deploy")
+                        if fail:
+                            msg = f"Batch deploy failed for networks: {networks_needing_deploy}"
+                            self.log.debug(msg)
+                else:
+                    # Version < 12: use legacy /deployments path
+                    path = self.paths["GET_NET_SWITCH_DEPLOY"].format(self.fabric)
+                    resp = dcnm_send(self.module, "POST", path, json.dumps(batch_deploy_payload))
+                    if resp:
+                        self.result["response"].append(resp)
+                        fail, dummy_changed = self.handle_response(resp, "deploy")
+                        if fail:
+                            msg = f"Batch deploy failed for networks: {networks_needing_deploy}"
+                            self.log.debug(msg)
 
             # Remove networks that reached terminal state
             for net in networks_to_remove:
@@ -4154,6 +4327,12 @@ class DcnmNetwork:
         msg += f"caller: {caller}. "
         msg += f"is_rollback: {is_rollback}"
         self.log.debug(msg)
+
+        # Populate serial number maps from calculated diffs before any push operations
+        # This ensures maps contain only switches affected by current operation
+        if self.fabric_type not in ["multisite_child", "multicluster_child"]:
+            self.populate_sn_maps_from_diffs()
+
 
         path = self.paths["GET_NET"].format(self.fabric)
 

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -4107,12 +4107,9 @@ class DcnmNetwork:
 
             # Separate networks by state
             for net, state in self.diff_delete.items():
-                if state.upper() == "OUT-OF-SYNC" or state == "TIMEOUT":
+                if state == "TIMEOUT":
                     del_failure += net + ","
-                    if state == "TIMEOUT":
-                        resp = "Timeout waiting for network to be in delete ready state.\n"
-                    if state == "OUT-OF-SYNC":
-                        resp = "Network is out of sync.\n"
+                    resp = "Timeout waiting for network to be in delete ready state.\n"
                     continue
 
                 if supports_bulk_delete:

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -4179,8 +4179,6 @@ class DcnmNetwork:
 
             for attempt in range(0, retry_count):
                 resp = dcnm_send(self.module, method, attach_path, json.dumps(self.diff_attach))
-                resp = dcnm_send(self.module, method, attach_path, json.dumps(self.diff_attach))
-
                 update_in_progress = False
                 for key in resp["DATA"].keys():
                     if re.search(r"Failed.*Please try after some time", str(resp["DATA"][key])):

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -3495,6 +3495,12 @@ class DcnmNetwork:
         msg += f"caller: {caller}"
         self.log.debug(msg)
 
+        # Early return if no networks to wait for
+        if not self.diff_delete:
+            msg = "No networks in diff_delete, returning immediately."
+            self.log.debug(msg)
+            return True
+
         # Create a list of networks that still need to reach terminal state
         pending_networks = list(self.diff_delete.keys())
 
@@ -3718,6 +3724,158 @@ class DcnmNetwork:
                 new_fabric = self.sn_fab.get(sn, old_fabric)
                 node["fabric"] = new_fabric
 
+    def bulk_delete_networks_with_retry(self, networks_to_delete, path, method, is_rollback=False):
+        """
+        # Summary
+
+        Perform bulk delete with retry logic for controller sync issues.
+
+        ## Description
+
+        The controller sometimes returns a 500 error with message
+        "Please do a Fabric Re-sync and try Again" for certain networks.
+        This method retries the bulk delete operation up to 3 times
+        with 30-second delays, retrying only the failed networks.
+
+        ## Parameters
+
+        - networks_to_delete: List of network names to delete
+        - path: Base API path for network operations
+        - method: HTTP method ("DELETE")
+        - is_rollback: Whether this is a rollback operation
+
+        ## Raises
+
+        Calls failure() if deletion fails after all retry attempts
+        """
+        caller = inspect.stack()[1][3]
+        method_name = inspect.stack()[0][3]
+
+        msg = "ENTERED. "
+        msg += f"caller: {caller}. "
+        msg += f"networks_to_delete: {networks_to_delete}"
+        self.log.debug(msg)
+
+        max_retries = 3
+        retry_delay = 30  # seconds
+        max_batch_size = 30
+        all_successful_networks = []
+        networks_to_retry = networks_to_delete.copy()
+
+        for attempt in range(1, max_retries + 1):
+            if not networks_to_retry:
+                # All networks deleted successfully
+                msg = "All networks deleted successfully."
+                self.log.debug(msg)
+                return
+
+            msg = f"Bulk delete attempt {attempt}/{max_retries} "
+            msg += f"for {len(networks_to_retry)} networks"
+            self.log.debug(msg)
+
+            # Process in batches
+            for i in range(0, len(networks_to_retry), max_batch_size):
+                batch = networks_to_retry[i:i + max_batch_size]
+                network_names = ','.join(batch)
+                delete_path = path.replace("/networks", "") + "/bulk-delete/networks?network-names=" + network_names
+
+                msg = f"Attempt {attempt}, batch {i//max_batch_size + 1}: "
+                msg += f"method: {method}, path: {delete_path}"
+                self.log.debug(msg)
+
+                # Send the request
+                response = dcnm_send(self.module, method, delete_path)
+
+                msg = f"Attempt {attempt}, batch response: "
+                msg += f"{json.dumps(response, indent=4, sort_keys=True)}"
+                self.log.debug(msg)
+
+                # Always append response for visibility
+                self.result["response"].append(response)
+
+                return_code = response.get("RETURN_CODE", 0)
+
+                # Check if request was successful
+                if return_code == 200:
+                    msg = f"Attempt {attempt}: Batch delete succeeded for networks: {network_names}"
+                    self.log.debug(msg)
+                    # Mark as changed if not in check mode
+                    if not self.module.check_mode:
+                        self.result["changed"] = True
+                    all_successful_networks.extend(batch)
+                    continue
+
+                # Handle partial success (500 error with failureList)
+                if return_code == 500:
+                    data = response.get("DATA", {})
+                    success_list = data.get("successList", [])
+                    failure_list = data.get("failureList", [])
+
+                    # Track successful deletions
+                    if success_list:
+                        all_successful_networks.extend(success_list)
+                        msg = f"Attempt {attempt}: Successfully deleted networks: "
+                        msg += f"{','.join(success_list)}"
+                        self.log.debug(msg)
+                        if not self.module.check_mode:
+                            self.result["changed"] = True
+
+                    # Extract failed network names for retry
+                    if failure_list:
+                        failed_names = [item.get("name") for item in failure_list if item.get("name")]
+                        failure_messages = [
+                            f"{item.get('name')}: {item.get('message')}"
+                            for item in failure_list
+                        ]
+                        msg = f"Attempt {attempt}: Failed networks: {', '.join(failure_messages)}"
+                        self.log.debug(msg)
+
+                        # If this is the last attempt, fail
+                        if attempt == max_retries:
+                            if is_rollback:
+                                self.failed_to_rollback = True
+                                return
+                            msg = f"{self.class_name}.{method_name}: "
+                            msg += f"Bulk delete failed after {max_retries} attempts. "
+                            msg += f"Successfully deleted: {','.join(all_successful_networks) if all_successful_networks else 'None'}. "
+                            msg += f"Failed: {', '.join(failure_messages)}"
+                            self.log.debug(msg)
+                            self.failure(response)
+                            return
+                    else:
+                        # No failure list but 500 error - all in this batch failed
+                        msg = f"Attempt {attempt}: Batch failed with 500 error, no failure details. Networks: {network_names}"
+                        self.log.debug(msg)
+                        if attempt == max_retries:
+                            if is_rollback:
+                                self.failed_to_rollback = True
+                                return
+                            msg = f"{self.class_name}.{method_name}: "
+                            msg += f"Bulk delete failed with 500 error after {max_retries} attempts. "
+                            msg += f"No failure details provided by controller."
+                            self.log.debug(msg)
+                            self.failure(response)
+                            return
+                else:
+                    # Other error codes
+                    fail, self.result["changed"] = self.handle_response(response, "delete")
+                    self.log.debug(f"Bulk deletion failed for networks {network_names} with response: {response}")
+                    if fail:
+                        if is_rollback:
+                            self.failed_to_rollback = True
+                            return
+                        self.failure(response)
+                        return
+
+            # After processing all batches in this attempt, update retry list
+            # Only retry networks that actually failed (not in success list)
+            if attempt < max_retries:
+                networks_to_retry = [net for net in networks_to_retry if net not in all_successful_networks]
+                if networks_to_retry:
+                    msg = f"Waiting {retry_delay} seconds before retry {attempt + 1}..."
+                    self.log.debug(msg)
+                    time.sleep(retry_delay)
+
     def push_to_remote(self, is_rollback=False):
         caller = inspect.stack()[1][3]
 
@@ -3867,24 +4025,14 @@ class DcnmNetwork:
                             return
                         self.failure(resp)
 
-            # Use the bulk-delete API for standalone, MSD parent, and multicluster parent fabrics.
+            # Use the bulk-delete API with retry logic for standalone, MSD parent, and multicluster parent fabrics.
             if supports_bulk_delete and networks_to_delete:
-
-                max_batch_size = 30
-
-                for i in range(0, len(networks_to_delete), max_batch_size):
-                    batch = networks_to_delete[i:i + max_batch_size]
-                    network_names = ','.join(batch)
-                    delete_path = path.replace("/networks", "") + "/bulk-delete/networks?network-names=" + network_names
-
-                    resp = dcnm_send(self.module, method, delete_path)
-                    self.result["response"].append(resp)
-                    fail, self.result["changed"] = self.handle_response(resp, "delete")
-                    if fail:
-                        if is_rollback:
-                            self.failed_to_rollback = True
-                            return
-                        self.failure(resp)
+                self.bulk_delete_networks_with_retry(
+                    networks_to_delete,
+                    path,
+                    method,
+                    is_rollback
+                )
 
         if del_failure:
             fail_msg = "Deletion of Networks {0} has failed: {1}".format(del_failure[:-1], resp)

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -1187,6 +1187,8 @@ class DcnmNetwork:
                 if path_key == "GET_NET_SWITCH_DEPLOY":
                     # Use the dedicated onemanage deploy endpoint
                     self.paths[path_key] = self.paths["GET_NET_SWITCH_DEPLOY_ONEMANAGE"]
+                elif path_key == "GET_NET_SWITCH_CONFIG_DEPLOY":
+                    self.paths[path_key] = proxy + self.paths[path_key.replace("lan-fabric/rest/control", "onemanage")]
                 else:
                     # Always replace lan-fabric/rest with onemanage AND prepend /onemanage for ALL versions
                     self.paths[path_key] = proxy + self.paths[path_key].replace("lan-fabric/rest", "onemanage")

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -1003,6 +1003,7 @@ import time
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.dcnm.plugins.module_utils.network.dcnm.dcnm import (
+    dcnm_get_bulk_api_support,
     dcnm_get_ip_addr_info,
     dcnm_get_url,
     dcnm_send,
@@ -1044,6 +1045,7 @@ class DcnmNetwork:
             "GET_NET": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{}/networks",
             "GET_NET_NAME": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{}/networks/{}",
             "GET_NET_BULK": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/bulk-create/networks",
+            "UPDATE_NET_BULK": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/v2/bulk-update/networks",
             "GET_VLAN": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/resource-manager/vlan/{}?vlanUsageType=TOP_DOWN_NETWORK_VLAN",
             "GET_NET_STATUS": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{}/networks/{}/status",
             "GET_NET_SWITCH_DEPLOY": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/networks/deploy",
@@ -1127,6 +1129,9 @@ class DcnmNetwork:
 
         msg = f"self.dcnm_version: {self.dcnm_version}"
         self.log.debug(msg)
+        # Check for bulk API support
+        self.has_bulk_api = dcnm_get_bulk_api_support(self.module)
+
 
         self.inventory_data = get_nd_fabric_inventory_details(self.module, self.dcnm_version, self.fabric, self.fabric_details)
 
@@ -4529,6 +4534,276 @@ class DcnmNetwork:
                     self.failed_to_rollback = True
                     return
                 self.failure(resp)
+
+    def _push_diff_create_update_bulk(self, is_rollback=False):
+        """
+        # Summary
+
+        Send diff_create_update to controller using v2 bulk-update API.
+        Used exclusively for dcnm_version == -1.
+
+        ## V2 Bulk Update API:
+        - Method: PUT
+        - Path: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/v2/bulk-update/networks
+        - Payload: Array of network objects
+        - networkTemplateConfig: dict object (not JSON string)
+
+        ## Response Format:
+        {
+          "successList": [
+            {"name": "net1", "id": 30001, "message": "Network updated successfully.", "status": "Success"}
+          ]
+        }
+        """
+        method_name = inspect.stack()[0][3]
+        caller = inspect.stack()[1][3]
+
+        msg = "ENTERED. "
+        msg += f"caller: {caller}."
+        self.log.debug(msg)
+
+        bulk_payload = []
+
+        msg = f"Processing {len(self.diff_create_update)} network(s) for bulk update"
+        self.log.debug(msg)
+
+        # Get skipped attributes for parent fabrics
+        skipped_attributes = self.get_skipped_attributes()
+        template_mapping = self.get_template_config_mapping()
+
+        # Convert skipped spec attributes to template config keys
+        skipped_template_keys = set()
+        for attr in skipped_attributes:
+            if attr in template_mapping:
+                skipped_template_keys.add(template_mapping[attr])
+
+        self.log.debug(f"Create_update {self.diff_create_update}")
+        for network in self.diff_create_update:
+            # Parse JSON string template config
+            json_to_dict = json.loads(network["networkTemplateConfig"])
+            network_name = json_to_dict.get("networkName")
+
+            msg = f"Processing network {network_name} for bulk update"
+            self.log.debug(msg)
+
+            msg = f"Network {network_name} template config: "
+            msg += f"{json.dumps(json_to_dict, indent=4, sort_keys=True)}"
+            self.log.debug(msg)
+
+            # Remove skipped attributes from template config for parent fabrics
+            for key in list(json_to_dict.keys()):
+                if key in skipped_template_keys:
+                    del json_to_dict[key]
+
+            # Build network object for v2 bulk API
+            # Key difference: networkTemplateConfig is dict, NOT JSON string
+            network_obj = {
+                "fabric": network["fabric"],
+                "networkName": network["networkName"],
+                "displayName": network.get("displayName", network["networkName"]),
+                "networkId": network["networkId"],
+                "networkTemplate": network["networkTemplate"],
+                "networkExtensionTemplate": network["networkExtensionTemplate"],
+                "vrf": network["vrf"],
+                "networkTemplateConfig": json_to_dict  # Dict object, not JSON string
+            }
+
+            msg = f"Network {network_name} bulk payload object: "
+            msg += f"{json.dumps(network_obj, indent=4, sort_keys=True)}"
+            self.log.debug(msg)
+
+            bulk_payload.append(network_obj)
+
+        if bulk_payload:
+            action = "bulk_update"
+            verb = "PUT"
+            path = self.paths["UPDATE_NET_BULK"]
+
+            msg = f"Sending v2 bulk-update request for {len(bulk_payload)} network(s)"
+            self.log.debug(msg)
+
+            msg = "Complete bulk update payload: "
+            msg += f"{json.dumps(bulk_payload, indent=4, sort_keys=True)}"
+            self.log.debug(msg)
+
+            resp = dcnm_send(self.module, verb, path, json.dumps(bulk_payload))
+            self.result["response"].append(resp)
+            fail, self.result["changed"] = self.handle_response(resp, action)
+            if fail:
+                if is_rollback:
+                    self.failed_to_rollback = True
+                    return
+                self.failure(resp)
+
+    def _push_diff_create_update_individual(self, is_rollback=False):
+        """
+        # Summary
+
+        Send diff_create_update to controller using individual PUT per network.
+        Used for all versions except dcnm_version == -1.
+
+        ## Individual Update API:
+        - Method: PUT
+        - Path: .../fabrics/{fabric}/networks/{networkName}
+        - Payload: Single network object
+        - networkTemplateConfig: JSON string
+        """
+        method_name = inspect.stack()[0][3]
+        caller = inspect.stack()[1][3]
+
+        msg = "ENTERED. "
+        msg += f"caller: {caller}."
+        self.log.debug(msg)
+
+        msg = f"Processing {len(self.diff_create_update)} network(s) for individual update"
+        self.log.debug(msg)
+
+        self.log.debug(f"Processing create/update operations for networks: {json.dumps(self.diff_create_update)}")
+
+        # Get skipped attributes for parent fabrics
+        skipped_attributes = self.get_skipped_attributes()
+        template_mapping = self.get_template_config_mapping()
+
+        # Convert skipped spec attributes to template config keys
+        skipped_template_keys = set()
+        for attr in skipped_attributes:
+            if attr in template_mapping:
+                skipped_template_keys.add(template_mapping[attr])
+
+        action = "create"
+        verb = "PUT"
+        base_path = self.paths["GET_NET"].format(self.fabric)
+
+        for net in self.diff_create_update:
+            # Remove skipped attributes from template config for parent fabrics
+            if net.get("networkTemplateConfig") and skipped_template_keys:
+                json_to_dict = json.loads(net["networkTemplateConfig"])
+                for key in list(json_to_dict.keys()):
+                    if key in skipped_template_keys:
+                        del json_to_dict[key]
+                net["networkTemplateConfig"] = json.dumps(json_to_dict)
+
+            update_path = base_path + "/{0}".format(net["networkName"])
+
+            msg = f"Sending individual update for network {net['networkName']}"
+            self.log.debug(msg)
+
+            msg = f"Network {net['networkName']} payload: "
+            msg += f"{json.dumps(net, indent=4, sort_keys=True)}"
+            self.log.debug(msg)
+
+            resp = dcnm_send(self.module, verb, update_path, json.dumps(net))
+            self.result["response"].append(resp)
+            fail, self.result["changed"] = self.handle_response(resp, action)
+            if fail:
+                if is_rollback:
+                    self.failed_to_rollback = True
+                    return
+                self.failure(resp)
+
+    # ========================================================================
+    # COMMENTED OUT: CONSOLIDATED SINGLE-METHOD APPROACH
+    # ========================================================================
+    # Alternative implementation using a single method with inline conditionals.
+    # This approach is more compact but less testable and maintainable.
+    # Uncomment and replace the three methods above if you prefer this style.
+    # ========================================================================
+    #
+    # def push_to_remote(self, is_rollback=False):
+    #     caller = inspect.stack()[1][3]
+    #
+    #     msg = "ENTERED. "
+    #     msg += f"caller: {caller}. "
+    #     msg += f"is_rollback: {is_rollback}"
+    #     self.log.debug(msg)
+    #
+    #     path = self.paths["GET_NET"].format(self.fabric)
+    #
+    #     # Handle network create/update operations
+    #     if self.diff_create_update:
+    #         # Determine if using bulk API
+    #         use_bulk_api = (self.dcnm_version == -1)
+    #
+    #         msg = f"Using {'v2 bulk-update' if use_bulk_api else 'individual update'} API"
+    #         self.log.debug(msg)
+    #
+    #         # Get skipped attributes for parent fabrics
+    #         skipped_attributes = self.get_skipped_attributes()
+    #         template_mapping = self.get_template_config_mapping()
+    #
+    #         # Convert skipped spec attributes to template config keys
+    #         skipped_template_keys = set()
+    #         for attr in skipped_attributes:
+    #             if attr in template_mapping:
+    #                 skipped_template_keys.add(template_mapping[attr])
+    #
+    #         # Initialize based on API type
+    #         if use_bulk_api:
+    #             bulk_payload = []
+    #             action = "bulk_update"
+    #             verb = "PUT"
+    #             bulk_path = self.paths["UPDATE_NET_BULK"]
+    #         else:
+    #             action = "create"
+    #             verb = "PUT"
+    #             base_path = self.paths["GET_NET"].format(self.fabric)
+    #
+    #         # Process each network
+    #         for net in self.diff_create_update:
+    #             # Parse template config
+    #             json_to_dict = json.loads(net["networkTemplateConfig"])
+    #             network_name = json_to_dict.get("networkName")
+    #
+    #             msg = f"Processing network {network_name}"
+    #             self.log.debug(msg)
+    #
+    #             # Remove skipped attributes
+    #             for key in list(json_to_dict.keys()):
+    #                 if key in skipped_template_keys:
+    #                     del json_to_dict[key]
+    #
+    #             if use_bulk_api:
+    #                 # Build network object for bulk API (dict template config)
+    #                 network_obj = {
+    #                     "fabric": net["fabric"],
+    #                     "networkName": net["networkName"],
+    #                     "displayName": net.get("displayName", net["networkName"]),
+    #                     "networkId": net["networkId"],
+    #                     "networkTemplate": net["networkTemplate"],
+    #                     "networkExtensionTemplate": net["networkExtensionTemplate"],
+    #                     "vrf": net["vrf"],
+    #                     "networkTemplateConfig": json_to_dict  # Dict
+    #                 }
+    #                 bulk_payload.append(network_obj)
+    #             else:
+    #                 # Individual update - keep JSON string format
+    #                 net["networkTemplateConfig"] = json.dumps(json_to_dict)
+    #                 update_path = base_path + "/{0}".format(net["networkName"])
+    #
+    #                 resp = dcnm_send(self.module, verb, update_path, json.dumps(net))
+    #                 self.result["response"].append(resp)
+    #                 fail, self.result["changed"] = self.handle_response(resp, action)
+    #                 if fail:
+    #                     if is_rollback:
+    #                         self.failed_to_rollback = True
+    #                         return
+    #                     self.failure(resp)
+    #
+    #         # Send bulk request if applicable
+    #         if use_bulk_api and bulk_payload:
+    #             msg = f"Sending v2 bulk-update request for {len(bulk_payload)} network(s)"
+    #             self.log.debug(msg)
+    #             resp = dcnm_send(self.module, verb, bulk_path, json.dumps(bulk_payload))
+    #             self.result["response"].append(resp)
+    #             fail, self.result["changed"] = self.handle_response(resp, action)
+    #             if fail:
+    #                 if is_rollback:
+    #                     self.failed_to_rollback = True
+    #                     return
+    #                 self.failure(resp)
+    #
+    #     # ... rest of existing code for detach, deploy, etc ...
+    # ========================================================================
 
     def get_fabric_multicast_group_address(self) -> str:
         """

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -1266,6 +1266,22 @@ class DcnmNetwork:
                     merged_ports.append(port)
         return ",".join(merged_ports)
 
+    @staticmethod
+    def get_secondary_gws_template_config(template_conf):
+        """
+        Build NDFC's aggregate secondary gateway template value from secondaryGW1-4.
+        """
+
+        secondary_gws = []
+        for key in ["secondaryGW1", "secondaryGW2", "secondaryGW3", "secondaryGW4"]:
+            secondary_gw = template_conf.get(key, "")
+            if secondary_gw is None:
+                secondary_gw = ""
+            if secondary_gw != "":
+                secondary_gws.append({"gatewayIpAddress": secondary_gw})
+
+        return json.dumps({"secondaryGWs": secondary_gws}, separators=(",", ":"))
+
     def normalize_vpc_torports(self, networks):
         """
         NDFC reflects TOR attachments on both VPC peers even when the playbook
@@ -2365,6 +2381,7 @@ class DcnmNetwork:
             template_conf["secondaryGW3"] = ""
         if template_conf["secondaryGW4"] is None:
             template_conf["secondaryGW4"] = ""
+        template_conf["secondaryGWs"] = self.get_secondary_gws_template_config(template_conf)
         if self.dcnm_version > 11:
             if template_conf["SVI_NETFLOW_MONITOR"] is None:
                 template_conf["SVI_NETFLOW_MONITOR"] = ""
@@ -2415,6 +2432,8 @@ class DcnmNetwork:
             t_conf.update(ENABLE_NETFLOW=json_to_dict.get("ENABLE_NETFLOW", False))
             t_conf.update(SVI_NETFLOW_MONITOR=json_to_dict.get("SVI_NETFLOW_MONITOR", ""))
             t_conf.update(VLAN_NETFLOW_MONITOR=json_to_dict.get("VLAN_NETFLOW_MONITOR", ""))
+
+        t_conf["secondaryGWs"] = self.get_secondary_gws_template_config(t_conf)
 
         if "mcastGroup" not in json_to_dict:
             del t_conf["mcastGroup"]
@@ -4635,6 +4654,8 @@ class DcnmNetwork:
                     t_conf.update(SVI_NETFLOW_MONITOR=json_to_dict.get("SVI_NETFLOW_MONITOR", ""))
                     t_conf.update(VLAN_NETFLOW_MONITOR=json_to_dict.get("VLAN_NETFLOW_MONITOR", ""))
 
+                t_conf["secondaryGWs"] = self.get_secondary_gws_template_config(t_conf)
+
                 # Remove skipped attributes from template config for parent fabrics
                 for key in list(t_conf.keys()):
                     if key in skipped_template_keys:
@@ -4892,6 +4913,10 @@ class DcnmNetwork:
                 dhcp_srvr2_vrf=dict(type="str", length_max=32),
                 dhcp_srvr3_vrf=dict(type="str", length_max=32),
                 dhcp_servers=dict(type="list", elements="dict", default=[]),
+                secondary_ip_gw1=dict(type="ipv4"),
+                secondary_ip_gw2=dict(type="ipv4"),
+                secondary_ip_gw3=dict(type="ipv4"),
+                secondary_ip_gw4=dict(type="ipv4"),
                 deploy=dict(type="bool", default=True if not is_query_state else None),
                 is_l2only=dict(type="bool", default=False),
             )
@@ -5292,6 +5317,31 @@ class DcnmNetwork:
         json_to_dict_want = json.loads(want["networkTemplateConfig"])
         json_to_dict_have = json.loads(have["networkTemplateConfig"])
 
+        # NDFC stores secondary gateways as a compact list.  In merged state,
+        # clearing a middle slot while omitting later slots is ambiguous and
+        # would remove a different gateway on the next idempotency pass.
+        if self.module.params["state"] == "merged":
+            secondary_keys = ["secondary_ip_gw1", "secondary_ip_gw2", "secondary_ip_gw3", "secondary_ip_gw4"]
+            for index, key in enumerate(secondary_keys):
+                if cfg.get(key, None) != "":
+                    continue
+
+                higher_have = []
+                higher_omitted = []
+                for higher_index, higher_key in enumerate(secondary_keys[index + 1:], start=index + 2):
+                    if json_to_dict_have.get(f"secondaryGW{higher_index}", "") in ("", None):
+                        continue
+                    higher_have.append(higher_key)
+                    if higher_key not in cfg:
+                        higher_omitted.append(higher_key)
+
+                if higher_have and higher_omitted:
+                    msg = "Network '{0}': state merged cannot clear {1} while higher secondary gateway values exist and are omitted. ".format(
+                        want["networkName"], key
+                    )
+                    msg += "NDFC stores secondary gateways as a compact list; specify the remaining secondary gateways in order or use state replaced to declare the full desired set."
+                    self.module.fail_json(msg=msg)
+
         # Update template configuration - common attributes
         if cfg.get("vlan_id", None) is None:
             json_to_dict_want["vlanId"] = json_to_dict_have["vlanId"]
@@ -5346,6 +5396,8 @@ class DcnmNetwork:
 
         if cfg.get("secondary_ip_gw4", None) is None:
             json_to_dict_want["secondaryGW4"] = json_to_dict_have["secondaryGW4"]
+
+        json_to_dict_want["secondaryGWs"] = self.get_secondary_gws_template_config(json_to_dict_want)
 
         # Route target configuration (common for all fabric types)
         if cfg.get("route_target_both", None) is None:

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -1014,6 +1014,7 @@ from ansible_collections.cisco.dcnm.plugins.module_utils.network.dcnm.dcnm impor
     validate_list_of_dicts,
     sanitize_lan_attach_list
 )
+from ..module_utils.common.log_v2 import Log
 
 
 class DcnmNetwork:
@@ -1096,6 +1097,12 @@ class DcnmNetwork:
         self.deploy_mode = module.params.get("deploy_mode", "switch")
         self.network_to_sns = {}
         self.deploy_payload = {}
+        # Centralized map tracking network-to-serial attachments
+        # Format: {network_name: set(serial_numbers)}
+        self.network_sn_attach_map = {}
+        # Centralized map tracking network-to-serial detachments for undeploy operations
+        # Format: {network_name: set(serial_numbers)}
+        self.network_sn_detach_map = {}
 
         # Get fabric details from parameter (set by action plugin) - MUST be done before inventory call
         fabric_details = module.params.get("_fabric_details")
@@ -1576,136 +1583,199 @@ class DcnmNetwork:
 
         return attach
 
-    def transform_deploy_payload_for_multicluster(self, deploy_payload, use_diff_attach=True):
+    def update_network_sn_attach_map(self):
         """
-        Transform deploy payload for multicluster parent fabrics ONLY.
+        Build/update centralized map of network-to-serial attachments.
 
-        For multicluster parent, the deploy API expects:
-        {"serialNumber1": "net1,net2,net3", "serialNumber2": "net1,net2,net3"}
+        Called after diff_attach is populated to create a single source of truth
+        for network attachment mappings. Uses set() for automatic deduplication.
 
-        For all other fabric types (including multicluster_child), use standard format:
-        {"networkNames": "net1,net2,net3"}
+        Map format: {network_name: set(serial_numbers)}
+        """
+        caller = inspect.stack()[1][3]
 
-        Uses diff_attach (for deploy) or have_attach (for undeploy) to build the serial number to networks mapping.
+        msg = "ENTERED. "
+        msg += f"caller: {caller}."
+        self.log.debug(msg)
+
+        self.network_sn_attach_map.clear()
+
+        for net_attach in self.diff_attach:
+            network_name = net_attach.get("networkName")
+            if not network_name:
+                continue
+
+            if network_name not in self.network_sn_attach_map:
+                self.network_sn_attach_map[network_name] = set()
+
+            for attach in net_attach.get("lanAttachList", []):
+                serial = attach.get("serialNumber")
+                if serial:
+                    self.network_sn_attach_map[network_name].add(serial)
+
+        msg = "self.network_sn_attach_map: "
+        msg += f"{json.dumps({k: list(v) for k, v in self.network_sn_attach_map.items()}, indent=4)}"
+        self.log.debug(msg)
+
+    def update_network_sn_detach_map(self):
+        """
+        Build/update centralized map of network-to-serial detachments.
+
+        Called after diff_detach is populated to create a single source of truth
+        for network detachment mappings during undeploy operations. Uses set() for
+        automatic deduplication.
+
+        Map format: {network_name: set(serial_numbers)}
+        """
+        caller = inspect.stack()[1][3]
+
+        msg = "ENTERED. "
+        msg += f"caller: {caller}."
+        self.log.debug(msg)
+
+        self.network_sn_detach_map.clear()
+
+        for net_detach in self.diff_detach:
+            network_name = net_detach.get("networkName")
+            if not network_name:
+                continue
+
+            if network_name not in self.network_sn_detach_map:
+                self.network_sn_detach_map[network_name] = set()
+
+            for detach in net_detach.get("lanAttachList", []):
+                serial = detach.get("serialNumber")
+                if serial:
+                    self.network_sn_detach_map[network_name].add(serial)
+
+        msg = "self.network_sn_detach_map: "
+        msg += f"{json.dumps({k: list(v) for k, v in self.network_sn_detach_map.items()}, indent=4)}"
+        self.log.debug(msg)
+
+    def get_deploy_switch_serials(self, network_names, is_undeploy=False):
+        """
+        Return list of switch serials affected by network deployments or undeployments.
+
+        Uses centralized network_sn_attach_map for deploy operations and
+        network_sn_detach_map for undeploy operations. The is_undeploy parameter
+        explicitly controls which map to use.
 
         Args:
-            deploy_payload: Original payload with networkNames format
-            use_diff_attach: If True, use diff_attach (for deploy operations).
-                           If False, use have_attach (for undeploy/delete operations).
+            network_names: Can be dict with "networkNames" key, string (comma-separated),
+                         or list of network names
+            is_undeploy: If True, reads from network_sn_detach_map (undeploy operations).
+                        If False (default), reads from network_sn_attach_map (deploy operations).
 
         Returns:
-            Transformed payload for multicluster_parent or original payload for other fabric types
+            list: Ordered list of unique serial numbers
         """
+        caller = inspect.stack()[1][3]
 
-        if not deploy_payload or "networkNames" not in deploy_payload:
-            return deploy_payload
+        msg = "ENTERED. "
+        msg += f"caller: {caller}. "
+        msg += f"network_names type: {type(network_names)}, is_undeploy: {is_undeploy}"
+        self.log.debug(msg)
 
-        network_names_str = deploy_payload["networkNames"]
-        if not network_names_str:
-            return {}
-
-        # Parse the comma-separated network names that need to be deployed
-        network_names_list = [name.strip() for name in network_names_str.split(",")]
-
-        # Choose attach source based on parameter
-        # For deploy operations: use diff_attach
-        # For undeploy/delete operations: use have_attach
-        attach_source = None
-        if use_diff_attach:
-            if hasattr(self, 'diff_attach') and self.diff_attach:
-                attach_source = self.diff_attach
-        else:
-            if hasattr(self, 'have_attach') and self.have_attach:
-                attach_source = self.have_attach
-
-        if not attach_source:
-            return deploy_payload
-
-        # Build serial -> networks mapping from attach source
-        # Only include networks that are in the deploy_payload
-        serial_to_networks = {}
-
-        for net_attach in attach_source:
-            network_name = net_attach.get("networkName")
-
-            # Only process networks that are in the deploy list
-            if not network_name or network_name not in network_names_list:
-                continue
-
-            lan_attach_list = net_attach.get("lanAttachList", [])
-            for attach in lan_attach_list:
-                serial = attach.get("serialNumber")
-
-                if not serial:
-                    continue
-
-                # Add this network to the serial's list
-                if serial not in serial_to_networks:
-                    serial_to_networks[serial] = []
-                if network_name not in serial_to_networks[serial]:
-                    serial_to_networks[serial].append(network_name)
-
-        # If we couldn't build the mapping, fall back to original payload
-        if not serial_to_networks:
-            return deploy_payload
-
-        # Build the multicluster format payload: {serialNumber: "net1,net2,net3"}
-        multicluster_payload = {}
-        for serial, networks in serial_to_networks.items():
-            multicluster_payload[serial] = ",".join(networks)
-
-        return multicluster_payload
-
-    def get_delete_deploy_switch_serials(self, network_names=None, attach_source=None):
-        """
-        Return ordered, unique switch serials affected by delete-time network detaches.
-        """
-
+        # Parse network_names to list format
         if isinstance(network_names, dict):
-            network_names = network_names.get("networkNames")
+            network_names = network_names.get("networkNames", "").split(",")
+        elif isinstance(network_names, str):
+            network_names = network_names.split(",")
 
-        wanted_networks = None
-        if network_names:
-            if isinstance(network_names, str):
-                wanted_networks = set(
-                    name.strip() for name in network_names.split(",") if name.strip()
-                )
-            else:
-                wanted_networks = set(network_names)
+        # Select the appropriate map based on operation type
+        serial_map = self.network_sn_detach_map if is_undeploy else self.network_sn_attach_map
+        
+        map_type = "detach" if is_undeploy else "attach"
+        msg = f"Using network_sn_{map_type}_map for serial lookup."
+        self.log.debug(msg)
 
-        source = attach_source
-        if source is None:
-            source = getattr(self, "diff_detach", [])
-        if isinstance(source, dict):
-            source = [source]
-
+        # Collect serials maintaining order while avoiding duplicates
         serials = []
         seen = set()
-        for net_attach in source or []:
-            network_name = net_attach.get("networkName")
-            if wanted_networks and network_name not in wanted_networks:
+        for network_name in network_names:
+            network_name = network_name.strip()
+            if not network_name:
                 continue
 
-            attach_list = net_attach.get("lanAttachList", net_attach.get("switchList", []))
-            for attach in attach_list:
-                serial = attach.get("serialNumber") or attach.get("switchSerialNo")
-                if not serial or serial in seen:
-                    continue
-                seen.add(serial)
-                serials.append(serial)
+            for serial in serial_map.get(network_name, set()):
+                if serial not in seen:
+                    seen.add(serial)
+                    serials.append(serial)
+
+        msg = f"Returning {len(serials)} serials for networks: {network_names}"
+        self.log.debug(msg)
 
         return serials
 
-    def deploy_deleted_network_switches(self, network_names=None, attach_source=None):
+    def network_serial_payload_transform(self, payload: dict) -> dict:
         """
-        Trigger switch-level config deploy for switches touched by network deletion.
+        Transform network deploy payload for multicluster/resource mode.
+
+        Converts from:
+            {"networkNames": "net1,net2,net3"}
+        To:
+            {"serial1": "net1,net2", "serial2": "net3"}
+
+        Uses centralized network_sn_attach_map as single source of truth.
+
+        Args:
+            payload: Deployment payload with networkNames key
+
+        Returns:
+            Transformed payload mapping serial numbers to comma-separated network names
+        """
+        caller = inspect.stack()[1][3]
+
+        msg = "ENTERED. "
+        msg += f"caller: {caller}."
+        self.log.debug(msg)
+
+        if not payload or "networkNames" not in payload:
+            return payload
+
+        network_names_str = payload["networkNames"]
+        if not network_names_str:
+            return {}
+
+        # Parse the comma-separated network names
+        network_names_list = [n.strip() for n in network_names_str.split(",")]
+
+        # Build serial -> networks mapping from centralized map
+        serial_to_networks = {}
+        for network_name in network_names_list:
+            for serial in self.network_sn_attach_map.get(network_name, set()):
+                if serial not in serial_to_networks:
+                    serial_to_networks[serial] = []
+                serial_to_networks[serial].append(network_name)
+
+        # Convert to multicluster format: {serialNumber: "net1,net2,net3"}
+        result = {serial: ",".join(nets) for serial, nets in serial_to_networks.items()}
+
+        msg = "Returning transformed payload: "
+        msg += f"{json.dumps(result, indent=4)}"
+        self.log.debug(msg)
+
+        return result
+
+    def deploy_network_switches(self, network_names=None, is_rollback=False, is_undeploy=False):
+        """
+        Trigger switch-level config deploy for switches affected by network operations.
+        
+        Uses network attachment data to determine affected switches.
+        Works for both deploy and undeploy operations.
+        Handles response internally and updates self.result.
+        
+        Args:
+            network_names: Networks to deploy/undeploy
+            is_rollback: Whether this is a rollback operation
+            is_undeploy: If True, uses detach map for undeploy. If False, uses attach map for deploy.
         """
 
-        serials = self.get_delete_deploy_switch_serials(network_names, attach_source)
+        serials = self.get_deploy_switch_serials(network_names, is_undeploy=is_undeploy)
         if not serials:
-            msg = "No switch serials found for delete-time config deploy."
+            msg = "No switch serials found for config deploy."
             self.log.debug(msg)
-            return None
+            return
 
         method = "POST"
         deploy_path = self.paths["GET_NET_SWITCH_CONFIG_DEPLOY"].format(
@@ -1713,7 +1783,16 @@ class DcnmNetwork:
             ",".join(serials)
         )
 
-        return dcnm_send(self.module, method, deploy_path)
+        resp = dcnm_send(self.module, method, deploy_path)
+        
+        if resp is not None:
+            self.result["response"].append(resp)
+            fail, self.result["changed"] = self.handle_response(resp, "deploy")
+            if fail:
+                if is_rollback:
+                    self.failed_to_rollback = True
+                    return
+                self.failure(resp)
 
     def diff_for_create(self, want, have):
         caller = inspect.stack()[1][3]
@@ -2567,6 +2646,15 @@ class DcnmNetwork:
                     dep_net = attach["networkName"]
 
                 sn = attach["switchSerialNo"]
+                
+                # Build network_sn_attach_map from have_attach (like VRF does)
+                # This ensures serials are available for networks with config-only changes
+                network_name = attach.get("networkName")
+                if network_name:
+                    if network_name not in self.network_sn_attach_map:
+                        self.network_sn_attach_map[network_name] = set()
+                    self.network_sn_attach_map[network_name].add(sn)
+                
                 vlan = attach.get("vlanId")
 
                 ports = ""
@@ -2676,6 +2764,10 @@ class DcnmNetwork:
         msg += f"{json.dumps(self.have_deploy, indent=4)}"
         self.log.debug(msg)
 
+        msg = "self.network_sn_attach_map (built from have_attach in get_have): "
+        msg += f"{json.dumps({k: list(v) for k, v in self.network_sn_attach_map.items()}, indent=4)}"
+        self.log.debug(msg)
+
     def get_want(self):
         caller = inspect.stack()[1][3]
 
@@ -2708,6 +2800,13 @@ class DcnmNetwork:
                 result = self.update_attach_params(attach, net["net_name"], deploy)
 
                 networks.append(result)
+                
+                # Update network_sn_attach_map from want_attach (like VRF does)
+                network_name = net["net_name"]
+                if network_name not in self.network_sn_attach_map:
+                    self.network_sn_attach_map[network_name] = set()
+                self.network_sn_attach_map[network_name].add(result["serialNumber"])
+                
             if networks:
                 self.normalize_vpc_torports(networks)
                 for attch in net["attach"]:
@@ -2768,6 +2867,10 @@ class DcnmNetwork:
         msg += f"{json.dumps(self.want_deploy, indent=4)}"
         self.log.debug(msg)
 
+        msg = "self.network_sn_attach_map (updated from want_attach in get_want): "
+        msg += f"{json.dumps({k: list(v) for k, v in self.network_sn_attach_map.items()}, indent=4)}"
+        self.log.debug(msg)
+
     def get_diff_delete(self):
         caller = inspect.stack()[1][3]
 
@@ -2781,6 +2884,9 @@ class DcnmNetwork:
 
         all_nets = ""
 
+        # Clear detach map at start of delete processing
+        self.network_sn_detach_map.clear()
+
         if self.config:
 
             for want_c in self.want_create:
@@ -2789,23 +2895,37 @@ class DcnmNetwork:
                     None,
                 ):
                     continue
-                diff_delete.update({want_c["networkName"]: "DEPLOYED"})
+
+                network_name = want_c["networkName"]
+                diff_delete.update({network_name: "DEPLOYED"})
 
                 have_a = next(
-                    (attach for attach in self.have_attach if attach["networkName"] == want_c["networkName"]),
+                    (attach for attach in self.have_attach if attach["networkName"] == network_name),
                     None,
                 )
 
                 if not have_a:
                     continue
 
+                # Build detach map inline while processing delete
+                # Initialize network entry in detach map
+                if network_name not in self.network_sn_detach_map:
+                    self.network_sn_detach_map[network_name] = set()
+
                 to_del = []
                 atch_h = have_a["lanAttachList"]
                 for a_h in atch_h:
+                    # Add serial to detach map for all attachments (needed for undeploy)
+                    serial = a_h.get("serialNumber")
+                    if serial:
+                        self.network_sn_detach_map[network_name].add(serial)
+
+                    # Only add to diff_detach if actually attached
                     if a_h["isAttached"]:
                         del a_h["isAttached"]
                         a_h.update({"deployment": False})
                         to_del.append(a_h)
+
                 if to_del:
                     have_a.update({"lanAttachList": to_del})
                     diff_detach.append(have_a)
@@ -2815,19 +2935,33 @@ class DcnmNetwork:
 
         else:
             for have_a in self.have_attach:
+                network_name = have_a["networkName"]
+                diff_delete.update({network_name: "DEPLOYED"})
+
+                # Build detach map inline while processing delete
+                # Initialize network entry in detach map
+                if network_name not in self.network_sn_detach_map:
+                    self.network_sn_detach_map[network_name] = set()
+
                 to_del = []
                 atch_h = have_a["lanAttachList"]
                 for a_h in atch_h:
+                    # Add serial to detach map for all attachments (needed for undeploy)
+                    serial = a_h.get("serialNumber")
+                    if serial:
+                        self.network_sn_detach_map[network_name].add(serial)
+
+                    # Only add to diff_detach if actually attached
                     if a_h["isAttached"]:
                         del a_h["isAttached"]
                         a_h.update({"deployment": False})
                         to_del.append(a_h)
+
                 if to_del:
                     have_a.update({"lanAttachList": to_del})
                     diff_detach.append(have_a)
                     all_nets += have_a["networkName"] + ","
 
-                diff_delete.update({have_a["networkName"]: "DEPLOYED"})
             if all_nets:
                 diff_undeploy.update({"networkNames": all_nets[:-1]})
 
@@ -2845,6 +2979,10 @@ class DcnmNetwork:
 
         msg = "self.diff_delete: "
         msg += f"{json.dumps(self.diff_delete, indent=4)}"
+        self.log.debug(msg)
+        
+        msg = "self.network_sn_detach_map (built inline during DELETE processing): "
+        msg += f"{json.dumps({k: list(v) for k, v in self.network_sn_detach_map.items()}, indent=4)}"
         self.log.debug(msg)
 
     def get_diff_override(self):
@@ -2877,8 +3015,21 @@ class DcnmNetwork:
 
             to_del = []
             if not found:
+                network_name = have_a["networkName"]
+                
+                # Build detach map inline for networks being deleted in override
+                # Initialize network entry in detach map
+                if network_name not in self.network_sn_detach_map:
+                    self.network_sn_detach_map[network_name] = set()
+                
                 atch_h = have_a["lanAttachList"]
                 for a_h in atch_h:
+                    # Add serial to detach map for all attachments (needed for undeploy)
+                    serial = a_h.get("serialNumber")
+                    if serial:
+                        self.network_sn_detach_map[network_name].add(serial)
+                    
+                    # Only add to diff_detach if actually attached
                     if a_h["isAttached"]:
                         del a_h["isAttached"]
                         a_h.update({"deployment": False})
@@ -2891,7 +3042,7 @@ class DcnmNetwork:
 
                 # The following is added just to help in deletion, we need to wait for detach transaction to complete
                 # before attempting to delete the network.
-                diff_delete.update({have_a["networkName"]: "DEPLOYED"})
+                diff_delete.update({network_name: "DEPLOYED"})
 
         if all_nets:
             diff_undeploy.update({"networkNames": all_nets[:-1]})
@@ -2902,6 +3053,11 @@ class DcnmNetwork:
         self.diff_undeploy = diff_undeploy
         self.diff_delete = diff_delete
         self.diff_detach = diff_detach
+        
+        msg = "self.network_sn_detach_map (built inline during OVERRIDE processing): "
+        msg += f"{json.dumps({k: list(v) for k, v in self.network_sn_detach_map.items()}, indent=4)}"
+        self.log.debug(msg)
+
         return warn_msg
 
     def get_diff_replace(self):
@@ -3271,6 +3427,10 @@ class DcnmNetwork:
         self.diff_deploy = diff_deploy
         self.diff_create_quick = diff_create_quick
 
+        # Note: network_sn_attach_map is now built from have_attach (in get_have)
+        # and want_attach (in get_want), similar to how VRF module handles it.
+        # This ensures serials are available for networks with config-only changes.
+
         return warn_msg
 
     def format_diff(self):
@@ -3543,22 +3703,36 @@ class DcnmNetwork:
             return
 
         method = "POST"
-        if self.fabric_type != "multicluster_parent" and self.deploy_mode == "switch":
-            resp = self.deploy_deleted_network_switches(
-                network_names=[net["networkName"]],
-                attach_source=[payload_net]
-            )
+        if self.dcnm_version >= 12:
+            # Version 12+: Determine deploy path and payload format based on deploy_mode
+            if self.deploy_mode == "switch":
+                # Use switch-level deploy (undeploy operation for delete)
+                self.deploy_network_switches(
+                    network_names=[net["networkName"]],
+                    is_rollback=False,
+                    is_undeploy=True
+                )
+            else:
+                # Use resource-level deploy: /networks/deploy path with SN:networkNames
+                path = self.paths["GET_NET"].format(self.fabric)
+                deploy_path = path.replace(f"/fabrics/{self.fabric}/networks", "/networks/deploy")
+                resp = dcnm_send(self.module, method, deploy_path, json.dumps(deploy_payload))
+                if resp is not None:
+                    self.result["response"].append(resp)
+                    fail, dummy_changed = self.handle_response(resp, "deploy")
+                    if fail:
+                        self.failure(resp)
         else:
+            # Version < 12: use legacy /deployments path
             path = self.paths["GET_NET_SWITCH_DEPLOY"].format(self.fabric)
             resp = dcnm_send(self.module, method, path, json.dumps(deploy_payload))
+            if resp is None:
+                return
 
-        if resp is None:
-            return
-
-        self.result["response"].append(resp)
-        fail, dummy_changed = self.handle_response(resp, "deploy")
-        if fail:
-            self.failure(resp)
+            self.result["response"].append(resp)
+            fail, dummy_changed = self.handle_response(resp, "deploy")
+            if fail:
+                self.failure(resp)
 
     def wait_for_network_del_ready(self):
         """
@@ -4040,26 +4214,39 @@ class DcnmNetwork:
         payload = copy.deepcopy(self.diff_undeploy)
         delete_ready = False
         if self.diff_undeploy:
-            use_delete_config_deploy = (
-                self.fabric_type != "multicluster_parent"
-                and self.deploy_mode == "switch"
-                and bool(self.diff_delete)
-            )
-            # For multicluster_parent, always use switch-level endpoint and payload format
-            # For all others, check deploy_mode parameter
-            if use_delete_config_deploy:
-                resp = self.deploy_deleted_network_switches(payload)
-            elif self.fabric_type == "multicluster_parent" or self.deploy_mode == "switch":
-                # Use switch-level deploy: transform payload to serial number format
-                deploy_path = self.paths["GET_NET_SWITCH_DEPLOY"].format(self.fabric)
-                deploy_payload = self.transform_deploy_payload_for_multicluster(payload, use_diff_attach=False)
-                resp = dcnm_send(self.module, method, deploy_path, json.dumps(deploy_payload))
+            if self.dcnm_version >= 12:
+                # Determine deploy path and payload format
+                if self.deploy_mode == "switch":
+                    # Use switch-level deploy (undeploy operation)
+                    self.deploy_network_switches(payload, is_rollback, is_undeploy=True)
+                else:
+                    # Use resource-level deploy: /networks/deploy path with SN:networkNames
+                    path = self.paths["GET_NET"].format(self.fabric)
+                    deploy_path = path.replace(f"/fabrics/{self.fabric}/networks", "/networks/deploy")
+                    deploy_payload = self.network_serial_payload_transform(payload)
+                    resp = dcnm_send(self.module, method, deploy_path, json.dumps(deploy_payload))
+                    if resp is not None:
+                        self.result["response"].append(resp)
+                        fail, self.result["changed"] = self.handle_response(resp, "deploy")
+                        if fail:
+                            if is_rollback:
+                                self.failed_to_rollback = True
+                                return
+                            self.failure(resp)
             else:
-                # Use resource-level deploy: standard /deployments path with networkNames
+                # Version < 12: use legacy /deployments path with networkNames
                 path = self.paths["GET_NET"].format(self.fabric)
                 deploy_path = path + "/deployments"
                 deploy_payload = payload
                 resp = dcnm_send(self.module, method, deploy_path, json.dumps(deploy_payload))
+                if resp is not None:
+                    self.result["response"].append(resp)
+                    fail, self.result["changed"] = self.handle_response(resp, "deploy")
+                    if fail:
+                        if is_rollback:
+                            self.failed_to_rollback = True
+                            return
+                        self.failure(resp)
 
             # Use the self.wait_for_network_attachments_del_ready() function to refresh the state
             # of self.diff_delete dict and re-attempt the undeploy action if
@@ -4069,20 +4256,45 @@ class DcnmNetwork:
                 str(state).upper() == "OUT-OF-SYNC" for state in self.diff_delete.values()
             )
             if delete_ready and undeploy_retry_needed:
-                if use_delete_config_deploy:
-                    resp = self.deploy_deleted_network_switches(payload)
-                else:
-                    resp = dcnm_send(self.module, method, deploy_path, json.dumps(deploy_payload))
+                msg = "Networks in OUT-OF-SYNC state detected. Retrying undeploy."
+                self.log.debug(msg)
+
+                # Reset delete_ready since we're performing another deploy operation
                 delete_ready = False
 
-            if resp is not None:
-                self.result["response"].append(resp)
-                fail, self.result["changed"] = self.handle_response(resp, "deploy")
-                if fail:
-                    if is_rollback:
-                        self.failed_to_rollback = True
-                        return
-                    self.failure(resp)
+                if self.dcnm_version >= 12:
+                    # Version 12+: Determine deploy path and payload format
+                    if self.deploy_mode == "switch":
+                        # Use switch-level deploy (undeploy retry)
+                        self.deploy_network_switches(payload, is_rollback, is_undeploy=True)
+                    else:
+                        # Use resource-level deploy: /networks/deploy path with SN:networkNames
+                        path = self.paths["GET_NET"].format(self.fabric)
+                        deploy_path = path.replace(f"/fabrics/{self.fabric}/networks", "/networks/deploy")
+                        deploy_payload = self.network_serial_payload_transform(payload)
+                        resp = dcnm_send(self.module, method, deploy_path, json.dumps(deploy_payload))
+                        if resp is not None:
+                            self.result["response"].append(resp)
+                            fail, self.result["changed"] = self.handle_response(resp, "deploy")
+                            if fail:
+                                if is_rollback:
+                                    self.failed_to_rollback = True
+                                    return
+                                self.failure(resp)
+                else:
+                    # Version < 12: use legacy /deployments path with networkNames
+                    path = self.paths["GET_NET"].format(self.fabric)
+                    deploy_path = path + "/deployments"
+                    deploy_payload = payload
+                    resp = dcnm_send(self.module, method, deploy_path, json.dumps(deploy_payload))
+                    if resp is not None:
+                        self.result["response"].append(resp)
+                        fail, self.result["changed"] = self.handle_response(resp, "deploy")
+                        if fail:
+                            if is_rollback:
+                                self.failed_to_rollback = True
+                                return
+                            self.failure(resp)
 
         method = "DELETE"
         del_failure = ""
@@ -4284,17 +4496,38 @@ class DcnmNetwork:
 
         method = "POST"
         if self.diff_deploy:
-            # For multicluster_parent, always use switch-level endpoint and payload format
-            # For all others, check deploy_mode parameter
-            if self.fabric_type == "multicluster_parent" or self.deploy_mode == "switch":
-                # Use switch-level deploy: transform payload to serial number format
-                deploy_path = self.paths["GET_NET_SWITCH_DEPLOY"].format(self.fabric)
-                deploy_payload = self.transform_deploy_payload_for_multicluster(self.diff_deploy, use_diff_attach=True)
+            # For multicluster_parent and multisite_parent, prepare payload for action plugin
+            if self.fabric_type == "multicluster_parent" or self.fabric_type == "multisite_parent":
+                # Transform payload based on deploy_mode
+                if self.deploy_mode == "switch":
+                    # Use centralized method to get switch serials (normal deploy)
+                    diff_deploy = self.get_deploy_switch_serials(self.diff_deploy, is_undeploy=False)
+                else:
+                    # Use resource mode: transform to serial->networks mapping
+                    diff_deploy = self.network_serial_payload_transform(self.diff_deploy)
+
+                # Wrap in structured format for type checking in action plugin
+                self.deploy_payload = {"payload": diff_deploy}
+                return
+
+            # For standalone/child fabrics, deploy directly with version-dependent paths
+            if self.dcnm_version >= 12:
+                # Version 12+: Determine deploy path and payload format based on deploy_mode
+                if self.deploy_mode == "switch":
+                    # Use switch-level deploy (normal deploy operation)
+                    self.deploy_network_switches(self.diff_deploy, is_rollback, is_undeploy=False)
+                    return
+                else:
+                    # Use resource-level deploy: /networks/deploy path with networkNames
+                    path = self.paths["GET_NET"].format(self.fabric)
+                    deploy_path = path.replace(f"/fabrics/{self.fabric}/networks", "/networks/deploy")
+                    deploy_payload = self.network_serial_payload_transform(self.diff_deploy)
             else:
-                # Use resource-level deploy: standard /deployments path with networkNames
+                # Version < 12: use legacy /deployments path with networkNames
                 path = self.paths["GET_NET"].format(self.fabric)
                 deploy_path = path + "/deployments"
                 deploy_payload = self.diff_deploy
+
             resp = dcnm_send(self.module, method, deploy_path, json.dumps(deploy_payload))
             self.result["response"].append(resp)
             fail, self.result["changed"] = self.handle_response(resp, "deploy")
@@ -5037,6 +5270,13 @@ class DcnmNetwork:
 
 def main():
     """main entry point for module execution"""
+
+    # Logging setup
+    try:
+        log = Log()
+        log.commit()
+    except (TypeError, ValueError):
+        pass
 
     element_spec = dict(
         fabric=dict(required=True, type="str"),

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -1641,7 +1641,7 @@ class DcnmNetwork:
 
         # Select the appropriate map based on operation type
         serial_map = self.network_sn_detach_map if is_undeploy else self.network_sn_attach_map
-        
+
         map_type = "detach" if is_undeploy else "attach"
         msg = f"Using network_sn_{map_type}_map for serial lookup."
         self.log.debug(msg)
@@ -1761,7 +1761,7 @@ class DcnmNetwork:
     def deploy_network_switches(self, network_names=None, is_rollback=False, is_undeploy=False):
         """
         Trigger switch-level config deploy for switches affected by network operations.
-        
+
         Uses network attachment data to determine affected switches.
         Works for both deploy and undeploy operations.
         Handles response internally and updates self.result.
@@ -2792,7 +2792,7 @@ class DcnmNetwork:
                 result = self.update_attach_params(attach, net["net_name"], deploy)
 
                 networks.append(result)
-                
+
             if networks:
                 self.normalize_vpc_torports(networks)
                 for attch in net["attach"]:
@@ -2971,7 +2971,7 @@ class DcnmNetwork:
             to_del = []
             if not found:
                 network_name = have_a["networkName"]
-                
+
                 atch_h = have_a["lanAttachList"]
                 for a_h in atch_h:
                     # Only add to diff_detach if actually attached
@@ -4242,7 +4242,7 @@ class DcnmNetwork:
                 network_names = ','.join(batch)
                 delete_path = path.replace("/networks", "") + "/bulk-delete/networks?network-names=" + network_names
 
-                msg = f"Attempt {attempt}, batch {i//max_batch_size + 1}: "
+                msg = f"Attempt {attempt}, batch {i // max_batch_size + 1}: "
                 msg += f"method: {method}, path: {delete_path}"
                 self.log.debug(msg)
 
@@ -4351,7 +4351,6 @@ class DcnmNetwork:
         # This ensures maps contain only switches affected by current operation
         if self.fabric_type not in ["multisite_child", "multicluster_child"]:
             self.populate_sn_maps_from_diffs()
-
 
         path = self.paths["GET_NET"].format(self.fabric)
 
@@ -5339,7 +5338,10 @@ class DcnmNetwork:
                     msg = "Network '{0}': state merged cannot clear {1} while higher secondary gateway values exist and are omitted. ".format(
                         want["networkName"], key
                     )
-                    msg += "NDFC stores secondary gateways as a compact list; specify the remaining secondary gateways in order or use state replaced to declare the full desired set."
+                    msg += (
+                        "NDFC stores secondary gateways as a compact list; specify the remaining secondary gateways "
+                        "in order or use state replaced to declare the full desired set."
+                    )
                     self.module.fail_json(msg=msg)
 
         # Update template configuration - common attributes

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -1005,7 +1005,7 @@ from ansible_collections.cisco.dcnm.plugins.module_utils.network.dcnm.dcnm impor
 
 class DcnmNetwork:
 
-    BULK_GET_HAVE_NETWORK_THRESHOLD = 25
+    BULK_GET_HAVE_NETWORK_THRESHOLD = 5
 
     dcnm_network_paths = {
         11: {
@@ -2383,7 +2383,7 @@ class DcnmNetwork:
             requested_network_set = set(requested_networks)
 
         use_large_config_bulk_inventory = (
-            state in ["merged", "replaced"]
+            state in ["merged", "replaced", "deleted"]
             and bool(requested_networks)
             and len(requested_networks) >= self.BULK_GET_HAVE_NETWORK_THRESHOLD
         )
@@ -3475,103 +3475,236 @@ class DcnmNetwork:
         if fail:
             self.failure(resp)
 
-    def wait_for_del_ready(self):
+    def wait_for_network_del_ready(self):
+        """
+        # Summary
+
+        Wait for networks to reach a terminal state ready for deletion by checking networkStatus.
+
+        Polls the GET /networks API once per retry iteration to check all networks.
+        Terminal states (ready for deletion):
+        - NA, OUT-OF-SYNC, FAILED: Can proceed with deletion
+        - DEPLOYED, PENDING: Must wait
+
+        ## Raises
+
+        Calls fail_json if timeout is reached while waiting for network to reach terminal state.
+        """
+        caller = inspect.stack()[1][3]
+        msg = "ENTERED. "
+        msg += f"caller: {caller}"
+        self.log.debug(msg)
+
+        # Create a list of networks that still need to reach terminal state
+        pending_networks = list(self.diff_delete.keys())
+
+        msg = f"Waiting for {len(pending_networks)} network(s) to reach terminal state: {pending_networks}"
+        self.log.debug(msg)
 
         method = "GET"
-        if self.diff_delete:
-            for net in self.diff_delete:
-                state = False
-                # For multicluster_parent, use GET_NET_ATTACH instead of GET_NET_STATUS
-                if self.fabric_type == "multicluster_parent":
-                    path = self.paths["GET_NET_ATTACH"].format(self.fabric, net)
+        path = self.paths["GET_NET"].format(self.fabric)
+        retry_count = max(500 // self.WAIT_TIME_FOR_DELETE_LOOP, 1)
+
+        while pending_networks and retry_count > 0:
+            retry_count -= 1
+
+            msg = f"Retry iteration, remaining: {retry_count}, pending networks: {len(pending_networks)}"
+            self.log.debug(msg)
+
+            # Make ONE API call to get all networks
+            resp = dcnm_send(self.module, method, path)
+
+            if resp.get("DATA") is None:
+                time.sleep(self.WAIT_TIME_FOR_DELETE_LOOP)
+                continue
+
+            # Build a lookup dict for faster access: {networkName: networkData}
+            networks_by_name = {net_data.get("networkName"): net_data for net_data in resp["DATA"]}
+
+            # Check all pending networks in this response
+            networks_to_remove = []
+            for net in pending_networks:
+                net_data = networks_by_name.get(net)
+
+                if net_data is None:
+                    # Network not found in response - it may have already been deleted
+                    msg = f"Network {net} not found in GET /networks response, assuming already deleted"
+                    self.log.debug(msg)
+                    self.diff_delete.update({net: "NA"})
+                    networks_to_remove.append(net)
+                    continue
+
+                network_status = net_data.get("networkStatus", "")
+
+                msg = f"network: {net}, networkStatus: {network_status}"
+                self.log.debug(msg)
+
+                # Check if network is in a terminal state ready for deletion
+                if network_status.upper() in ("OUT-OF-SYNC", "FAILED"):
+                    self.diff_delete.update({net: "OUT-OF-SYNC"})
+                    networks_to_remove.append(net)
+                elif network_status.upper() == "NA" or network_status == "":
+                    self.diff_delete.update({net: "NA"})
+                    networks_to_remove.append(net)
                 else:
-                    path = self.paths["GET_NET_STATUS"].format(self.fabric, net)
+                    # Network is still in DEPLOYED, PENDING, or other non-terminal state
+                    self.diff_delete.update({net: "DEPLOYED"})
 
-                retry = max(500 // self.WAIT_TIME_FOR_DELETE_LOOP, 1)
-                deploy_started = False
-                while not state and retry >= 0:
-                    retry -= 1
-                    resp = dcnm_send(self.module, method, path)
-                    state = True
+            # Remove networks that reached terminal state
+            for net in networks_to_remove:
+                pending_networks.remove(net)
+                msg = f"Network {net} reached terminal state, removed from pending list"
+                self.log.debug(msg)
 
-                    # For multicluster_parent with GET_NET_ATTACH, response structure is different
-                    if self.fabric_type == "multicluster_parent":
-                        if resp.get("DATA") is None:
-                            time.sleep(self.WAIT_TIME_FOR_DELETE_LOOP)
-                            state = False
-                            continue
+            # If we still have pending networks, sleep before next retry
+            if pending_networks:
+                msg = f"Still waiting for {len(pending_networks)} network(s): {pending_networks}"
+                self.log.debug(msg)
+                time.sleep(self.WAIT_TIME_FOR_DELETE_LOOP)
 
-                        # GET_NET_ATTACH returns: [{'networkName': 'name', 'lanAttachList': [attachments]}]
-                        if isinstance(resp["DATA"], list) and len(resp["DATA"]) > 0:
-                            # Sanitize the lanAttachList entries
-                            sanitized_data = sanitize_lan_attach_list(
-                                resp["DATA"]
-                            )
-                            # Get the lanAttachList from the first element
-                            attach_list = sanitized_data[0].get("lanAttachList", [])
-                            # Check for PENDING state and trigger detach/deploy if needed
-                            for attach in attach_list:
-                                if attach.get("lanAttachState") == "PENDING" and not deploy_started:
-                                    # For multicluster, we need to convert the response structure
-                                    # from: [{'networkName': 'name', 'lanAttachList': [attachments]}]
-                                    # to: {'networkName': 'name', 'fabric': 'fabric', 'switchList': [attachments]}
+        # Check if we timed out
+        if pending_networks:
+            msg = "Timeout waiting for networks to be ready for deletion. "
+            msg += f"Pending networks: {pending_networks}, "
+            msg += f"States: {[(net, self.diff_delete.get(net)) for net in pending_networks]}"
+            self.module.fail_json(msg=msg)
 
-                                    # Convert multicluster response to format expected by detach_and_deploy_for_del
-                                    adapted_net = {
-                                        "networkName": resp["DATA"][0]["networkName"],
-                                        "fabric": self.fabric,
-                                        "switchList": resp["DATA"][0]["lanAttachList"]
-                                    }
+        msg = "All networks reached terminal state. Ready for deletion."
+        self.log.debug(msg)
+        return True
 
-                                    # Note: lanAttachList uses 'lanAttachState' while switchList uses 'lanAttachedState'
-                                    # We need to rename the key for compatibility
-                                    for switch in adapted_net["switchList"]:
-                                        if "lanAttachState" in switch:
-                                            switch["lanAttachedState"] = switch["lanAttachState"]
-                                        if "switchSerialNo" in switch:
-                                            switch["serialNumber"] = switch["switchSerialNo"]
+    def wait_for_network_attachments_del_ready(self):
+        """
+        # Summary
 
-                                    self.detach_and_deploy_for_del(adapted_net)
-                                    deploy_started = True
+        Wait for network attachments to be ready for deletion by checking lanAttachState.
 
-                            for attach in attach_list:
-                                if attach.get("lanAttachState") == "OUT-OF-SYNC" or attach.get("lanAttachState") == "FAILED":
-                                    self.diff_delete.update({net: "OUT-OF-SYNC"})
-                                    break
-                                if attach.get("lanAttachState") != "NA":
-                                    self.diff_delete.update({net: "DEPLOYED"})
-                                    state = False
-                                    time.sleep(self.WAIT_TIME_FOR_DELETE_LOOP)
-                                    break
-                            else:
-                                # All attachments are NA or no attachments
-                                self.diff_delete.update({net: "NA"})
-                        else:
-                            # No data found, network is ready
-                            self.diff_delete.update({net: "NA"})
+        Uses bulk GET_NET_ATTACH API to check all networks in a single call per retry iteration.
+        Terminal states (ready for deletion):
+        - NA: Attachment has been removed
+        - OUT-OF-SYNC, FAILED: Can proceed with cleanup
+        - Other states: Must wait for undeployment to complete
 
-                    else:
-                        # Original logic for GET_NET_STATUS (non-multicluster)
-                        if resp["DATA"]:
-                            if resp["DATA"]["networkStatus"].upper() == "PENDING" and not deploy_started:
-                                self.detach_and_deploy_for_del(resp["DATA"])
-                                deploy_started = True
-                            attach_list = resp["DATA"]["switchList"]
-                            for atch in attach_list:
-                                if atch["lanAttachedState"].upper() == "OUT-OF-SYNC" or atch["lanAttachedState"].upper() == "FAILED":
-                                    self.diff_delete.update({net: "OUT-OF-SYNC"})
-                                    break
-                                if atch["lanAttachedState"].upper() != "NA":
-                                    self.diff_delete.update({net: "DEPLOYED"})
-                                    state = False
-                                    time.sleep(self.WAIT_TIME_FOR_DELETE_LOOP)
-                                    break
-                                self.diff_delete.update({net: "NA"})
-                if retry < 0:
-                    self.diff_delete.update({net: "TIMEOUT"})
-                    return False
+        ## Raises
 
+        Calls fail_json if timeout is reached while waiting for attachments.
+        """
+        caller = inspect.stack()[1][3]
+        msg = f"ENTERED. caller: {caller}, fabric_type: {self.fabric_type}"
+        self.log.debug(msg)
+
+        method = "GET"
+        if not self.diff_delete:
             return True
+
+        # Create list of networks pending deletion readiness
+        pending_networks = list(self.diff_delete.keys())
+        msg = f"Waiting for {len(pending_networks)} network(s) attachments to reach terminal state"
+        self.log.debug(msg)
+
+        retry_count = max(500 // self.WAIT_TIME_FOR_DELETE_LOOP, 1)
+        deploy_triggered = set()  # Track networks that had deploy triggered
+
+        while pending_networks and retry_count > 0:
+            retry_count -= 1
+
+            # Make ONE bulk API call for all pending networks
+            network_names = ",".join(pending_networks)
+
+            if self.fabric_type == "multicluster_parent":
+                path = self.paths["GET_NET_ATTACH"].format(self.fabric, network_names)
+            else:
+                # For non-multicluster, use GET_NET_ATTACH for consistency and bulk support
+                path = self.paths["GET_NET_ATTACH"].format(self.fabric, network_names)
+
+            resp = dcnm_send(self.module, method, path)
+
+            if resp.get("DATA") is None:
+                time.sleep(self.WAIT_TIME_FOR_DELETE_LOOP)
+                continue
+
+            # Sanitize and build lookup dictionary
+            sanitized_data = sanitize_lan_attach_list(resp["DATA"]) if resp["DATA"] else []
+            networks_by_name = {
+                net_data.get("networkName"): net_data 
+                for net_data in sanitized_data
+            }
+
+            # Process all pending networks
+            networks_to_remove = []
+            for net in pending_networks:
+                net_data = networks_by_name.get(net)
+
+                if not net_data:
+                    # Network not found in response, mark as ready
+                    self.diff_delete.update({net: "NA"})
+                    networks_to_remove.append(net)
+                    continue
+
+                attach_list = net_data.get("lanAttachList", [])
+
+                # Check for PENDING state and trigger detach/deploy once per network
+                if net not in deploy_triggered:
+                    has_pending = any(
+                        attach.get("lanAttachState") == "PENDING" 
+                        for attach in attach_list
+                    )
+                    if has_pending:
+                        # Convert response structure for detach_and_deploy_for_del
+                        adapted_net = {
+                            "networkName": net,
+                            "fabric": self.fabric,
+                            "switchList": attach_list
+                        }
+                        # Rename keys for compatibility
+                        for switch in adapted_net["switchList"]:
+                            if "lanAttachState" in switch:
+                                switch["lanAttachedState"] = switch["lanAttachState"]
+                            if "switchSerialNo" in switch:
+                                switch["serialNumber"] = switch["switchSerialNo"]
+
+                        self.detach_and_deploy_for_del(adapted_net)
+                        deploy_triggered.add(net)
+
+                # Check if all attachments are in terminal state
+                all_terminal = True
+                has_out_of_sync = False
+                for attach in attach_list:
+                    state = attach.get("lanAttachState", "")
+                    if state in ("OUT-OF-SYNC", "FAILED"):
+                        has_out_of_sync = True
+                    elif state != "NA":
+                        all_terminal = False
+                        break
+
+                if all_terminal:
+                    final_state = "OUT-OF-SYNC" if has_out_of_sync else "NA"
+                    self.diff_delete.update({net: final_state})
+                    networks_to_remove.append(net)
+                else:
+                    self.diff_delete.update({net: "DEPLOYED"})
+
+            # Remove networks that reached terminal state
+            for net in networks_to_remove:
+                pending_networks.remove(net)
+
+            # Sleep before next retry if there are still pending networks
+            if pending_networks:
+                msg = f"Still waiting for {len(pending_networks)} network(s): {pending_networks}"
+                self.log.debug(msg)
+                time.sleep(self.WAIT_TIME_FOR_DELETE_LOOP)
+
+        # Check if we timed out
+        if pending_networks:
+            msg = f"Timeout waiting for network attachments. Pending: {pending_networks}"
+            self.log.debug(msg)
+            for net in pending_networks:
+                self.diff_delete.update({net: "TIMEOUT"})
+            return False
+
+        msg = "All network attachments reached terminal state"
+        self.log.debug(msg)
+        return True
 
     def update_ms_fabric(self, diff):
         # Update fabric field for both multisite (MFD) and multicluster parent fabrics
@@ -3669,10 +3802,10 @@ class DcnmNetwork:
                 deploy_payload = payload
 
             resp = dcnm_send(self.module, method, deploy_path, json.dumps(deploy_payload))
-            # Use the self.wait_for_del_ready() function to refresh the state
+            # Use the self.wait_for_network_attachments_del_ready() function to refresh the state
             # of self.diff_delete dict and re-attempt the undeploy action if
             # the state of the network is "OUT-OF-SYNC"
-            delete_ready = self.wait_for_del_ready()
+            delete_ready = self.wait_for_network_attachments_del_ready()
             undeploy_retry_needed = any(
                 str(state).upper() == "OUT-OF-SYNC" for state in self.diff_delete.values()
             )
@@ -3690,7 +3823,17 @@ class DcnmNetwork:
 
         method = "DELETE"
         del_failure = ""
-        if self.diff_delete and (delete_ready or self.wait_for_del_ready()):
+
+        # First, wait for attachments to be ready for deletion (lanAttachState = NA)
+        attachments_ready = delete_ready or self.wait_for_network_attachments_del_ready()
+
+        # Then, wait for network itself to be ready for deletion (networkStatus = NA/OUT-OF-SYNC/FAILED)
+        if attachments_ready:
+            networks_ready = self.wait_for_network_del_ready()
+        else:
+            networks_ready = False
+
+        if self.diff_delete and networks_ready:
             resp = ""
             networks_to_delete = []
             supports_bulk_delete = self.fabric_type in [

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -1110,6 +1110,11 @@ class DcnmNetwork:
         self.log.debug(msg)
 
         self.ip_sn, self.hn_sn = get_ip_sn_dict(self.inventory_data)
+        self.logical_name_inventory = {}
+        for switch_details in self.inventory_data.values():
+            logical_name = switch_details.get("logicalName")
+            if logical_name:
+                self.logical_name_inventory[logical_name.lower()] = switch_details
 
         self.ip_fab, self.sn_fab = get_ip_sn_fabric_dict(self.inventory_data)
         # Use get_nd_fabric_details for ND/multicluster support (handles proxy paths for child fabrics)
@@ -1206,8 +1211,25 @@ class DcnmNetwork:
         """
         if search is None:
             return None
+
         match = (d for d in search if d[key] == value)
         return next(match, None)
+
+    @staticmethod
+    def merge_port_lists(port_lists):
+        """
+        Merge comma-separated interface lists while preserving first-seen order.
+        """
+
+        merged_ports = []
+        for port_list in port_lists:
+            if not port_list:
+                continue
+            for port in port_list.split(","):
+                port = port.strip()
+                if port and port not in merged_ports:
+                    merged_ports.append(port)
+        return ",".join(merged_ports)
 
     def diff_for_attach_deploy(self, want_a, have_a, replace=False):
         caller = inspect.stack()[1][3]
@@ -2369,20 +2391,29 @@ class DcnmNetwork:
                 sn = attach["switchSerialNo"]
                 vlan = attach.get("vlanId")
 
-                if attach["portNames"] and re.match(r"\S+\(\S+\d+\/\d+\)", attach["portNames"]):
-                    for idx, sw_list in enumerate(re.findall(r"\S+\(\S+\d+\/\d+\)", attach["portNames"])):
-                        torports = {}
-                        sw = sw_list.split("(")
-                        eth_list = sw[1].split(")")
-                        if idx == 0:
-                            ports = eth_list[0]
-                            continue
-                        torports.update({"switch": sw[0]})
-                        torports.update({"torPorts": eth_list[0]})
-                        torlist.append(torports)
-                    attach.update({"torports": torlist})
-                else:
-                    ports = attach["portNames"]
+                ports = ""
+                if attach["portNames"]:
+                    named_port_entries = re.findall(r"(\S+)\(([^)]*)\)", attach["portNames"])
+                    if named_port_entries:
+                        residual_ports = re.sub(r"\S+\([^)]*\)", "", attach["portNames"]).strip()
+                        non_tor_port_lists = []
+                        for switch_name, port_list in named_port_entries:
+                            switch_details = self.logical_name_inventory.get(switch_name.lower(), {})
+                            role = switch_details.get("switchRole", "").lower()
+                            if role == "tor":
+                                torlist.append({"switch": switch_name, "torPorts": port_list})
+                            else:
+                                non_tor_port_lists.append(port_list)
+
+                        if residual_ports:
+                            ports = residual_ports
+                        elif non_tor_port_lists:
+                            ports = self.merge_port_lists(non_tor_port_lists)
+
+                        if torlist:
+                            attach.update({"torports": torlist})
+                    else:
+                        ports = attach["portNames"]
 
                 # The deletes and updates below are done to update the incoming dictionary format to
                 # match to what the outgoing payload requirements mandate.

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -4168,7 +4168,17 @@ class DcnmNetwork:
                         if not v_a["torports"]:
                             del v_a["torports"]
 
-            for attempt in range(0, 50):
+            # Calculate dynamic retry count based on number of attachments
+            attachment_count = sum(len(net.get("lanAttachList", [])) for net in self.diff_attach)
+            base_timeout = max(attachment_count * 30, 500)  # 30 seconds per attachment, minimum 500s
+            retry_count = max(base_timeout // 1, 1)  # 1 second sleep per retry
+
+            msg = f"Attempting to attach {attachment_count} network attachment(s). "
+            msg += f"attachment_count: {attachment_count}, base_timeout: {base_timeout}s, retry_count: {retry_count}"
+            self.log.debug(msg)
+
+            for attempt in range(0, retry_count):
+                resp = dcnm_send(self.module, method, attach_path, json.dumps(self.diff_attach))
                 resp = dcnm_send(self.module, method, attach_path, json.dumps(self.diff_attach))
 
                 update_in_progress = False

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -5003,7 +5003,7 @@ class DcnmNetwork:
 
         # Responses to all other operations POST and PUT are handled here.
         # Accept both 200 (OK) and 207 (Multi-Status) for bulk operations
-        if res.get("MESSAGE") != "OK" or res["RETURN_CODE"] not in [200, 207]:
+        if res.get("MESSAGE") not in ["OK", "Multi-Status"] or res["RETURN_CODE"] not in [200, 207]:
             fail = True
             changed = False
             return fail, changed

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -1005,6 +1005,8 @@ from ansible_collections.cisco.dcnm.plugins.module_utils.network.dcnm.dcnm impor
 
 class DcnmNetwork:
 
+    BULK_GET_HAVE_NETWORK_THRESHOLD = 25
+
     dcnm_network_paths = {
         11: {
             "GET_VRF": "/rest/top-down/fabrics/{}/vrfs",
@@ -2356,20 +2358,31 @@ class DcnmNetwork:
                     if not vrf_found:
                         self.module.fail_json(msg="VRF: {0} is missing in fabric: {1}".format(vrf_missing, self.fabric))
 
-        use_targeted_network_lookups = state in ["merged", "replaced", "deleted"] and bool(self.config)
-        use_bulk_network_inventory = state == "overridden"
+        requested_networks = []
+        requested_network_set = set()
 
-        if use_targeted_network_lookups:
-            requested_networks = []
+        if self.config:
             seen_networks = set()
-
             for net in self.config:
                 net_name = net.get("net_name")
                 if not net_name or net_name in seen_networks:
                     continue
                 seen_networks.add(net_name)
                 requested_networks.append(net_name)
+            requested_network_set = set(requested_networks)
 
+        use_large_config_bulk_inventory = (
+            state in ["merged", "replaced"]
+            and bool(requested_networks)
+            and len(requested_networks) >= self.BULK_GET_HAVE_NETWORK_THRESHOLD
+        )
+        use_targeted_network_lookups = (
+            state in ["merged", "replaced", "deleted"] and bool(requested_networks) and not use_large_config_bulk_inventory
+        )
+        use_bulk_network_inventory = state == "overridden" or use_large_config_bulk_inventory
+        filter_bulk_inventory_to_requested_networks = use_large_config_bulk_inventory
+
+        if use_targeted_network_lookups:
             for network_name in requested_networks:
                 path = self.paths["GET_NET_NAME"].format(self.fabric, network_name)
                 network = dcnm_send(self.module, method, path)
@@ -2399,6 +2412,8 @@ class DcnmNetwork:
 
             if networks.get("DATA"):
                 for net in networks["DATA"]:
+                    if filter_bulk_inventory_to_requested_networks and net.get("networkName") not in requested_network_set:
+                        continue
                     normalized_net = self.normalize_have_network(net)
                     curr_networks.append(normalized_net["networkName"])
                     have_create.append(normalized_net)
@@ -3667,6 +3682,11 @@ class DcnmNetwork:
         if self.diff_delete and (delete_ready or self.wait_for_del_ready()):
             resp = ""
             networks_to_delete = []
+            supports_bulk_delete = self.fabric_type in [
+                "standalone",
+                "multisite_parent",
+                "multicluster_parent",
+            ]
 
             # Separate networks by state
             for net, state in self.diff_delete.items():
@@ -3678,10 +3698,10 @@ class DcnmNetwork:
                         resp = "Network is out of sync.\n"
                     continue
 
-                if self.fabric_type == "multicluster_parent":
+                if supports_bulk_delete:
                     networks_to_delete.append(net)
                 else:
-                    # Non-multicluster_parent fabrics use individual delete
+                    # Fall back to individual deletes for fabric types without bulk-delete support.
                     delete_path = path + "/" + net
                     delete_payload = {net: "NA"}
                     resp = dcnm_send(self.module, method, delete_path, json.dumps(delete_payload))
@@ -3693,8 +3713,8 @@ class DcnmNetwork:
                             return
                         self.failure(resp)
 
-            # Batch delete for multicluster_parent using bulk-delete API
-            if self.fabric_type == "multicluster_parent" and networks_to_delete:
+            # Use the bulk-delete API for standalone, MSD parent, and multicluster parent fabrics.
+            if supports_bulk_delete and networks_to_delete:
 
                 max_batch_size = 30
 

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -3632,7 +3632,7 @@ class DcnmNetwork:
             # Sanitize and build lookup dictionary
             sanitized_data = sanitize_lan_attach_list(resp["DATA"]) if resp["DATA"] else []
             networks_by_name = {
-                net_data.get("networkName"): net_data 
+                net_data.get("networkName"): net_data
                 for net_data in sanitized_data
             }
 
@@ -3652,7 +3652,7 @@ class DcnmNetwork:
                 # Check for PENDING state and trigger detach/deploy once per network
                 if net not in deploy_triggered:
                     has_pending = any(
-                        attach.get("lanAttachState") == "PENDING" 
+                        attach.get("lanAttachState") == "PENDING"
                         for attach in attach_list
                     )
                     if has_pending:
@@ -3852,14 +3852,14 @@ class DcnmNetwork:
                                 return
                             msg = f"{self.class_name}.{method_name}: "
                             msg += f"Bulk delete failed with 500 error after {max_retries} attempts. "
-                            msg += f"No failure details provided by controller."
+                            msg += "No failure details provided by controller."
                             self.log.debug(msg)
                             self.failure(response)
                             return
                 else:
                     # Other error codes
                     fail, self.result["changed"] = self.handle_response(response, "delete")
-                    self.log.debug(f"Bulk deletion failed for networks {network_names} with response: {response}")
+                    self.log.debug("Bulk deletion failed for networks %s with response: %s", network_names, response)
                     if fail:
                         if is_rollback:
                             self.failed_to_rollback = True

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -3514,13 +3514,16 @@ class DcnmNetwork:
 
         # Create a list of networks that still need to reach terminal state
         pending_networks = list(self.diff_delete.keys())
+        network_count = len(pending_networks)
+        base_timeout = max(network_count * 30, 500)
+        retry_count = max(base_timeout // self.WAIT_TIME_FOR_DELETE_LOOP, 1)
 
-        msg = f"Waiting for {len(pending_networks)} network(s) to reach terminal state: {pending_networks}"
+        msg = f"Waiting for {len(pending_networks)} network(s) to reach terminal state. "
+        msg += f"network_count: {network_count}, base_timeout: {base_timeout}s, retry_count: {retry_count}"
         self.log.debug(msg)
 
         method = "GET"
         path = self.paths["GET_NET"].format(self.fabric)
-        retry_count = max(500 // self.WAIT_TIME_FOR_DELETE_LOOP, 1)
 
         while pending_networks and retry_count > 0:
             retry_count -= 1
@@ -3616,10 +3619,14 @@ class DcnmNetwork:
 
         # Create list of networks pending deletion readiness
         pending_networks = list(self.diff_delete.keys())
-        msg = f"Waiting for {len(pending_networks)} network(s) attachments to reach terminal state"
+        network_count = len(pending_networks)
+        base_timeout = max(network_count * 30, 500)
+        retry_count = max(base_timeout // self.WAIT_TIME_FOR_DELETE_LOOP, 1)
+
+        msg = f"Waiting for {len(pending_networks)} network(s) attachments to reach terminal state. "
+        msg += f"network_count: {network_count}, base_timeout: {base_timeout}s, retry_count: {retry_count}"
         self.log.debug(msg)
 
-        retry_count = max(500 // self.WAIT_TIME_FOR_DELETE_LOOP, 1)
         deploy_triggered = set()  # Track networks that had deploy triggered
 
         while pending_networks and retry_count > 0:

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -74,6 +74,19 @@ options:
       - deleted
       - query
     default: merged
+  deploy_mode:
+    description:
+    - Controls the deployment method when deploy is enabled
+    - When set to 'switch' (default), deployments use switch-level API with serial numbers
+    - When set to 'resource', deployments use resource-level API with network names
+    - This parameter is ignored for multicluster parent fabrics which always use switch-level deployment
+    - Applies to both create/deploy and delete/undeploy operations
+    type: str
+    required: false
+    choices:
+      - switch
+      - resource
+    default: switch
   config:
     description:
     - List of details of networks being managed. Not required for state deleted
@@ -1078,6 +1091,7 @@ class DcnmNetwork:
         self.diff_input_format = []
         self.query = []
         self.deployment_states = {}
+        self.deploy_mode = module.params.get("deploy_mode", "switch")
         self.network_to_sns = {}
         self.deploy_payload = {}
 
@@ -1580,9 +1594,6 @@ class DcnmNetwork:
         Returns:
             Transformed payload for multicluster_parent or original payload for other fabric types
         """
-        # Only transform for multicluster_parent, all others (including multicluster_child) use standard format
-        if self.fabric_type != "multicluster_parent":
-            return deploy_payload
 
         if not deploy_payload or "networkNames" not in deploy_payload:
             return deploy_payload
@@ -3948,13 +3959,14 @@ class DcnmNetwork:
         payload = copy.deepcopy(self.diff_undeploy)
         delete_ready = False
         if self.diff_undeploy:
-            # For multicluster_parent, use special endpoint and payload format
-            # For all others (including multicluster_child), use standard /deployments path
-            if self.fabric_type == "multicluster_parent":
+            # For multicluster_parent, always use switch-level endpoint and payload format
+            # For all others, check deploy_mode parameter
+            if self.fabric_type == "multicluster_parent" or self.deploy_mode == "switch":
+                # Use switch-level deploy: transform payload to serial number format
                 deploy_path = self.paths["GET_NET_SWITCH_DEPLOY"].format(self.fabric)
                 deploy_payload = self.transform_deploy_payload_for_multicluster(payload, use_diff_attach=False)
             else:
-                # Standard path for standalone, multisite, and multicluster_child
+                # Use resource-level deploy: standard /deployments path with networkNames
                 path = self.paths["GET_NET"].format(self.fabric)
                 deploy_path = path + "/deployments"
                 deploy_payload = payload
@@ -4174,13 +4186,14 @@ class DcnmNetwork:
 
         method = "POST"
         if self.diff_deploy:
-            # For multicluster_parent, use special endpoint and payload format
-            # For all others (including multicluster_child), use standard /deployments path
-            if self.fabric_type == "multicluster_parent":
+            # For multicluster_parent, always use switch-level endpoint and payload format
+            # For all others, check deploy_mode parameter
+            if self.fabric_type == "multicluster_parent" or self.deploy_mode == "switch":
+                # Use switch-level deploy: transform payload to serial number format
                 deploy_path = self.paths["GET_NET_SWITCH_DEPLOY"].format(self.fabric)
                 deploy_payload = self.transform_deploy_payload_for_multicluster(self.diff_deploy, use_diff_attach=True)
             else:
-                # Standard path for standalone, multisite, and multicluster_child
+                # Use resource-level deploy: standard /deployments path with networkNames
                 path = self.paths["GET_NET"].format(self.fabric)
                 deploy_path = path + "/deployments"
                 deploy_payload = self.diff_deploy
@@ -4946,6 +4959,12 @@ def main():
         state=dict(
             default="merged",
             choices=["merged", "replaced", "deleted", "overridden", "query"],
+        ),
+        deploy_mode=dict(
+            required=False,
+            type="str",
+            choices=["switch", "resource"],
+            default="switch"
         ),
     )
 

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -2295,18 +2295,29 @@ class DcnmNetwork:
         if not isinstance(resp, dict):
             return False
 
-        if resp.get("RETURN_CODE") != 400:
-            return False
-
+        return_code = resp.get("RETURN_CODE")
         data = resp.get("DATA")
-        if not isinstance(data, dict):
-            return False
 
-        message = data.get("message", "")
-        if not isinstance(message, str):
-            return False
+        # Check for non-onemanage 400 error: "Invalid network name"
+        if return_code == 400:
+            if not isinstance(data, dict):
+                return False
 
-        return message.lower() == "invalid network name"
+            message = data.get("message", "")
+            if not isinstance(message, str):
+                return False
+
+            return message.lower() == "invalid network name"
+
+        # Check for onemanage 500 error: "Network ... not found in cache"
+        if return_code == 500:
+            if not isinstance(data, str):
+                return False
+
+            # Check for the onemanage-specific "not found in cache" message
+            return "not found in cache" in data.lower()
+
+        return False
 
     def get_have(self):
         caller = inspect.stack()[1][3]

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -2237,6 +2237,75 @@ class DcnmNetwork:
 
         return net_upd
 
+    def normalize_have_network(self, network):
+        net = copy.deepcopy(network)
+
+        json_to_dict = net.get("networkTemplateConfig", {})
+        if isinstance(json_to_dict, str):
+            json_to_dict = json.loads(json_to_dict)
+
+        t_conf = {
+            "vlanId": json_to_dict.get("vlanId", ""),
+            "gatewayIpAddress": json_to_dict.get("gatewayIpAddress", ""),
+            "isLayer2Only": json_to_dict.get("isLayer2Only", False),
+            "tag": json_to_dict.get("tag", ""),
+            "vlanName": json_to_dict.get("vlanName", ""),
+            "intfDescription": json_to_dict.get("intfDescription", ""),
+            "mtu": json_to_dict.get("mtu", ""),
+            "suppressArp": json_to_dict.get("suppressArp", False),
+            "dhcpServerAddr1": json_to_dict.get("dhcpServerAddr1", ""),
+            "dhcpServerAddr2": json_to_dict.get("dhcpServerAddr2", ""),
+            "dhcpServerAddr3": json_to_dict.get("dhcpServerAddr3", ""),
+            "vrfDhcp": json_to_dict.get("vrfDhcp", ""),
+            "vrfDhcp2": json_to_dict.get("vrfDhcp2", ""),
+            "vrfDhcp3": json_to_dict.get("vrfDhcp3", ""),
+            "dhcpServers": json_to_dict.get("dhcpServers", ""),
+            "loopbackId": json_to_dict.get("loopbackId", ""),
+            "mcastGroup": json_to_dict.get("mcastGroup", ""),
+            "gatewayIpV6Address": json_to_dict.get("gatewayIpV6Address", ""),
+            "secondaryGW1": json_to_dict.get("secondaryGW1", ""),
+            "secondaryGW2": json_to_dict.get("secondaryGW2", ""),
+            "secondaryGW3": json_to_dict.get("secondaryGW3", ""),
+            "secondaryGW4": json_to_dict.get("secondaryGW4", ""),
+            "trmEnabled": json_to_dict.get("trmEnabled", False),
+            "rtBothAuto": json_to_dict.get("rtBothAuto", False),
+            "enableL3OnBorder": json_to_dict.get("enableL3OnBorder", False),
+            "networkName": json_to_dict.get("networkName", False),
+        }
+
+        if self.dcnm_version > 11:
+            t_conf.update(ENABLE_NETFLOW=json_to_dict.get("ENABLE_NETFLOW", False))
+            t_conf.update(SVI_NETFLOW_MONITOR=json_to_dict.get("SVI_NETFLOW_MONITOR", ""))
+            t_conf.update(VLAN_NETFLOW_MONITOR=json_to_dict.get("VLAN_NETFLOW_MONITOR", ""))
+
+        if "mcastGroup" not in json_to_dict:
+            del t_conf["mcastGroup"]
+
+        net.update({"networkTemplateConfig": json.dumps(t_conf)})
+        net.pop("displayName", None)
+        net.pop("serviceNetworkTemplate", None)
+        net.pop("source", None)
+
+        return net
+
+    @staticmethod
+    def is_missing_named_network_response(resp):
+        if not isinstance(resp, dict):
+            return False
+
+        if resp.get("RETURN_CODE") != 400:
+            return False
+
+        data = resp.get("DATA")
+        if not isinstance(data, dict):
+            return False
+
+        message = data.get("message", "")
+        if not isinstance(message, str):
+            return False
+
+        return message.lower() == "invalid network name"
+
     def get_have(self):
         caller = inspect.stack()[1][3]
 
@@ -2287,65 +2356,70 @@ class DcnmNetwork:
                     if not vrf_found:
                         self.module.fail_json(msg="VRF: {0} is missing in fabric: {1}".format(vrf_missing, self.fabric))
 
-        for vrf in vrf_objects["DATA"]:
+        use_targeted_network_lookups = state in ["merged", "replaced", "deleted"] and bool(self.config)
+        use_bulk_network_inventory = state == "overridden"
 
-            path = self.paths["GET_VRF_NET"].format(self.fabric, vrf["vrfName"])
+        if use_targeted_network_lookups:
+            requested_networks = []
+            seen_networks = set()
 
-            networks_per_vrf = dcnm_send(self.module, method, path)
+            for net in self.config:
+                net_name = net.get("net_name")
+                if not net_name or net_name in seen_networks:
+                    continue
+                seen_networks.add(net_name)
+                requested_networks.append(net_name)
 
-            if not networks_per_vrf["DATA"]:
-                continue
+            for network_name in requested_networks:
+                path = self.paths["GET_NET_NAME"].format(self.fabric, network_name)
+                network = dcnm_send(self.module, method, path)
 
-            for net in networks_per_vrf["DATA"]:
-                json_to_dict = json.loads(net["networkTemplateConfig"])
-                t_conf = {
-                    "vlanId": json_to_dict.get("vlanId", ""),
-                    "gatewayIpAddress": json_to_dict.get("gatewayIpAddress", ""),
-                    "isLayer2Only": json_to_dict.get("isLayer2Only", False),
-                    "tag": json_to_dict.get("tag", ""),
-                    "vlanName": json_to_dict.get("vlanName", ""),
-                    "intfDescription": json_to_dict.get("intfDescription", ""),
-                    "mtu": json_to_dict.get("mtu", ""),
-                    "suppressArp": json_to_dict.get("suppressArp", False),
-                    "dhcpServerAddr1": json_to_dict.get("dhcpServerAddr1", ""),
-                    "dhcpServerAddr2": json_to_dict.get("dhcpServerAddr2", ""),
-                    "dhcpServerAddr3": json_to_dict.get("dhcpServerAddr3", ""),
-                    "vrfDhcp": json_to_dict.get("vrfDhcp", ""),
-                    "vrfDhcp2": json_to_dict.get("vrfDhcp2", ""),
-                    "vrfDhcp3": json_to_dict.get("vrfDhcp3", ""),
-                    "dhcpServers": json_to_dict.get("dhcpServers", ""),
-                    "loopbackId": json_to_dict.get("loopbackId", ""),
-                    "mcastGroup": json_to_dict.get("mcastGroup", ""),
-                    "gatewayIpV6Address": json_to_dict.get("gatewayIpV6Address", ""),
-                    "secondaryGW1": json_to_dict.get("secondaryGW1", ""),
-                    "secondaryGW2": json_to_dict.get("secondaryGW2", ""),
-                    "secondaryGW3": json_to_dict.get("secondaryGW3", ""),
-                    "secondaryGW4": json_to_dict.get("secondaryGW4", ""),
-                    "trmEnabled": json_to_dict.get("trmEnabled", False),
-                    "rtBothAuto": json_to_dict.get("rtBothAuto", False),
-                    "enableL3OnBorder": json_to_dict.get("enableL3OnBorder", False),
-                    "networkName": json_to_dict.get("networkName", False),
-                }
+                missing_network, not_ok = self.handle_response(network, "query_dcnm")
 
-                if self.dcnm_version > 11:
-                    t_conf.update(ENABLE_NETFLOW=json_to_dict.get("ENABLE_NETFLOW", False))
-                    t_conf.update(SVI_NETFLOW_MONITOR=json_to_dict.get("SVI_NETFLOW_MONITOR", ""))
-                    t_conf.update(VLAN_NETFLOW_MONITOR=json_to_dict.get("VLAN_NETFLOW_MONITOR", ""))
+                if missing_network or self.is_missing_named_network_response(network):
+                    continue
+                if not_ok:
+                    msg = "Unable to find network: {0} under fabric: {1}".format(network_name, self.fabric)
+                    self.module.fail_json(msg=msg)
 
-                # Remove mcastGroup when Fabric is MSD
-                if "mcastGroup" not in json_to_dict:
-                    del t_conf["mcastGroup"]
+                network_data = network.get("DATA")
+                if not network_data:
+                    continue
+                if isinstance(network_data, list):
+                    if not network_data:
+                        continue
+                    network_data = network_data[0]
 
-                net.update({"networkTemplateConfig": json.dumps(t_conf)})
-                del net["displayName"]
-                del net["serviceNetworkTemplate"]
-                del net["source"]
+                normalized_net = self.normalize_have_network(network_data)
+                curr_networks.append(normalized_net["networkName"])
+                have_create.append(normalized_net)
+        elif use_bulk_network_inventory:
+            path = self.paths["GET_NET"].format(self.fabric)
+            networks = dcnm_send(self.module, method, path)
 
-                curr_networks.append(net["networkName"])
+            if networks.get("DATA"):
+                for net in networks["DATA"]:
+                    normalized_net = self.normalize_have_network(net)
+                    curr_networks.append(normalized_net["networkName"])
+                    have_create.append(normalized_net)
+        else:
+            for vrf in vrf_objects["DATA"]:
 
-                have_create.append(net)
+                path = self.paths["GET_VRF_NET"].format(self.fabric, vrf["vrfName"])
 
-        if l2only_configured is True or state == "deleted":
+                networks_per_vrf = dcnm_send(self.module, method, path)
+
+                if not networks_per_vrf["DATA"]:
+                    continue
+
+                for net in networks_per_vrf["DATA"]:
+                    normalized_net = self.normalize_have_network(net)
+                    curr_networks.append(normalized_net["networkName"])
+                    have_create.append(normalized_net)
+
+        if (l2only_configured is True and not use_bulk_network_inventory) or (
+            state == "deleted" and not use_targeted_network_lookups
+        ):
             path = self.paths["GET_VRF_NET"].format(self.fabric, "NA")
             networks_per_navrf = dcnm_send(self.module, method, path)
 
@@ -2353,48 +2427,9 @@ class DcnmNetwork:
                 for l2net in networks_per_navrf["DATA"]:
                     json_to_dict = json.loads(l2net["networkTemplateConfig"])
                     if (json_to_dict.get("vrfName", "")) == "NA":
-                        t_conf = {
-                            "vlanId": json_to_dict.get("vlanId", ""),
-                            "gatewayIpAddress": json_to_dict.get("gatewayIpAddress", ""),
-                            "isLayer2Only": json_to_dict.get("isLayer2Only", False),
-                            "tag": json_to_dict.get("tag", ""),
-                            "vlanName": json_to_dict.get("vlanName", ""),
-                            "intfDescription": json_to_dict.get("intfDescription", ""),
-                            "mtu": json_to_dict.get("mtu", ""),
-                            "suppressArp": json_to_dict.get("suppressArp", False),
-                            "dhcpServerAddr1": json_to_dict.get("dhcpServerAddr1", ""),
-                            "dhcpServerAddr2": json_to_dict.get("dhcpServerAddr2", ""),
-                            "dhcpServerAddr3": json_to_dict.get("dhcpServerAddr3", ""),
-                            "vrfDhcp": json_to_dict.get("vrfDhcp", ""),
-                            "vrfDhcp2": json_to_dict.get("vrfDhcp2", ""),
-                            "vrfDhcp3": json_to_dict.get("vrfDhcp3", ""),
-                            "dhcpServers": json_to_dict.get("dhcpServers", ""),
-                            "loopbackId": json_to_dict.get("loopbackId", ""),
-                            "mcastGroup": json_to_dict.get("mcastGroup", ""),
-                            "gatewayIpV6Address": json_to_dict.get("gatewayIpV6Address", ""),
-                            "secondaryGW1": json_to_dict.get("secondaryGW1", ""),
-                            "secondaryGW2": json_to_dict.get("secondaryGW2", ""),
-                            "secondaryGW3": json_to_dict.get("secondaryGW3", ""),
-                            "secondaryGW4": json_to_dict.get("secondaryGW4", ""),
-                            "trmEnabled": json_to_dict.get("trmEnabled", False),
-                            "rtBothAuto": json_to_dict.get("rtBothAuto", False),
-                            "enableL3OnBorder": json_to_dict.get("enableL3OnBorder", False),
-                            "networkName": json_to_dict.get("networkName", ""),
-                        }
-
-                        if self.dcnm_version > 11:
-                            t_conf.update(ENABLE_NETFLOW=json_to_dict.get("ENABLE_NETFLOW", False))
-                            t_conf.update(SVI_NETFLOW_MONITOR=json_to_dict.get("SVI_NETFLOW_MONITOR", ""))
-                            t_conf.update(VLAN_NETFLOW_MONITOR=json_to_dict.get("VLAN_NETFLOW_MONITOR", ""))
-
-                        l2net.update({"networkTemplateConfig": json.dumps(t_conf)})
-                        del l2net["displayName"]
-                        del l2net["serviceNetworkTemplate"]
-                        del l2net["source"]
-
-                        curr_networks.append(l2net["networkName"])
-
-                        have_create.append(l2net)
+                        normalized_net = self.normalize_have_network(l2net)
+                        curr_networks.append(normalized_net["networkName"])
+                        have_create.append(normalized_net)
 
         if not curr_networks:
             return
@@ -3594,6 +3629,7 @@ class DcnmNetwork:
 
         method = "POST"
         payload = copy.deepcopy(self.diff_undeploy)
+        delete_ready = False
         if self.diff_undeploy:
             # For multicluster_parent, use special endpoint and payload format
             # For all others (including multicluster_child), use standard /deployments path
@@ -3610,10 +3646,13 @@ class DcnmNetwork:
             # Use the self.wait_for_del_ready() function to refresh the state
             # of self.diff_delete dict and re-attempt the undeploy action if
             # the state of the network is "OUT-OF-SYNC"
-            self.wait_for_del_ready()
-            for net, state in self.diff_delete.items():
-                if state.upper() == "OUT-OF-SYNC":
-                    resp = dcnm_send(self.module, method, deploy_path, json.dumps(self.diff_undeploy))
+            delete_ready = self.wait_for_del_ready()
+            undeploy_retry_needed = any(
+                str(state).upper() == "OUT-OF-SYNC" for state in self.diff_delete.values()
+            )
+            if delete_ready and undeploy_retry_needed:
+                resp = dcnm_send(self.module, method, deploy_path, json.dumps(self.diff_undeploy))
+                delete_ready = False
 
             self.result["response"].append(resp)
             fail, self.result["changed"] = self.handle_response(resp, "deploy")
@@ -3625,7 +3664,7 @@ class DcnmNetwork:
 
         method = "DELETE"
         del_failure = ""
-        if self.diff_delete and self.wait_for_del_ready():
+        if self.diff_delete and (delete_ready or self.wait_for_del_ready()):
             resp = ""
             networks_to_delete = []
 

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -1640,6 +1640,39 @@ class DcnmNetwork:
 
         return serials
 
+    def get_delete_deploy_switch_serials(self, network_names):
+        """
+        Return switch serials affected by deleted networks using diff_detach data.
+
+        This keeps compatibility with delete-specific callers while the main
+        deploy path uses get_deploy_switch_serials(..., is_undeploy=True).
+        """
+        if isinstance(network_names, dict):
+            network_names = network_names.get("networkNames", "").split(",")
+        elif isinstance(network_names, str):
+            network_names = network_names.split(",")
+
+        requested_networks = [network_name.strip() for network_name in network_names if network_name.strip()]
+        serials = []
+        seen = set()
+
+        for network in getattr(self, "diff_detach", []):
+            if network.get("networkName") not in requested_networks:
+                continue
+            for attach in network.get("lanAttachList", []):
+                serial = attach.get("serialNumber") or attach.get("switchSerialNo")
+                if serial and serial not in seen:
+                    seen.add(serial)
+                    serials.append(serial)
+
+        if serials:
+            return serials
+
+        if hasattr(self, "network_sn_detach_map"):
+            return self.get_deploy_switch_serials(network_names, is_undeploy=True)
+
+        return []
+
     def network_serial_payload_transform(self, payload: dict, is_undeploy: bool = False) -> dict:
         """
         Transform network deploy payload for multicluster/resource mode.
@@ -3645,25 +3678,23 @@ class DcnmNetwork:
             return
 
         method = "POST"
-        if self.dcnm_version >= 12:
-            # Version 12+: Determine deploy path and payload format based on deploy_mode
-            if self.deploy_mode == "switch":
-                # Use switch-level deploy (undeploy operation for delete)
-                self.deploy_network_switches(
-                    network_names=[net["networkName"]],
-                    is_rollback=False,
-                    is_undeploy=True
-                )
-            else:
-                # Use resource-level deploy: /networks/deploy path with SN:networkNames
-                path = self.paths["GET_NET"].format(self.fabric)
-                deploy_path = path.replace(f"/fabrics/{self.fabric}/networks", "/networks/deploy")
-                resp = dcnm_send(self.module, method, deploy_path, json.dumps(deploy_payload))
-                if resp is not None:
-                    self.result["response"].append(resp)
-                    fail, dummy_changed = self.handle_response(resp, "deploy")
-                    if fail:
-                        self.failure(resp)
+        if self.deploy_mode == "switch":
+            # Use switch-level deploy (undeploy operation for delete)
+            self.deploy_network_switches(
+                network_names=[net["networkName"]],
+                is_rollback=False,
+                is_undeploy=True
+            )
+        elif self.dcnm_version >= 12:
+            # Version 12+: use resource-level deploy with SN:networkNames payload.
+            path = self.paths["GET_NET"].format(self.fabric)
+            deploy_path = path.replace(f"/fabrics/{self.fabric}/networks", "/networks/deploy")
+            resp = dcnm_send(self.module, method, deploy_path, json.dumps(deploy_payload))
+            if resp is not None:
+                self.result["response"].append(resp)
+                fail, dummy_changed = self.handle_response(resp, "deploy")
+                if fail:
+                    self.failure(resp)
         else:
             # Version < 12: use legacy /deployments path
             path = self.paths["GET_NET_SWITCH_DEPLOY"].format(self.fabric)
@@ -3789,7 +3820,7 @@ class DcnmNetwork:
 
         Wait for network attachments to be ready for deletion by checking lanAttachState.
 
-        Uses bulk GET_NET_ATTACH API to check all networks in a single call per retry iteration.
+        Uses batched GET_NET_ATTACH API calls to check all networks per retry iteration.
         Terminal states (ready for deletion):
         - NA: Attachment has been removed
         - OUT-OF-SYNC, FAILED: Can proceed with cleanup
@@ -3818,31 +3849,55 @@ class DcnmNetwork:
         self.log.debug(msg)
 
         deploy_triggered = set()  # Track networks that had deploy triggered
+        batch_size = 30
 
         while pending_networks and retry_count > 0:
             retry_count -= 1
 
-            # Make ONE bulk API call for all pending networks
-            network_names = ",".join(pending_networks)
+            networks_by_name = {}
+            poll_incomplete = False
 
-            if self.fabric_type == "multicluster_parent":
+            # Keep the query string small enough for large delete batches.
+            for index in range(0, len(pending_networks), batch_size):
+                network_names = ",".join(pending_networks[index:index + batch_size])
                 path = self.paths["GET_NET_ATTACH"].format(self.fabric, network_names)
-            else:
-                # For non-multicluster, use GET_NET_ATTACH for consistency and bulk support
-                path = self.paths["GET_NET_ATTACH"].format(self.fabric, network_names)
+                resp = dcnm_send(self.module, method, path)
 
-            resp = dcnm_send(self.module, method, path)
+                if not isinstance(resp, dict):
+                    msg = "Unexpected response while waiting for network attachments. "
+                    msg += f"path: {path}, response_type: {type(resp).__name__}, response: {str(resp)[:500]}"
+                    self.module.fail_json(msg=msg)
 
-            if resp.get("DATA") is None:
+                data = resp.get("DATA")
+                if data is None:
+                    poll_incomplete = True
+                    break
+
+                if not isinstance(data, list):
+                    msg = "Unexpected DATA while waiting for network attachments. "
+                    msg += f"path: {path}, return_code: {resp.get('RETURN_CODE')}, "
+                    msg += f"data_type: {type(data).__name__}, data: {str(data)[:500]}"
+                    self.module.fail_json(msg=msg)
+
+                sanitized_data = sanitize_lan_attach_list(data) if data else []
+                if not isinstance(sanitized_data, list):
+                    msg = "Unexpected sanitized DATA while waiting for network attachments. "
+                    msg += f"path: {path}, data_type: {type(sanitized_data).__name__}"
+                    self.module.fail_json(msg=msg)
+
+                for net_data in sanitized_data:
+                    if not isinstance(net_data, dict):
+                        msg = "Unexpected network attachment entry while waiting for network attachments. "
+                        msg += f"path: {path}, entry_type: {type(net_data).__name__}, entry: {str(net_data)[:500]}"
+                        self.module.fail_json(msg=msg)
+
+                    network_name = net_data.get("networkName")
+                    if network_name:
+                        networks_by_name[network_name] = net_data
+
+            if poll_incomplete:
                 time.sleep(self.WAIT_TIME_FOR_DELETE_LOOP)
                 continue
-
-            # Sanitize and build lookup dictionary
-            sanitized_data = sanitize_lan_attach_list(resp["DATA"]) if resp["DATA"] else []
-            networks_by_name = {
-                net_data.get("networkName"): net_data
-                for net_data in sanitized_data
-            }
 
             # Process all pending networks
             networks_to_remove = []
@@ -4156,25 +4211,23 @@ class DcnmNetwork:
         payload = copy.deepcopy(self.diff_undeploy)
         delete_ready = False
         if self.diff_undeploy:
-            if self.dcnm_version >= 12:
-                # Determine deploy path and payload format
-                if self.deploy_mode == "switch":
-                    # Use switch-level deploy (undeploy operation)
-                    self.deploy_network_switches(payload, is_rollback, is_undeploy=True)
-                else:
-                    # Use resource-level deploy: /networks/deploy path with SN:networkNames
-                    path = self.paths["GET_NET"].format(self.fabric)
-                    deploy_path = path.replace(f"/fabrics/{self.fabric}/networks", "/networks/deploy")
-                    deploy_payload = self.network_serial_payload_transform(payload, is_undeploy=True)
-                    resp = dcnm_send(self.module, method, deploy_path, json.dumps(deploy_payload))
-                    if resp is not None:
-                        self.result["response"].append(resp)
-                        fail, self.result["changed"] = self.handle_response(resp, "deploy")
-                        if fail:
-                            if is_rollback:
-                                self.failed_to_rollback = True
-                                return
-                            self.failure(resp)
+            if self.deploy_mode == "switch":
+                # Use switch-level deploy (undeploy operation)
+                self.deploy_network_switches(payload, is_rollback, is_undeploy=True)
+            elif self.dcnm_version >= 12:
+                # Use resource-level deploy: /networks/deploy path with SN:networkNames
+                path = self.paths["GET_NET"].format(self.fabric)
+                deploy_path = path.replace(f"/fabrics/{self.fabric}/networks", "/networks/deploy")
+                deploy_payload = self.network_serial_payload_transform(payload, is_undeploy=True)
+                resp = dcnm_send(self.module, method, deploy_path, json.dumps(deploy_payload))
+                if resp is not None:
+                    self.result["response"].append(resp)
+                    fail, self.result["changed"] = self.handle_response(resp, "deploy")
+                    if fail:
+                        if is_rollback:
+                            self.failed_to_rollback = True
+                            return
+                        self.failure(resp)
             else:
                 # Version < 12: use legacy /deployments path with networkNames
                 path = self.paths["GET_NET"].format(self.fabric)
@@ -4204,25 +4257,23 @@ class DcnmNetwork:
                 # Reset delete_ready since we're performing another deploy operation
                 delete_ready = False
 
-                if self.dcnm_version >= 12:
-                    # Version 12+: Determine deploy path and payload format
-                    if self.deploy_mode == "switch":
-                        # Use switch-level deploy (undeploy retry)
-                        self.deploy_network_switches(payload, is_rollback, is_undeploy=True)
-                    else:
-                        # Use resource-level deploy: /networks/deploy path with SN:networkNames
-                        path = self.paths["GET_NET"].format(self.fabric)
-                        deploy_path = path.replace(f"/fabrics/{self.fabric}/networks", "/networks/deploy")
-                        deploy_payload = self.network_serial_payload_transform(payload, is_undeploy=True)
-                        resp = dcnm_send(self.module, method, deploy_path, json.dumps(deploy_payload))
-                        if resp is not None:
-                            self.result["response"].append(resp)
-                            fail, self.result["changed"] = self.handle_response(resp, "deploy")
-                            if fail:
-                                if is_rollback:
-                                    self.failed_to_rollback = True
-                                    return
-                                self.failure(resp)
+                if self.deploy_mode == "switch":
+                    # Use switch-level deploy (undeploy retry)
+                    self.deploy_network_switches(payload, is_rollback, is_undeploy=True)
+                elif self.dcnm_version >= 12:
+                    # Use resource-level deploy: /networks/deploy path with SN:networkNames
+                    path = self.paths["GET_NET"].format(self.fabric)
+                    deploy_path = path.replace(f"/fabrics/{self.fabric}/networks", "/networks/deploy")
+                    deploy_payload = self.network_serial_payload_transform(payload, is_undeploy=True)
+                    resp = dcnm_send(self.module, method, deploy_path, json.dumps(deploy_payload))
+                    if resp is not None:
+                        self.result["response"].append(resp)
+                        fail, self.result["changed"] = self.handle_response(resp, "deploy")
+                        if fail:
+                            if is_rollback:
+                                self.failed_to_rollback = True
+                                return
+                            self.failure(resp)
                 else:
                     # Version < 12: use legacy /deployments path with networkNames
                     path = self.paths["GET_NET"].format(self.fabric)

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -1131,7 +1131,8 @@ class DcnmNetwork:
         self.log.debug(msg)
         # Check for bulk API support
         self.has_bulk_api = dcnm_get_bulk_api_support(self.module)
-
+        msg = f"Bulk API support detected: {self.has_bulk_api}"
+        self.log.debug(msg)
 
         self.inventory_data = get_nd_fabric_inventory_details(self.module, self.dcnm_version, self.fabric, self.fabric_details)
 
@@ -1643,6 +1644,8 @@ class DcnmNetwork:
         msg = f"Returning {len(serials)} serials for networks: {network_names}"
         self.log.debug(msg)
 
+        msg = f"Serials: {serials}"
+        self.log.debug(msg)
         return serials
 
     def get_delete_deploy_switch_serials(self, network_names):
@@ -1715,7 +1718,7 @@ class DcnmNetwork:
 
         # Select the appropriate map based on operation type
         network_to_serial_map = self.network_sn_detach_map if is_undeploy else self.network_sn_attach_map
-        
+
         map_type = "detach" if is_undeploy else "attach"
         msg = f"Using network_sn_{map_type}_map for payload transformation."
         self.log.debug(msg)
@@ -1744,7 +1747,7 @@ class DcnmNetwork:
         Uses network attachment data to determine affected switches.
         Works for both deploy and undeploy operations.
         Handles response internally and updates self.result.
-        
+
         Args:
             network_names: Networks to deploy/undeploy
             is_rollback: Whether this is a rollback operation
@@ -1764,7 +1767,7 @@ class DcnmNetwork:
         )
 
         resp = dcnm_send(self.module, method, deploy_path)
-        
+
         if resp is not None:
             self.result["response"].append(resp)
             fail, self.result["changed"] = self.handle_response(resp, "deploy")
@@ -4166,25 +4169,71 @@ class DcnmNetwork:
                 if attr in template_mapping:
                     skipped_template_keys.add(template_mapping[attr])
 
-            for net in self.diff_create_update:
-                # Remove skipped attributes from template config for parent fabrics
-                if net.get("networkTemplateConfig") and skipped_template_keys:
-                    json_to_dict = json.loads(net["networkTemplateConfig"])
-                    for key in list(json_to_dict.keys()):
-                        if key in skipped_template_keys:
-                            del json_to_dict[key]
-                    net["networkTemplateConfig"] = json.dumps(json_to_dict)
+            action = "create"
+            use_bulk = self.has_bulk_api and self.fabric_type != "multicluster_parent"
+            # Initialize based on API type
+            if use_bulk:
+                bulk_payload = []
+                verb = "PUT"
+                bulk_path = self.paths["UPDATE_NET_BULK"]
+            else:
+                verb = "PUT"
+                base_path = self.paths["GET_NET"].format(self.fabric)
 
-                update_path = path + "/{0}".format(net["networkName"])
-                resp = dcnm_send(self.module, method, update_path, json.dumps(net))
+            # Process each network
+            for net in self.diff_create_update:
+                # Parse template config
+                json_to_dict = json.loads(net["networkTemplateConfig"])
+                network_name = json_to_dict.get("networkName")
+
+                msg = f"Processing network {network_name}"
+                self.log.debug(msg)
+
+                # Remove skipped attributes
+                for key in list(json_to_dict.keys()):
+                    if key in skipped_template_keys:
+                        del json_to_dict[key]
+
+                if use_bulk:
+                    # Build network object for bulk API (dict template config)
+                    network_obj = {
+                        "fabric": net["fabric"],
+                        "networkName": net["networkName"],
+                        "displayName": net.get("displayName", net["networkName"]),
+                        "networkId": net["networkId"],
+                        "networkTemplate": net["networkTemplate"],
+                        "networkExtensionTemplate": net["networkExtensionTemplate"],
+                        "vrf": net["vrf"],
+                        "networkTemplateConfig": json_to_dict  # Dict
+                    }
+                    bulk_payload.append(network_obj)
+                else:
+                    # Individual update - keep JSON string format
+                    net["networkTemplateConfig"] = json.dumps(json_to_dict)
+                    update_path = base_path + "/{0}".format(net["networkName"])
+
+                    resp = dcnm_send(self.module, verb, update_path, json.dumps(net))
+                    self.result["response"].append(resp)
+                    fail, self.result["changed"] = self.handle_response(resp, action)
+                    if fail:
+                        if is_rollback:
+                            self.failed_to_rollback = True
+                            return
+                        self.failure(resp)
+
+            # Send bulk request if applicable
+            if use_bulk and bulk_payload:
+                msg = f"Sending v2 bulk-update request for {len(bulk_payload)} network(s)"
+                self.log.debug(msg)
+
+                resp = dcnm_send(self.module, verb, bulk_path, json.dumps(bulk_payload))
                 self.result["response"].append(resp)
-                fail, self.result["changed"] = self.handle_response(resp, "create")
+                fail, self.result["changed"] = self.handle_response(resp, action)
                 if fail:
                     if is_rollback:
                         self.failed_to_rollback = True
                         return
                     self.failure(resp)
-
         #
         # The detach and un-deploy operations are executed before the create,attach and deploy to particularly
         # address cases where a VLAN of a network being deleted is re-used on a new network being created. This is
@@ -4534,276 +4583,6 @@ class DcnmNetwork:
                     self.failed_to_rollback = True
                     return
                 self.failure(resp)
-
-    def _push_diff_create_update_bulk(self, is_rollback=False):
-        """
-        # Summary
-
-        Send diff_create_update to controller using v2 bulk-update API.
-        Used exclusively for dcnm_version == -1.
-
-        ## V2 Bulk Update API:
-        - Method: PUT
-        - Path: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/v2/bulk-update/networks
-        - Payload: Array of network objects
-        - networkTemplateConfig: dict object (not JSON string)
-
-        ## Response Format:
-        {
-          "successList": [
-            {"name": "net1", "id": 30001, "message": "Network updated successfully.", "status": "Success"}
-          ]
-        }
-        """
-        method_name = inspect.stack()[0][3]
-        caller = inspect.stack()[1][3]
-
-        msg = "ENTERED. "
-        msg += f"caller: {caller}."
-        self.log.debug(msg)
-
-        bulk_payload = []
-
-        msg = f"Processing {len(self.diff_create_update)} network(s) for bulk update"
-        self.log.debug(msg)
-
-        # Get skipped attributes for parent fabrics
-        skipped_attributes = self.get_skipped_attributes()
-        template_mapping = self.get_template_config_mapping()
-
-        # Convert skipped spec attributes to template config keys
-        skipped_template_keys = set()
-        for attr in skipped_attributes:
-            if attr in template_mapping:
-                skipped_template_keys.add(template_mapping[attr])
-
-        self.log.debug(f"Create_update {self.diff_create_update}")
-        for network in self.diff_create_update:
-            # Parse JSON string template config
-            json_to_dict = json.loads(network["networkTemplateConfig"])
-            network_name = json_to_dict.get("networkName")
-
-            msg = f"Processing network {network_name} for bulk update"
-            self.log.debug(msg)
-
-            msg = f"Network {network_name} template config: "
-            msg += f"{json.dumps(json_to_dict, indent=4, sort_keys=True)}"
-            self.log.debug(msg)
-
-            # Remove skipped attributes from template config for parent fabrics
-            for key in list(json_to_dict.keys()):
-                if key in skipped_template_keys:
-                    del json_to_dict[key]
-
-            # Build network object for v2 bulk API
-            # Key difference: networkTemplateConfig is dict, NOT JSON string
-            network_obj = {
-                "fabric": network["fabric"],
-                "networkName": network["networkName"],
-                "displayName": network.get("displayName", network["networkName"]),
-                "networkId": network["networkId"],
-                "networkTemplate": network["networkTemplate"],
-                "networkExtensionTemplate": network["networkExtensionTemplate"],
-                "vrf": network["vrf"],
-                "networkTemplateConfig": json_to_dict  # Dict object, not JSON string
-            }
-
-            msg = f"Network {network_name} bulk payload object: "
-            msg += f"{json.dumps(network_obj, indent=4, sort_keys=True)}"
-            self.log.debug(msg)
-
-            bulk_payload.append(network_obj)
-
-        if bulk_payload:
-            action = "bulk_update"
-            verb = "PUT"
-            path = self.paths["UPDATE_NET_BULK"]
-
-            msg = f"Sending v2 bulk-update request for {len(bulk_payload)} network(s)"
-            self.log.debug(msg)
-
-            msg = "Complete bulk update payload: "
-            msg += f"{json.dumps(bulk_payload, indent=4, sort_keys=True)}"
-            self.log.debug(msg)
-
-            resp = dcnm_send(self.module, verb, path, json.dumps(bulk_payload))
-            self.result["response"].append(resp)
-            fail, self.result["changed"] = self.handle_response(resp, action)
-            if fail:
-                if is_rollback:
-                    self.failed_to_rollback = True
-                    return
-                self.failure(resp)
-
-    def _push_diff_create_update_individual(self, is_rollback=False):
-        """
-        # Summary
-
-        Send diff_create_update to controller using individual PUT per network.
-        Used for all versions except dcnm_version == -1.
-
-        ## Individual Update API:
-        - Method: PUT
-        - Path: .../fabrics/{fabric}/networks/{networkName}
-        - Payload: Single network object
-        - networkTemplateConfig: JSON string
-        """
-        method_name = inspect.stack()[0][3]
-        caller = inspect.stack()[1][3]
-
-        msg = "ENTERED. "
-        msg += f"caller: {caller}."
-        self.log.debug(msg)
-
-        msg = f"Processing {len(self.diff_create_update)} network(s) for individual update"
-        self.log.debug(msg)
-
-        self.log.debug(f"Processing create/update operations for networks: {json.dumps(self.diff_create_update)}")
-
-        # Get skipped attributes for parent fabrics
-        skipped_attributes = self.get_skipped_attributes()
-        template_mapping = self.get_template_config_mapping()
-
-        # Convert skipped spec attributes to template config keys
-        skipped_template_keys = set()
-        for attr in skipped_attributes:
-            if attr in template_mapping:
-                skipped_template_keys.add(template_mapping[attr])
-
-        action = "create"
-        verb = "PUT"
-        base_path = self.paths["GET_NET"].format(self.fabric)
-
-        for net in self.diff_create_update:
-            # Remove skipped attributes from template config for parent fabrics
-            if net.get("networkTemplateConfig") and skipped_template_keys:
-                json_to_dict = json.loads(net["networkTemplateConfig"])
-                for key in list(json_to_dict.keys()):
-                    if key in skipped_template_keys:
-                        del json_to_dict[key]
-                net["networkTemplateConfig"] = json.dumps(json_to_dict)
-
-            update_path = base_path + "/{0}".format(net["networkName"])
-
-            msg = f"Sending individual update for network {net['networkName']}"
-            self.log.debug(msg)
-
-            msg = f"Network {net['networkName']} payload: "
-            msg += f"{json.dumps(net, indent=4, sort_keys=True)}"
-            self.log.debug(msg)
-
-            resp = dcnm_send(self.module, verb, update_path, json.dumps(net))
-            self.result["response"].append(resp)
-            fail, self.result["changed"] = self.handle_response(resp, action)
-            if fail:
-                if is_rollback:
-                    self.failed_to_rollback = True
-                    return
-                self.failure(resp)
-
-    # ========================================================================
-    # COMMENTED OUT: CONSOLIDATED SINGLE-METHOD APPROACH
-    # ========================================================================
-    # Alternative implementation using a single method with inline conditionals.
-    # This approach is more compact but less testable and maintainable.
-    # Uncomment and replace the three methods above if you prefer this style.
-    # ========================================================================
-    #
-    # def push_to_remote(self, is_rollback=False):
-    #     caller = inspect.stack()[1][3]
-    #
-    #     msg = "ENTERED. "
-    #     msg += f"caller: {caller}. "
-    #     msg += f"is_rollback: {is_rollback}"
-    #     self.log.debug(msg)
-    #
-    #     path = self.paths["GET_NET"].format(self.fabric)
-    #
-    #     # Handle network create/update operations
-    #     if self.diff_create_update:
-    #         # Determine if using bulk API
-    #         use_bulk_api = (self.dcnm_version == -1)
-    #
-    #         msg = f"Using {'v2 bulk-update' if use_bulk_api else 'individual update'} API"
-    #         self.log.debug(msg)
-    #
-    #         # Get skipped attributes for parent fabrics
-    #         skipped_attributes = self.get_skipped_attributes()
-    #         template_mapping = self.get_template_config_mapping()
-    #
-    #         # Convert skipped spec attributes to template config keys
-    #         skipped_template_keys = set()
-    #         for attr in skipped_attributes:
-    #             if attr in template_mapping:
-    #                 skipped_template_keys.add(template_mapping[attr])
-    #
-    #         # Initialize based on API type
-    #         if use_bulk_api:
-    #             bulk_payload = []
-    #             action = "bulk_update"
-    #             verb = "PUT"
-    #             bulk_path = self.paths["UPDATE_NET_BULK"]
-    #         else:
-    #             action = "create"
-    #             verb = "PUT"
-    #             base_path = self.paths["GET_NET"].format(self.fabric)
-    #
-    #         # Process each network
-    #         for net in self.diff_create_update:
-    #             # Parse template config
-    #             json_to_dict = json.loads(net["networkTemplateConfig"])
-    #             network_name = json_to_dict.get("networkName")
-    #
-    #             msg = f"Processing network {network_name}"
-    #             self.log.debug(msg)
-    #
-    #             # Remove skipped attributes
-    #             for key in list(json_to_dict.keys()):
-    #                 if key in skipped_template_keys:
-    #                     del json_to_dict[key]
-    #
-    #             if use_bulk_api:
-    #                 # Build network object for bulk API (dict template config)
-    #                 network_obj = {
-    #                     "fabric": net["fabric"],
-    #                     "networkName": net["networkName"],
-    #                     "displayName": net.get("displayName", net["networkName"]),
-    #                     "networkId": net["networkId"],
-    #                     "networkTemplate": net["networkTemplate"],
-    #                     "networkExtensionTemplate": net["networkExtensionTemplate"],
-    #                     "vrf": net["vrf"],
-    #                     "networkTemplateConfig": json_to_dict  # Dict
-    #                 }
-    #                 bulk_payload.append(network_obj)
-    #             else:
-    #                 # Individual update - keep JSON string format
-    #                 net["networkTemplateConfig"] = json.dumps(json_to_dict)
-    #                 update_path = base_path + "/{0}".format(net["networkName"])
-    #
-    #                 resp = dcnm_send(self.module, verb, update_path, json.dumps(net))
-    #                 self.result["response"].append(resp)
-    #                 fail, self.result["changed"] = self.handle_response(resp, action)
-    #                 if fail:
-    #                     if is_rollback:
-    #                         self.failed_to_rollback = True
-    #                         return
-    #                     self.failure(resp)
-    #
-    #         # Send bulk request if applicable
-    #         if use_bulk_api and bulk_payload:
-    #             msg = f"Sending v2 bulk-update request for {len(bulk_payload)} network(s)"
-    #             self.log.debug(msg)
-    #             resp = dcnm_send(self.module, verb, bulk_path, json.dumps(bulk_payload))
-    #             self.result["response"].append(resp)
-    #             fail, self.result["changed"] = self.handle_response(resp, action)
-    #             if fail:
-    #                 if is_rollback:
-    #                     self.failed_to_rollback = True
-    #                     return
-    #                 self.failure(resp)
-    #
-    #     # ... rest of existing code for detach, deploy, etc ...
-    # ========================================================================
 
     def get_fabric_multicast_group_address(self) -> str:
         """
@@ -5223,7 +5002,8 @@ class DcnmNetwork:
             return False, False
 
         # Responses to all other operations POST and PUT are handled here.
-        if res.get("MESSAGE") != "OK" or res["RETURN_CODE"] != 200:
+        # Accept both 200 (OK) and 207 (Multi-Status) for bulk operations
+        if res.get("MESSAGE") != "OK" or res["RETURN_CODE"] not in [200, 207]:
             fail = True
             changed = False
             return fail, changed

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -1231,6 +1231,47 @@ class DcnmNetwork:
                     merged_ports.append(port)
         return ",".join(merged_ports)
 
+    def normalize_vpc_torports(self, networks):
+        """
+        NDFC reflects TOR attachments on both VPC peers even when the playbook
+        only models them on one peer. Mirror one-sided TOR intent across the
+        peer pair before diffing so merged/replaced are evaluated consistently.
+        """
+
+        if not networks:
+            return
+
+        networks_by_serial = {network.get("serialNumber"): network for network in networks}
+
+        for network in networks:
+            serial = network.get("serialNumber")
+            if not serial:
+                continue
+
+            ip_address = next((ip for ip, ser in self.ip_sn.items() if ser == serial), None)
+            if not ip_address:
+                continue
+
+            switch_details = self.inventory_data.get(ip_address, {})
+            if not switch_details.get("isVpcConfigured"):
+                continue
+
+            peer_serial = switch_details.get("peerSerialNumber")
+            if not peer_serial:
+                continue
+
+            peer_network = networks_by_serial.get(peer_serial)
+            if not peer_network:
+                continue
+
+            network_torports = network.get("torports") or []
+            peer_torports = peer_network.get("torports") or []
+
+            if network_torports and not peer_torports:
+                peer_network["torports"] = copy.deepcopy(network_torports)
+            elif peer_torports and not network_torports:
+                network["torports"] = copy.deepcopy(peer_torports)
+
     def diff_for_attach_deploy(self, want_a, have_a, replace=False):
         caller = inspect.stack()[1][3]
 
@@ -1240,16 +1281,18 @@ class DcnmNetwork:
         self.log.debug(msg)
 
         attach_list = []
-        atch_tor_ports = []
 
         if not want_a:
             return attach_list
 
+        working_have_a = copy.deepcopy(have_a) if have_a else []
+        original_have_a = copy.deepcopy(have_a) if have_a else []
+
         dep_net = False
         for want in want_a:
             found = False
-            if have_a:
-                for have in have_a:
+            if working_have_a:
+                for have in working_have_a:
                     if want["serialNumber"] == have["serialNumber"] and want["networkName"] == have["networkName"]:
                         found = True
 
@@ -1269,19 +1312,21 @@ class DcnmNetwork:
                                                     h_tor_ports = tor_h["torPorts"].split(",") if tor_h["torPorts"] else []
                                                     w_tor_ports = tor_w["torPorts"].split(",") if tor_w["torPorts"] else []
 
-                                                    if sorted(h_tor_ports) != sorted(w_tor_ports):
-                                                        atch_tor_ports = list(set(w_tor_ports) - set(h_tor_ports))
-
                                                     if replace:
-                                                        atch_tor_ports = w_tor_ports
+                                                        merged_tor_ports = w_tor_ports
                                                     else:
-                                                        atch_tor_ports.extend(h_tor_ports)
+                                                        merged_tor_ports = self.merge_port_lists(
+                                                            [tor_w.get("torPorts", ""), tor_h.get("torPorts", "")]
+                                                        )
+                                                        merged_tor_ports = (
+                                                            merged_tor_ports.split(",") if merged_tor_ports else []
+                                                        )
 
-                                                    torconfig = tor_w["switch"] + "(" + ",".join(atch_tor_ports) + ")"
+                                                    torconfig = tor_w["switch"] + "(" + ",".join(merged_tor_ports) + ")"
                                                     torconfig_list.append(torconfig)
                                                     # Update torports_configured to True. If there is no other config change for attach
                                                     # We will still append this attach to attach_list as there is tor port change
-                                                    if sorted(atch_tor_ports) != sorted(h_tor_ports):
+                                                    if sorted(merged_tor_ports) != sorted(h_tor_ports):
                                                         torports_configured = True
 
                                         if not torports_present:
@@ -1437,7 +1482,7 @@ class DcnmNetwork:
                     if peer_ser == attch["serialNumber"]:
                         peer_found = True
                 if not peer_found:
-                    for hav in have_a:
+                    for hav in original_have_a:
                         if hav["serialNumber"] == peer_ser:
                             havtoattach = copy.deepcopy(hav)
                             havtoattach.update({"switchPorts": ""})
@@ -2531,6 +2576,7 @@ class DcnmNetwork:
 
                 networks.append(result)
             if networks:
+                self.normalize_vpc_torports(networks)
                 for attch in net["attach"]:
                     for ip, ser in self.ip_sn.items():
                         if ser == attch["serialNumber"]:

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -1033,6 +1033,7 @@ class DcnmNetwork:
             "GET_NET_STATUS": "/rest/top-down/fabrics/{}/networks/{}/status",
             "GET_NET_SWITCH_DEPLOY": "/rest/top-down/fabrics/networks/deploy",
             "GET_NET_SWITCH_DEPLOY_ONEMANAGE": "/onemanage/rest/top-down/networks/deploy",
+            "GET_NET_SWITCH_CONFIG_DEPLOY": "/rest/control/fabrics/{}/config-deploy/{}?forceShowRun=false",
         },
         12: {
             "GET_VRF": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{}/vrfs",
@@ -1046,6 +1047,7 @@ class DcnmNetwork:
             "GET_NET_STATUS": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{}/networks/{}/status",
             "GET_NET_SWITCH_DEPLOY": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/networks/deploy",
             "GET_NET_SWITCH_DEPLOY_ONEMANAGE": "/onemanage/appcenter/cisco/ndfc/api/v1/onemanage/top-down/networks/deploy",
+            "GET_NET_SWITCH_CONFIG_DEPLOY": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{}/config-deploy/{}?forceShowRun=false",
         },
     }
 
@@ -1653,6 +1655,65 @@ class DcnmNetwork:
             multicluster_payload[serial] = ",".join(networks)
 
         return multicluster_payload
+
+    def get_delete_deploy_switch_serials(self, network_names=None, attach_source=None):
+        """
+        Return ordered, unique switch serials affected by delete-time network detaches.
+        """
+
+        if isinstance(network_names, dict):
+            network_names = network_names.get("networkNames")
+
+        wanted_networks = None
+        if network_names:
+            if isinstance(network_names, str):
+                wanted_networks = set(
+                    name.strip() for name in network_names.split(",") if name.strip()
+                )
+            else:
+                wanted_networks = set(network_names)
+
+        source = attach_source
+        if source is None:
+            source = getattr(self, "diff_detach", [])
+        if isinstance(source, dict):
+            source = [source]
+
+        serials = []
+        seen = set()
+        for net_attach in source or []:
+            network_name = net_attach.get("networkName")
+            if wanted_networks and network_name not in wanted_networks:
+                continue
+
+            attach_list = net_attach.get("lanAttachList", net_attach.get("switchList", []))
+            for attach in attach_list:
+                serial = attach.get("serialNumber") or attach.get("switchSerialNo")
+                if not serial or serial in seen:
+                    continue
+                seen.add(serial)
+                serials.append(serial)
+
+        return serials
+
+    def deploy_deleted_network_switches(self, network_names=None, attach_source=None):
+        """
+        Trigger switch-level config deploy for switches touched by network deletion.
+        """
+
+        serials = self.get_delete_deploy_switch_serials(network_names, attach_source)
+        if not serials:
+            msg = "No switch serials found for delete-time config deploy."
+            self.log.debug(msg)
+            return None
+
+        method = "POST"
+        deploy_path = self.paths["GET_NET_SWITCH_CONFIG_DEPLOY"].format(
+            self.fabric,
+            ",".join(serials)
+        )
+
+        return dcnm_send(self.module, method, deploy_path)
 
     def diff_for_create(self, want, have):
         caller = inspect.stack()[1][3]
@@ -3478,9 +3539,22 @@ class DcnmNetwork:
             if fail:
                 self.failure(resp)
 
+        if not deploy_payload:
+            return
+
         method = "POST"
-        path = self.paths["GET_NET_SWITCH_DEPLOY"].format(self.fabric)
-        resp = dcnm_send(self.module, method, path, json.dumps(deploy_payload))
+        if self.fabric_type != "multicluster_parent" and self.deploy_mode == "switch":
+            resp = self.deploy_deleted_network_switches(
+                network_names=[net["networkName"]],
+                attach_source=[payload_net]
+            )
+        else:
+            path = self.paths["GET_NET_SWITCH_DEPLOY"].format(self.fabric)
+            resp = dcnm_send(self.module, method, path, json.dumps(deploy_payload))
+
+        if resp is None:
+            return
+
         self.result["response"].append(resp)
         fail, dummy_changed = self.handle_response(resp, "deploy")
         if fail:
@@ -3966,19 +4040,27 @@ class DcnmNetwork:
         payload = copy.deepcopy(self.diff_undeploy)
         delete_ready = False
         if self.diff_undeploy:
+            use_delete_config_deploy = (
+                self.fabric_type != "multicluster_parent"
+                and self.deploy_mode == "switch"
+                and bool(self.diff_delete)
+            )
             # For multicluster_parent, always use switch-level endpoint and payload format
             # For all others, check deploy_mode parameter
-            if self.fabric_type == "multicluster_parent" or self.deploy_mode == "switch":
+            if use_delete_config_deploy:
+                resp = self.deploy_deleted_network_switches(payload)
+            elif self.fabric_type == "multicluster_parent" or self.deploy_mode == "switch":
                 # Use switch-level deploy: transform payload to serial number format
                 deploy_path = self.paths["GET_NET_SWITCH_DEPLOY"].format(self.fabric)
                 deploy_payload = self.transform_deploy_payload_for_multicluster(payload, use_diff_attach=False)
+                resp = dcnm_send(self.module, method, deploy_path, json.dumps(deploy_payload))
             else:
                 # Use resource-level deploy: standard /deployments path with networkNames
                 path = self.paths["GET_NET"].format(self.fabric)
                 deploy_path = path + "/deployments"
                 deploy_payload = payload
+                resp = dcnm_send(self.module, method, deploy_path, json.dumps(deploy_payload))
 
-            resp = dcnm_send(self.module, method, deploy_path, json.dumps(deploy_payload))
             # Use the self.wait_for_network_attachments_del_ready() function to refresh the state
             # of self.diff_delete dict and re-attempt the undeploy action if
             # the state of the network is "OUT-OF-SYNC"
@@ -3987,16 +4069,20 @@ class DcnmNetwork:
                 str(state).upper() == "OUT-OF-SYNC" for state in self.diff_delete.values()
             )
             if delete_ready and undeploy_retry_needed:
-                resp = dcnm_send(self.module, method, deploy_path, json.dumps(self.diff_undeploy))
+                if use_delete_config_deploy:
+                    resp = self.deploy_deleted_network_switches(payload)
+                else:
+                    resp = dcnm_send(self.module, method, deploy_path, json.dumps(deploy_payload))
                 delete_ready = False
 
-            self.result["response"].append(resp)
-            fail, self.result["changed"] = self.handle_response(resp, "deploy")
-            if fail:
-                if is_rollback:
-                    self.failed_to_rollback = True
-                    return
-                self.failure(resp)
+            if resp is not None:
+                self.result["response"].append(resp)
+                fail, self.result["changed"] = self.handle_response(resp, "deploy")
+                if fail:
+                    if is_rollback:
+                        self.failed_to_rollback = True
+                        return
+                    self.failure(resp)
 
         method = "DELETE"
         del_failure = ""

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -1583,75 +1583,6 @@ class DcnmNetwork:
 
         return attach
 
-    def update_network_sn_attach_map(self):
-        """
-        Build/update centralized map of network-to-serial attachments.
-
-        Called after diff_attach is populated to create a single source of truth
-        for network attachment mappings. Uses set() for automatic deduplication.
-
-        Map format: {network_name: set(serial_numbers)}
-        """
-        caller = inspect.stack()[1][3]
-
-        msg = "ENTERED. "
-        msg += f"caller: {caller}."
-        self.log.debug(msg)
-
-        self.network_sn_attach_map.clear()
-
-        for net_attach in self.diff_attach:
-            network_name = net_attach.get("networkName")
-            if not network_name:
-                continue
-
-            if network_name not in self.network_sn_attach_map:
-                self.network_sn_attach_map[network_name] = set()
-
-            for attach in net_attach.get("lanAttachList", []):
-                serial = attach.get("serialNumber")
-                if serial:
-                    self.network_sn_attach_map[network_name].add(serial)
-
-        msg = "self.network_sn_attach_map: "
-        msg += f"{json.dumps({k: list(v) for k, v in self.network_sn_attach_map.items()}, indent=4)}"
-        self.log.debug(msg)
-
-    def update_network_sn_detach_map(self):
-        """
-        Build/update centralized map of network-to-serial detachments.
-
-        Called after diff_detach is populated to create a single source of truth
-        for network detachment mappings during undeploy operations. Uses set() for
-        automatic deduplication.
-
-        Map format: {network_name: set(serial_numbers)}
-        """
-        caller = inspect.stack()[1][3]
-
-        msg = "ENTERED. "
-        msg += f"caller: {caller}."
-        self.log.debug(msg)
-
-        self.network_sn_detach_map.clear()
-
-        for net_detach in self.diff_detach:
-            network_name = net_detach.get("networkName")
-            if not network_name:
-                continue
-
-            if network_name not in self.network_sn_detach_map:
-                self.network_sn_detach_map[network_name] = set()
-
-            for detach in net_detach.get("lanAttachList", []):
-                serial = detach.get("serialNumber")
-                if serial:
-                    self.network_sn_detach_map[network_name].add(serial)
-
-        msg = "self.network_sn_detach_map: "
-        msg += f"{json.dumps({k: list(v) for k, v in self.network_sn_detach_map.items()}, indent=4)}"
-        self.log.debug(msg)
-
     def get_deploy_switch_serials(self, network_names, is_undeploy=False):
         """
         Return list of switch serials affected by network deployments or undeployments.
@@ -1707,7 +1638,7 @@ class DcnmNetwork:
 
         return serials
 
-    def network_serial_payload_transform(self, payload: dict) -> dict:
+    def network_serial_payload_transform(self, payload: dict, is_undeploy: bool = False) -> dict:
         """
         Transform network deploy payload for multicluster/resource mode.
 
@@ -1716,10 +1647,11 @@ class DcnmNetwork:
         To:
             {"serial1": "net1,net2", "serial2": "net3"}
 
-        Uses centralized network_sn_attach_map as single source of truth.
+        Uses centralized network_sn_attach_map or network_sn_detach_map based on operation type.
 
         Args:
             payload: Deployment payload with networkNames key
+            is_undeploy: If True, uses network_sn_detach_map (undeploy). If False (default), uses network_sn_attach_map (deploy).
 
         Returns:
             Transformed payload mapping serial numbers to comma-separated network names
@@ -1727,7 +1659,8 @@ class DcnmNetwork:
         caller = inspect.stack()[1][3]
 
         msg = "ENTERED. "
-        msg += f"caller: {caller}."
+        msg += f"caller: {caller}. "
+        msg += f"is_undeploy: {is_undeploy}"
         self.log.debug(msg)
 
         if not payload or "networkNames" not in payload:
@@ -1740,10 +1673,17 @@ class DcnmNetwork:
         # Parse the comma-separated network names
         network_names_list = [n.strip() for n in network_names_str.split(",")]
 
+        # Select the appropriate map based on operation type
+        network_to_serial_map = self.network_sn_detach_map if is_undeploy else self.network_sn_attach_map
+        
+        map_type = "detach" if is_undeploy else "attach"
+        msg = f"Using network_sn_{map_type}_map for payload transformation."
+        self.log.debug(msg)
+
         # Build serial -> networks mapping from centralized map
         serial_to_networks = {}
         for network_name in network_names_list:
-            for serial in self.network_sn_attach_map.get(network_name, set()):
+            for serial in network_to_serial_map.get(network_name, set()):
                 if serial not in serial_to_networks:
                     serial_to_networks[serial] = []
                 serial_to_networks[serial].append(network_name)
@@ -4223,7 +4163,7 @@ class DcnmNetwork:
                     # Use resource-level deploy: /networks/deploy path with SN:networkNames
                     path = self.paths["GET_NET"].format(self.fabric)
                     deploy_path = path.replace(f"/fabrics/{self.fabric}/networks", "/networks/deploy")
-                    deploy_payload = self.network_serial_payload_transform(payload)
+                    deploy_payload = self.network_serial_payload_transform(payload, is_undeploy=True)
                     resp = dcnm_send(self.module, method, deploy_path, json.dumps(deploy_payload))
                     if resp is not None:
                         self.result["response"].append(resp)
@@ -4271,7 +4211,7 @@ class DcnmNetwork:
                         # Use resource-level deploy: /networks/deploy path with SN:networkNames
                         path = self.paths["GET_NET"].format(self.fabric)
                         deploy_path = path.replace(f"/fabrics/{self.fabric}/networks", "/networks/deploy")
-                        deploy_payload = self.network_serial_payload_transform(payload)
+                        deploy_payload = self.network_serial_payload_transform(payload, is_undeploy=True)
                         resp = dcnm_send(self.module, method, deploy_path, json.dumps(deploy_payload))
                         if resp is not None:
                             self.result["response"].append(resp)
@@ -4504,7 +4444,7 @@ class DcnmNetwork:
                     diff_deploy = self.get_deploy_switch_serials(self.diff_deploy, is_undeploy=False)
                 else:
                     # Use resource mode: transform to serial->networks mapping
-                    diff_deploy = self.network_serial_payload_transform(self.diff_deploy)
+                    diff_deploy = self.network_serial_payload_transform(self.diff_deploy, is_undeploy=False)
 
                 # Wrap in structured format for type checking in action plugin
                 self.deploy_payload = {"payload": diff_deploy}
@@ -4521,7 +4461,7 @@ class DcnmNetwork:
                     # Use resource-level deploy: /networks/deploy path with networkNames
                     path = self.paths["GET_NET"].format(self.fabric)
                     deploy_path = path.replace(f"/fabrics/{self.fabric}/networks", "/networks/deploy")
-                    deploy_payload = self.network_serial_payload_transform(self.diff_deploy)
+                    deploy_payload = self.network_serial_payload_transform(self.diff_deploy, is_undeploy=False)
             else:
                 # Version < 12: use legacy /deployments path with networkNames
                 path = self.paths["GET_NET"].format(self.fabric)

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -2381,7 +2381,8 @@ class DcnmNetwork:
             template_conf["secondaryGW3"] = ""
         if template_conf["secondaryGW4"] is None:
             template_conf["secondaryGW4"] = ""
-        template_conf["secondaryGWs"] = self.get_secondary_gws_template_config(template_conf)
+        if self.fabric_type not in ["multisite_child", "multicluster_child"]:
+            template_conf["secondaryGWs"] = self.get_secondary_gws_template_config(template_conf)
         if self.dcnm_version > 11:
             if template_conf["SVI_NETFLOW_MONITOR"] is None:
                 template_conf["SVI_NETFLOW_MONITOR"] = ""
@@ -2433,7 +2434,8 @@ class DcnmNetwork:
             t_conf.update(SVI_NETFLOW_MONITOR=json_to_dict.get("SVI_NETFLOW_MONITOR", ""))
             t_conf.update(VLAN_NETFLOW_MONITOR=json_to_dict.get("VLAN_NETFLOW_MONITOR", ""))
 
-        t_conf["secondaryGWs"] = self.get_secondary_gws_template_config(t_conf)
+        if self.fabric_type not in ["multisite_child", "multicluster_child"]:
+            t_conf["secondaryGWs"] = self.get_secondary_gws_template_config(t_conf)
 
         if "mcastGroup" not in json_to_dict:
             del t_conf["mcastGroup"]
@@ -4653,7 +4655,8 @@ class DcnmNetwork:
                     t_conf.update(SVI_NETFLOW_MONITOR=json_to_dict.get("SVI_NETFLOW_MONITOR", ""))
                     t_conf.update(VLAN_NETFLOW_MONITOR=json_to_dict.get("VLAN_NETFLOW_MONITOR", ""))
 
-                t_conf["secondaryGWs"] = self.get_secondary_gws_template_config(t_conf)
+                if self.fabric_type not in ["multisite_child", "multicluster_child"]:
+                    t_conf["secondaryGWs"] = self.get_secondary_gws_template_config(t_conf)
 
                 # Remove skipped attributes from template config for parent fabrics
                 for key in list(t_conf.keys()):
@@ -4912,10 +4915,6 @@ class DcnmNetwork:
                 dhcp_srvr2_vrf=dict(type="str", length_max=32),
                 dhcp_srvr3_vrf=dict(type="str", length_max=32),
                 dhcp_servers=dict(type="list", elements="dict", default=[]),
-                secondary_ip_gw1=dict(type="ipv4"),
-                secondary_ip_gw2=dict(type="ipv4"),
-                secondary_ip_gw3=dict(type="ipv4"),
-                secondary_ip_gw4=dict(type="ipv4"),
                 deploy=dict(type="bool", default=True if not is_query_state else None),
                 is_l2only=dict(type="bool", default=False),
             )
@@ -5399,7 +5398,8 @@ class DcnmNetwork:
         if cfg.get("secondary_ip_gw4", None) is None:
             json_to_dict_want["secondaryGW4"] = json_to_dict_have["secondaryGW4"]
 
-        json_to_dict_want["secondaryGWs"] = self.get_secondary_gws_template_config(json_to_dict_want)
+        if self.fabric_type not in ["multisite_child", "multicluster_child"]:
+            json_to_dict_want["secondaryGWs"] = self.get_secondary_gws_template_config(json_to_dict_want)
 
         # Route target configuration (common for all fabric types)
         if cfg.get("route_target_both", None) is None:

--- a/plugins/modules/dcnm_policy.py
+++ b/plugins/modules/dcnm_policy.py
@@ -774,7 +774,7 @@ class DcnmPolicy:
             key = "templateName"
 
         for have in self.have:
-            if (have[key] == policy[key]) and (
+            if (have.get(key) == policy.get(key)) and (
                 have.get("serialNumber", None) == policy["serialNumber"]
             ):
                 found.append(have)

--- a/plugins/modules/dcnm_resource_manager.py
+++ b/plugins/modules/dcnm_resource_manager.py
@@ -902,7 +902,8 @@ class DcnmResManager:
 
         mismatch_values = []
 
-        if res1["entityType"] != res2["scopeType"]:
+        # Case-insensitive comparison for entityType/scopeType since DCNM may return lowercase
+        if res1["entityType"].lower() != res2["scopeType"].lower():
             mismatch_values.append(
                 {
                     "have_entity_type": res1["entityType"],
@@ -954,7 +955,8 @@ class DcnmResManager:
             res1["entityName"], res2["entityName"]
         ):
             return False
-        if res1["entityType"] != res2["scopeType"]:
+        # Case-insensitive comparison for entityType/scopeType since DCNM may return lowercase
+        if res1["entityType"].lower() != res2["scopeType"].lower():
             return False
         if res1["resourcePool"]["poolName"] != res2["poolName"]:
             return False
@@ -1151,7 +1153,7 @@ class DcnmResManager:
         }
 
         resources = []
-        
+
         for res in diff_create:
             resource_item = {
                 "entityName": res["entityName"],
@@ -1159,16 +1161,16 @@ class DcnmResManager:
                 "poolName": res["poolName"],
                 "vrfName": res.get("vrfName", "default")  # Use vrfName from resource if available
             }
-            
+
             # Add resourceValue if resource is present
             if res.get("resource") is not None:
                 resource_item["resourceValue"] = str(res["resource"])
-            
+
             # Build scopeDetails based on scopeType
             scope_details = {}
             scope_type = scope_type_xlate_reverse.get(res["scopeType"], "fabric")
             scope_details["scopeType"] = scope_type
-            
+
             if res["scopeType"] == "Fabric":
                 scope_details["fabricName"] = self.fabric
             elif res["scopeType"] == "Device":
@@ -1177,33 +1179,45 @@ class DcnmResManager:
                 # Parse entity name to get interface: format is "SERIAL~InterfaceName"
                 entity_parts = res["entityName"].split("~")
                 scope_details["switchId"] = res["scopeValue"]
-                if len(entity_parts) > 1:
-                    scope_details["interfaceName"] = entity_parts[1]
+                if len(entity_parts) < 2:
+                    self.module.fail_json(
+                        msg=f"Invalid entity_name format for device_interface scope: '{res['entityName']}'. "
+                            f"Expected format: 'SERIAL~InterfaceName'"
+                    )
+                scope_details["interfaceName"] = entity_parts[1]
             elif res["scopeType"] == "DevicePair":
                 # Parse entity name: format is "SERIAL1~SERIAL2~..."
                 entity_parts = res["entityName"].split("~")
-                if len(entity_parts) >= 2:
-                    scope_details["srcSwitchId"] = entity_parts[0]
-                    scope_details["dstSwitchId"] = entity_parts[1]
+                if len(entity_parts) < 2:
+                    self.module.fail_json(
+                        msg=f"Invalid entity_name format for device_pair scope: '{res['entityName']}'. "
+                            f"Expected format: 'SERIAL1~SERIAL2'"
+                    )
+                scope_details["srcSwitchId"] = entity_parts[0]
+                scope_details["dstSwitchId"] = entity_parts[1]
             elif res["scopeType"] == "Link":
                 # Parse entity name: format is "SERIAL1~Interface1~SERIAL2~Interface2"
                 entity_parts = res["entityName"].split("~")
-                if len(entity_parts) >= 4:
-                    scope_details["srcSwitchId"] = entity_parts[0]
-                    scope_details["srcInterfaceName"] = entity_parts[1]
-                    scope_details["dstSwitchId"] = entity_parts[2]
-                    scope_details["dstInterfaceName"] = entity_parts[3]
-            
+                if len(entity_parts) < 4:
+                    self.module.fail_json(
+                        msg=f"Invalid entity_name format for link scope: '{res['entityName']}'. "
+                            f"Expected format: 'SERIAL1~Interface1~SERIAL2~Interface2'"
+                    )
+                scope_details["srcSwitchId"] = entity_parts[0]
+                scope_details["srcInterfaceName"] = entity_parts[1]
+                scope_details["dstSwitchId"] = entity_parts[2]
+                scope_details["dstInterfaceName"] = entity_parts[3]
+
             resource_item["scopeDetails"] = scope_details
             resources.append(resource_item)
-        
+
         bulk_payload = {
             "fabricName": self.fabric,
             "Body": {
                 "resources": resources
             }
         }
-        
+
         return bulk_payload
 
     def dcnm_rm_send_message_to_dcnm(self):

--- a/plugins/modules/dcnm_resource_manager.py
+++ b/plugins/modules/dcnm_resource_manager.py
@@ -284,6 +284,7 @@ import ipaddress
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.dcnm.plugins.module_utils.network.dcnm.dcnm import (
+    dcnm_get_bulk_api_support,
     dcnm_send,
     validate_list_of_dicts,
     dcnm_version_supported,
@@ -310,11 +311,13 @@ class DcnmResManager:
             "RM_GET_RESOURCES_BY_SNO_AND_POOLNAME": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/resource-manager/switch/{}/pools/{}",
             "RM_GET_RESOURCES_BY_FABRIC_AND_POOLNAME": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/resource-manager/fabric/{}/pools/{}",
             "RM_CREATE_RESOURCE": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/resource-manager/fabrics/{}/resources",
+            "RM_BULK_CREATE_RESOURCE": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/resource-manager/createResource?isManual=true",
             "RM_DELETE_RESOURCE": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/resource-manager/resources?id=",
         },
     }
 
     def __init__(self, module):
+        self.log = logging.getLogger(f"DcnmResManager")
         self.module = module
         self.params = module.params
         self.fabric = module.params["fabric"]
@@ -331,6 +334,8 @@ class DcnmResManager:
         ]
 
         self.dcnm_version = dcnm_version_supported(self.module)
+        # Check for bulk API support
+        self.has_bulk_api = dcnm_get_bulk_api_support(self.module)
 
         self.inventory_data = get_fabric_inventory_details(
             self.module, self.fabric
@@ -1125,6 +1130,83 @@ class DcnmResManager:
                 return True
         return False
 
+    def dcnm_rm_build_bulk_payload(self, diff_create):
+
+        """
+        Routine to build bulk create payload from diff_create list. The bulk payload format is required
+        for the RM_BULK_CREATE_RESOURCE API.
+
+        Parameters:
+            diff_create - list of resources to be created
+
+        Returns:
+            bulk_payload - formatted payload for bulk creation API
+        """
+
+        scope_type_xlate_reverse = {
+            "Fabric": "fabric",
+            "Device": "device",
+            "DeviceInterface": "deviceInterface",
+            "DevicePair": "devicePair",
+            "Link": "link",
+        }
+
+        resources = []
+        
+        for res in diff_create:
+            resource_item = {
+                "entityName": res["entityName"],
+                "isPreAllocated": True,
+                "poolName": res["poolName"],
+                "vrfName": res.get("vrfName", "default")  # Use vrfName from resource if available
+            }
+            
+            # Add resourceValue if resource is present
+            if res.get("resource") is not None:
+                resource_item["resourceValue"] = str(res["resource"])
+            
+            # Build scopeDetails based on scopeType
+            scope_details = {}
+            scope_type = scope_type_xlate_reverse.get(res["scopeType"], "fabric")
+            scope_details["scopeType"] = scope_type
+            
+            if res["scopeType"] == "Fabric":
+                scope_details["fabricName"] = self.fabric
+            elif res["scopeType"] == "Device":
+                scope_details["switchId"] = res["scopeValue"]
+            elif res["scopeType"] == "DeviceInterface":
+                # Parse entity name to get interface: format is "SERIAL~InterfaceName"
+                entity_parts = res["entityName"].split("~")
+                scope_details["switchId"] = res["scopeValue"]
+                if len(entity_parts) > 1:
+                    scope_details["interfaceName"] = entity_parts[1]
+            elif res["scopeType"] == "DevicePair":
+                # Parse entity name: format is "SERIAL1~SERIAL2~..."
+                entity_parts = res["entityName"].split("~")
+                if len(entity_parts) >= 2:
+                    scope_details["srcSwitchId"] = entity_parts[0]
+                    scope_details["dstSwitchId"] = entity_parts[1]
+            elif res["scopeType"] == "Link":
+                # Parse entity name: format is "SERIAL1~Interface1~SERIAL2~Interface2"
+                entity_parts = res["entityName"].split("~")
+                if len(entity_parts) >= 4:
+                    scope_details["srcSwitchId"] = entity_parts[0]
+                    scope_details["srcInterfaceName"] = entity_parts[1]
+                    scope_details["dstSwitchId"] = entity_parts[2]
+                    scope_details["dstInterfaceName"] = entity_parts[3]
+            
+            resource_item["scopeDetails"] = scope_details
+            resources.append(resource_item)
+        
+        bulk_payload = {
+            "fabricName": self.fabric,
+            "Body": {
+                "resources": resources
+            }
+        }
+        
+        return bulk_payload
+
     def dcnm_rm_send_message_to_dcnm(self):
 
         """
@@ -1142,19 +1224,35 @@ class DcnmResManager:
         create_flag = False
         delete_flag = False
 
-        path = self.paths["RM_CREATE_RESOURCE"].format(self.fabric)
+        if self.diff_create:
+            # Use bulk API if bulk API is available
+            if self.has_bulk_api:
+                # Build bulk payload
+                bulk_payload = self.dcnm_rm_build_bulk_payload(self.diff_create)
+                path = self.paths["RM_BULK_CREATE_RESOURCE"]
+            
+                json_payload = json.dumps(bulk_payload)
+                resp = dcnm_send(self.module, "POST", path, json_payload)
+                create_flag = True
+                
+                self.result["response"].append(resp)
+                # Accept both 200 (OK) and 207 (Multi-Status) as success for bulk operations
+                if resp and resp.get("RETURN_CODE") not in [200, 207]:
+                    resp["CHANGED"] = self.changed_dict[0]
+                    self.module.fail_json(msg=resp)
+            else:
+                # Use individual API calls for other versions
+                path = self.paths["RM_CREATE_RESOURCE"].format(self.fabric)
+                
+                for res in self.diff_create:
+                    json_payload = json.dumps(res)
+                    resp = dcnm_send(self.module, "POST", path, json_payload)
+                    create_flag = True
 
-        for res in self.diff_create:
-
-            json_payload = json.dumps(res)
-            resp = dcnm_send(self.module, "POST", path, json_payload)
-
-            create_flag = True
-
-            self.result["response"].append(resp)
-            if resp and resp.get("RETURN_CODE") != 200:
-                resp["CHANGED"] = self.changed_dict[0]
-                self.module.fail_json(msg=resp)
+                    self.result["response"].append(resp)
+                    if resp and resp.get("RETURN_CODE") != 200:
+                        resp["CHANGED"] = self.changed_dict[0]
+                        self.module.fail_json(msg=resp)
 
         if self.diff_delete:
             path = self.paths["RM_DELETE_RESOURCE"].format(self.fabric)
@@ -1166,7 +1264,8 @@ class DcnmResManager:
             delete_flag = True
 
             self.result["response"].append(resp)
-            if resp and resp.get("RETURN_CODE") != 200:
+            # Accept both 200 (OK) and 207 (Multi-Status) as success for bulk operations
+            if resp and resp.get("RETURN_CODE") not in [200, 207]:
                 resp["CHANGED"] = self.changed_dict[0]
                 self.module.fail_json(msg=resp)
 

--- a/plugins/modules/dcnm_resource_manager.py
+++ b/plugins/modules/dcnm_resource_manager.py
@@ -317,7 +317,6 @@ class DcnmResManager:
     }
 
     def __init__(self, module):
-        self.log = logging.getLogger(f"DcnmResManager")
         self.module = module
         self.params = module.params
         self.fabric = module.params["fabric"]

--- a/plugins/modules/dcnm_resource_manager.py
+++ b/plugins/modules/dcnm_resource_manager.py
@@ -1230,11 +1230,11 @@ class DcnmResManager:
                 # Build bulk payload
                 bulk_payload = self.dcnm_rm_build_bulk_payload(self.diff_create)
                 path = self.paths["RM_BULK_CREATE_RESOURCE"]
-            
+
                 json_payload = json.dumps(bulk_payload)
                 resp = dcnm_send(self.module, "POST", path, json_payload)
                 create_flag = True
-                
+  
                 self.result["response"].append(resp)
                 # Accept both 200 (OK) and 207 (Multi-Status) as success for bulk operations
                 if resp and resp.get("RETURN_CODE") not in [200, 207]:
@@ -1243,7 +1243,7 @@ class DcnmResManager:
             else:
                 # Use individual API calls for other versions
                 path = self.paths["RM_CREATE_RESOURCE"].format(self.fabric)
-                
+
                 for res in self.diff_create:
                     json_payload = json.dumps(res)
                     resp = dcnm_send(self.module, "POST", path, json_payload)

--- a/plugins/modules/dcnm_resource_manager.py
+++ b/plugins/modules/dcnm_resource_manager.py
@@ -1247,7 +1247,7 @@ class DcnmResManager:
                 json_payload = json.dumps(bulk_payload)
                 resp = dcnm_send(self.module, "POST", path, json_payload)
                 create_flag = True
-  
+
                 self.result["response"].append(resp)
                 # Accept both 200 (OK) and 207 (Multi-Status) as success for bulk operations
                 if resp and resp.get("RETURN_CODE") not in [200, 207]:

--- a/plugins/modules/dcnm_resource_manager.py
+++ b/plugins/modules/dcnm_resource_manager.py
@@ -1144,14 +1144,6 @@ class DcnmResManager:
             bulk_payload - formatted payload for bulk creation API
         """
 
-        scope_type_xlate_reverse = {
-            "Fabric": "fabric",
-            "Device": "device",
-            "DeviceInterface": "deviceInterface",
-            "DevicePair": "devicePair",
-            "Link": "link",
-        }
-
         resources = []
 
         for res in diff_create:
@@ -1168,8 +1160,7 @@ class DcnmResManager:
 
             # Build scopeDetails based on scopeType
             scope_details = {}
-            scope_type = scope_type_xlate_reverse.get(res["scopeType"], "fabric")
-            scope_details["scopeType"] = scope_type
+            scope_details["scopeType"] = res["scopeType"]
 
             if res["scopeType"] == "Fabric":
                 scope_details["fabricName"] = self.fabric

--- a/plugins/modules/dcnm_vpc_pair.py
+++ b/plugins/modules/dcnm_vpc_pair.py
@@ -480,7 +480,6 @@ class DcnmVpcPair:
         self.result = dict(changed=False, diff=[], response=[])
 
     def log_msg(self, msg):
-
         if self.fd is None:
             self.fd = open("dcnm_vpc_pair.log", "a+")
         if self.fd is not None:
@@ -489,7 +488,6 @@ class DcnmVpcPair:
             self.fd.flush()
 
     def dcnm_vpc_pair_merge_want_and_have_objects(self, want, have):
-
         """
         Routine to merge the 'want' and 'have' if required. If an object requires mering, then the
         values from 'want' and 'have' will be combined into one instead of overwriting.
@@ -503,7 +501,6 @@ class DcnmVpcPair:
         """
 
         for key in list(want.keys()):
-
             # Check if <key>_defaulted is present in 'want'. If present merge the original key if
             # <key>_defaulted is True.
 
@@ -520,14 +517,11 @@ class DcnmVpcPair:
                     # NOTE: key requires a merge between 'want' and 'have'. The following utility
                     #       function must do the appropriate checks and merge the key values from 'want'
                     #       and 'have'.
-                    dcnm_vpc_pair_utils_merge_want_and_have(
-                        self, want, have, key
-                    )
+                    dcnm_vpc_pair_utils_merge_want_and_have(self, want, have, key)
                 # Remove the <key>_defaulted from want
                 want.pop(key + "_defaulted")
 
     def dcnm_vpc_pair_merge_want_and_have(self, want, have):
-
         """
         Routine to check for mergeable keys in want and merge the same with whatever is already exsiting
         in have.
@@ -554,17 +548,12 @@ class DcnmVpcPair:
         self.dcnm_vpc_pair_merge_want_and_have_objects(want, have)
 
         # If "nvPairs" object is not present in 'want' or 'have' then nothing to be merged
-        if (want.get("nvPairs", None) is None) or (
-            (have.get("nvPairs", None) is None)
-        ):
+        if (want.get("nvPairs", None) is None) or (have.get("nvPairs", None) is None):
             return
 
-        self.dcnm_vpc_pair_merge_want_and_have_objects(
-            want["nvPairs"], have["nvPairs"]
-        )
+        self.dcnm_vpc_pair_merge_want_and_have_objects(want["nvPairs"], have["nvPairs"])
 
     def dcnm_vpc_pair_get_diff_query(self):
-
         """
         Routine to retrieve vPC switch pairs from controller. This routine extracts information provided by the
         user and filters the output based on that.
@@ -576,14 +565,11 @@ class DcnmVpcPair:
             None
         """
 
-        vpc_pair_list = dcnm_vpc_pair_utils_get_all_filtered_vpc_pair_pairs(
-            self
-        )
+        vpc_pair_list = dcnm_vpc_pair_utils_get_all_filtered_vpc_pair_pairs(self)
         if vpc_pair_list != []:
             self.result["response"].extend(vpc_pair_list)
 
     def dcnm_vpc_pair_get_diff_overridden(self, cfg):
-
         """
         Routine to override existing vPC information with what is included in the playbook. This routine
         deletes all vPC pairs which are not part of the current config and creates new ones based on what is
@@ -613,7 +599,6 @@ class DcnmVpcPair:
             rc = self.dcnm_vpc_pair_get_diff_merge()
 
     def dcnm_vpc_pair_get_diff_deleted(self):
-
         """
         Routine to get a list of payload information that will be used to delete Vpc_pair.
         This routine updates self.diff_delete with payloads that are used to delete Vpc_pair
@@ -632,7 +617,6 @@ class DcnmVpcPair:
             return
 
         for elem in self.vpc_pair_info:
-
             # Perform any translations that may be required on the vpc_pair_info.
             xelem = dcnm_vpc_pair_utils_translate_vpc_pair_info(self, elem)
             have = dcnm_vpc_pair_utils_get_vpc_pair_info(self, xelem)
@@ -640,8 +624,14 @@ class DcnmVpcPair:
             # Check the peering before deleting. Delete only the peering that is requested for.
             if (
                 (have == [])
-                or (xelem["peerOneId"] != have["peerOneId"] and xelem["peerOneId"] != have["peerTwoId"])
-                or (xelem["peerTwoId"] != have["peerTwoId"] and xelem["peerTwoId"] != have["peerOneId"])
+                or (
+                    xelem["peerOneId"] != have["peerOneId"]
+                    and xelem["peerOneId"] != have["peerTwoId"]
+                )
+                or (
+                    xelem["peerTwoId"] != have["peerTwoId"]
+                    and xelem["peerTwoId"] != have["peerOneId"]
+                )
             ):
                 continue
 
@@ -649,7 +639,6 @@ class DcnmVpcPair:
                 self.dcnm_vpc_pair_update_delete_payloads(have)
 
     def dcnm_vpc_pair_update_delete_payloads(self, have):
-
         # Get the delete payload based on 'have'
         del_payload = dcnm_vpc_pair_utils_get_delete_payload(self, have)
 
@@ -668,13 +657,10 @@ class DcnmVpcPair:
                 del_deploy_payload != {}
                 and del_deploy_payload not in self.diff_delete_deploy
             ):
-                self.changed_dict[0]["delete_deploy"].append(
-                    del_deploy_payload
-                )
+                self.changed_dict[0]["delete_deploy"].append(del_deploy_payload)
                 self.diff_delete_deploy.append(del_deploy_payload)
 
     def dcnm_vpc_pair_get_diff_merge(self):
-
         """
         Routine to populate a list of payload information in self.diff_create to create/update Vpc_pair.
 
@@ -689,10 +675,7 @@ class DcnmVpcPair:
             return
 
         for elem in self.want:
-
-            rc, reasons, have = dcnm_vpc_pair_utils_compare_want_and_have(
-                self, elem
-            )
+            rc, reasons, have = dcnm_vpc_pair_utils_compare_want_and_have(self, elem)
 
             if rc == "DCNM_VPC_PAIR_CREATE":
                 # Object does not exists, create a new one.
@@ -712,33 +695,26 @@ class DcnmVpcPair:
                         self.dcnm_vpc_pair_merge_want_and_have(elem, have)
                     self.diff_modify.append(elem)
 
-            # Check if "deploy" flag is True. If True, deploy the changes.
             if self.deploy:
-                # Before building deploy payload, check
-                #  - if something is being created
-                #  - if something that is existing is being updated
-                #  - if switches are in "In-Sync" state already
-
-                sync_state = dcnm_vpc_pair_utils_get_sync_status(self, elem)
-
-                if (
-                    (rc == "DCNM_VPC_PAIR_CREATE")
-                    or (rc == "DCNM_VPC_PAIR_MERGE")
-                    or (sync_state != "In-Sync")
-                ):
+                if (rc == "DCNM_VPC_PAIR_CREATE") or (rc == "DCNM_VPC_PAIR_MERGE"):
                     payload = dcnm_vpc_pair_utils_get_vpc_pair_deploy_payload(
                         self, elem
                     )
                     if payload != {} and payload not in self.diff_deploy:
                         self.diff_deploy.append(payload)
+                else:
+                    sync_state = dcnm_vpc_pair_utils_get_sync_status(self, elem)
+                    if sync_state != "In-Sync":
+                        payload = dcnm_vpc_pair_utils_get_vpc_pair_deploy_payload(
+                            self, elem
+                        )
+                        if payload != {} and payload not in self.diff_deploy:
+                            self.diff_deploy.append(payload)
 
         if self.diff_deploy != []:
-            self.changed_dict[0]["deploy"].extend(
-                copy.deepcopy(self.diff_deploy)
-            )
+            self.changed_dict[0]["deploy"].extend(copy.deepcopy(self.diff_deploy))
 
     def dcnm_vpc_pair_update_want(self):
-
         """
         This routine does the following when the state is 'merged'. For every object in self.want
 
@@ -757,7 +733,6 @@ class DcnmVpcPair:
             return
 
         for want in self.want:
-
             match_have = dcnm_vpc_pair_utils_get_matching_have(self, want)
             match_cfg = dcnm_vpc_pair_utils_get_matching_cfg(self, want)
 
@@ -770,7 +745,6 @@ class DcnmVpcPair:
                 )
 
     def dcnm_vpc_pair_get_want(self):
-
         """
         This routine updates self.want with the payload information based on the playbook configuration.
 
@@ -788,7 +762,6 @@ class DcnmVpcPair:
             return
 
         for elem in self.vpc_pair_info:
-
             # If a separate payload is required for every switch included in the payload, then modify this
             # code to loop over the switches. Also the get payload routine should be modified appropriately.
 
@@ -798,7 +771,6 @@ class DcnmVpcPair:
                 self.want.append(payload)
 
     def dcnm_vpc_pair_get_have(self):
-
         """
         Routine to get exisitng vpc_pair information from DCNM that matches information in self.want.
         This routine updates self.have with all the vpc_pair that match the given playbook configuration
@@ -845,7 +817,6 @@ class DcnmVpcPair:
                 self.have.append(have)
 
     def dcnm_vpc_pair_validate_deleted_state_input(self, cfg):
-
         """
         Playbook input will be different for differnt states. This routine validates the
         deleted state input. This routine updates self.vpc_pair_info with
@@ -872,7 +843,6 @@ class DcnmVpcPair:
             self.vpc_pair_info.extend(vpc_pair_info)
 
     def dcnm_vpc_pair_validate_query_state_input(self, cfg):
-
         """
         Playbook input will be different for differnt states. This routine validates the
         query state input. This routine updates self.vpc_pair_info with
@@ -899,7 +869,6 @@ class DcnmVpcPair:
             self.vpc_pair_info.extend(vpc_pair_info)
 
     def dcnm_vpc_pair_validate_input(self, cfg):
-
         # The generator hanldes only the case where:
         #   - there are some common paremeters that are included in the playbook
         #   - and a profile which is a 'dict' and which is either based on a template or some fixed structure
@@ -921,9 +890,7 @@ class DcnmVpcPair:
         # Even 'common_spec' may require some updates based on other information.
         dcnm_vpc_pair_utils_update_common_spec(self, common_spec)
 
-        vpc_pair_info, invalid_params = validate_list_of_dicts(
-            cfg, common_spec
-        )
+        vpc_pair_info, invalid_params = validate_list_of_dicts(cfg, common_spec)
         if invalid_params:
             mesg = "Invalid parameters in playbook: {0}".format(invalid_params)
             self.module.fail_json(msg=mesg)
@@ -962,7 +929,6 @@ class DcnmVpcPair:
         self.vpc_pair_info.append(vpc_pair_info[0])
 
     def dcnm_vpc_pair_validate_all_input(self):
-
         """
         Routine to validate playbook input based on the state. Since each state has a different
         config structure, this routine handles the validation based on the given state
@@ -979,7 +945,6 @@ class DcnmVpcPair:
 
         cfg = []
         for item in self.config:
-
             citem = copy.deepcopy(item)
 
             cfg.append(citem)
@@ -995,7 +960,6 @@ class DcnmVpcPair:
             cfg.remove(citem)
 
     def dcnm_vpc_pair_get_payload(self, vpc_pair_info):
-
         """
         This routine builds the complete object payload based on the information in self.want
 
@@ -1006,14 +970,11 @@ class DcnmVpcPair:
             vpc_pair_payload (dict): Object payload information populated with appropriate data from playbook config
         """
 
-        vpc_pair_payload = dcnm_vpc_pair_utils_get_vpc_pair_payload(
-            self, vpc_pair_info
-        )
+        vpc_pair_payload = dcnm_vpc_pair_utils_get_vpc_pair_payload(self, vpc_pair_info)
 
         return vpc_pair_payload
 
     def dcnm_vpc_pair_update_inventory_data(self):
-
         """
         Routine to update inventory data for all fabrics included in the playbook. This routine
         also updates ip_sn, sn_hn and hn_sn objetcs from the updated inventory data.
@@ -1086,7 +1047,6 @@ class DcnmVpcPair:
             )
 
     def dcnm_vpc_pair_translate_playbook_info(self, config, ip_sn, hn_sn):
-
         """
         Routine to translate parameters in playbook if required.
             - This routine converts the hostname information included in
@@ -1105,12 +1065,10 @@ class DcnmVpcPair:
             return
 
         for cfg in config:
-
             # Add other translations as required
             dcnm_vpc_pair_utils_translate_config(self, cfg)
 
     def dcnm_vpc_pair_fetch_template_details(self, template_info):
-
         """
         Routine to fetch details of all templates inlcuded in 'template_info'. The template information
         obtained will be formatted appropriately to represent playbook format with other details to assist
@@ -1126,9 +1084,7 @@ class DcnmVpcPair:
 
         template_list = []
         for name in template_info:
-            tinfo = dcnm_get_template_specs(
-                self.module, name, self.dcnm_version
-            )
+            tinfo = dcnm_get_template_specs(self.module, name, self.dcnm_version)
             # While fetching template details we will not require arg_spec for the same. Remove that from
             # the result
             tinfo.pop(name + "_spec")
@@ -1139,7 +1095,6 @@ class DcnmVpcPair:
         return template_list
 
     def dcnm_vpc_pair_send_message_to_dcnm(self):
-
         """
         Routine to push payloads to DCNM server. This routine implements required error checks and retry mechanisms to handle
         transient errors. This routine checks self.diff_create, self.diff_delete lists and push appropriate requests to DCNM.
@@ -1169,7 +1124,6 @@ class DcnmVpcPair:
         )
 
     def dcnm_vpc_pair_update_module_info(self):
-
         """
         Routine to update version and fabric details
 
@@ -1181,18 +1135,14 @@ class DcnmVpcPair:
         """
 
         self.dcnm_version = dcnm_version_supported(self.module)
-        self.inventory_data = get_fabric_inventory_details(
-            self.module, self.fabric
-        )
+        self.inventory_data = get_fabric_inventory_details(self.module, self.fabric)
 
         self.src_fabric_info = get_fabric_details(self.module, self.fabric)
         self.paths = dcnm_vpc_pair_utils_get_paths(self.dcnm_version)
 
 
 def main():
-
-    """ main entry point for module execution
-    """
+    """main entry point for module execution"""
     element_spec = dict(
         src_fabric=dict(required=True, type="str"),
         config=dict(required=False, type="list", elements="dict", default=[]),
@@ -1212,9 +1162,7 @@ def main():
         templates=dict(type="list", elements="str", default=[]),
     )
 
-    module = AnsibleModule(
-        argument_spec=element_spec, supports_check_mode=True
-    )
+    module = AnsibleModule(argument_spec=element_spec, supports_check_mode=True)
 
     dcnm_vpc_pair = DcnmVpcPair(module)
 
@@ -1254,10 +1202,7 @@ def main():
 
     dcnm_vpc_pair.dcnm_vpc_pair_validate_all_input()
 
-    if (
-        module.params["state"] != "query"
-        and module.params["state"] != "deleted"
-    ):
+    if module.params["state"] != "query" and module.params["state"] != "deleted":
         dcnm_vpc_pair.dcnm_vpc_pair_get_want()
         dcnm_vpc_pair.dcnm_vpc_pair_get_have()
 
@@ -1268,9 +1213,7 @@ def main():
 
         dcnm_vpc_pair.dcnm_vpc_pair_update_want()
 
-    if (module.params["state"] == "merged") or (
-        module.params["state"] == "replaced"
-    ):
+    if (module.params["state"] == "merged") or (module.params["state"] == "replaced"):
         dcnm_vpc_pair.dcnm_vpc_pair_get_diff_merge()
 
     if module.params["state"] == "deleted":

--- a/plugins/modules/dcnm_vrf.py
+++ b/plugins/modules/dcnm_vrf.py
@@ -46,6 +46,19 @@ options:
       - deleted
       - query
     default: merged
+  deploy_mode:
+    description:
+    - Controls the deployment method when deploy is enabled
+    - When set to 'switch' (default), deployments use switch-level API with serial numbers
+    - When set to 'resource', deployments use resource-level API with VRF names
+    - This parameter is ignored for multicluster parent fabrics which always use switch-level deployment
+    - Applies to both create/deploy and delete/undeploy operations
+    type: str
+    required: false
+    choices:
+      - switch
+      - resource
+    default: switch
   config:
     description:
     - List of details of vrfs being managed. Not required for state deleted
@@ -1119,6 +1132,7 @@ class DcnmVrf:
         self.diff_input_format = []
         self.deploy_payload = {}
         self.query = []
+        self.deploy_mode = module.params.get("deploy_mode", "switch")
 
         self.action_fabric_details = self.params.get("fabric_details")
 
@@ -3767,10 +3781,15 @@ class DcnmVrf:
         verb = "POST"
         diff_undeploy = self.diff_undeploy
 
-        if self.action_fabric_type == "multicluster_parent":
+        # Determine deploy path and payload format
+        # For multicluster_parent, always use switch-level
+        # For all others, check deploy_mode parameter
+        if self.action_fabric_type == "multicluster_parent" or self.deploy_mode == "switch":
+            # Use switch-level deploy: transform payload to serial number format
             deploy_path = path.replace(f"/fabrics/{self.fabric}/vrfs", "/vrfs/deploy")
             diff_undeploy = self.vrf_serial_payload_transform(self.diff_undeploy)
         else:
+            # Use resource-level deploy: standard /deployments path with vrfNames
             deploy_path = path + "/deployments"
 
         self.send_to_controller(
@@ -4800,10 +4819,15 @@ class DcnmVrf:
         path = self.paths["GET_VRF"].format(self.fabric)
         diff_deploy = self.diff_deploy
 
-        if self.action_fabric_type == "multicluster_parent":
+        # Determine deploy path and payload format
+        # For multicluster_parent, always use switch-level
+        # For all others, check deploy_mode parameter
+        if self.action_fabric_type == "multicluster_parent" or self.deploy_mode == "switch":
+            # Use switch-level deploy: transform payload to serial number format
             deploy_path = path.replace(f"/fabrics/{self.fabric}/vrfs", "/vrfs/deploy")
             diff_deploy = self.vrf_serial_payload_transform(diff_deploy)
         else:
+            # Use resource-level deploy: standard /deployments path with vrfNames
             deploy_path = path + "/deployments"
 
         if self.action_fabric_type == "multicluster_parent" or self.action_fabric_type == "multisite_parent":
@@ -5853,6 +5877,12 @@ def main():
                 nd_version=dict(required=False, type="float"),
                 members=dict(required=False, type="list", elements="dict")
             )
+        ),
+        deploy_mode=dict(
+            required=False,
+            type="str",
+            choices=["switch", "resource"],
+            default="switch"
         )
     )
 

--- a/plugins/modules/dcnm_vrf.py
+++ b/plugins/modules/dcnm_vrf.py
@@ -1076,18 +1076,24 @@ class DcnmVrf:
         self.params = module.params
         self.state = self.params.get("state")
 
-        msg = f"self.state: {self.state}, "
-        msg += "self.params: "
-        msg += f"{json.dumps(self.params, indent=4, sort_keys=True)}"
-        self.log.debug(msg)
+        if self.log.isEnabledFor(logging.DEBUG):
+            msg = f"self.state: {self.state}, "
+            msg += "self.params: "
+            msg += f"{json.dumps(self.params, indent=4, sort_keys=True)}"
+            self.log.debug(msg)
 
         self.fabric = module.params["fabric"]
         self.config = copy.deepcopy(module.params.get("config"))
+        self.config_by_vrf_name = {}
+        self.vrf_lite_vrf_names = set()
+        self.any_vrf_lite_in_config = False
+        self._refresh_config_indexes()
 
-        msg = f"self.state: {self.state}, "
-        msg += "self.config: "
-        msg += f"{json.dumps(self.config, indent=4, sort_keys=True)}"
-        self.log.debug(msg)
+        if self.log.isEnabledFor(logging.DEBUG):
+            msg = f"self.state: {self.state}, "
+            msg += "self.config: "
+            msg += f"{json.dumps(self.config, indent=4, sort_keys=True)}"
+            self.log.debug(msg)
 
         # Setting self.conf_changed to class scope since, after refactoring,
         # it is initialized and updated in one refactored method
@@ -1119,6 +1125,7 @@ class DcnmVrf:
         # O(1) lookup dict populated by get_have()
         self.have_attach_by_name = {}
         self.want_attach = []
+        self.want_attach_by_name = {}
         self.diff_attach = []
         self.validated = []
         # diff_detach contains all attachments of a vrf being deleted,
@@ -1164,17 +1171,19 @@ class DcnmVrf:
 
         self.inventory_data = get_nd_fabric_inventory_details(self.module, self.dcnm_version, self.fabric, self.action_fabric_details)
 
-        msg = "self.inventory_data: "
-        msg += f"{json.dumps(self.inventory_data, indent=4, sort_keys=True)}"
-        self.log.debug(msg)
+        if self.log.isEnabledFor(logging.DEBUG):
+            msg = "self.inventory_data: "
+            msg += f"{json.dumps(self.inventory_data, indent=4, sort_keys=True)}"
+            self.log.debug(msg)
 
         self.ip_sn, self.hn_sn = get_ip_sn_dict(self.inventory_data)
         self.sn_ip = {value: key for (key, value) in self.ip_sn.items()}
         self.fabric_data = get_nd_fabric_details(self.module, self.dcnm_version, self.fabric, self.action_fabric_details)
 
-        msg = "self.fabric_data: "
-        msg += f"{json.dumps(self.fabric_data, indent=4, sort_keys=True)}"
-        self.log.debug(msg)
+        if self.log.isEnabledFor(logging.DEBUG):
+            msg = "self.fabric_data: "
+            msg += f"{json.dumps(self.fabric_data, indent=4, sort_keys=True)}"
+            self.log.debug(msg)
 
         self.fabric_type = self.fabric_data.get("fabricType")
         self.fabric_nvpairs = self.fabric_data.get("nvPairs")
@@ -1310,6 +1319,29 @@ class DcnmVrf:
         match = (d for d in search if d[key] == value)
         return next(match, None)
 
+    def _refresh_config_indexes(self):
+        """
+        Build cached lookups for config data used repeatedly in diff paths.
+        """
+        validated = getattr(self, "validated", [])
+        config = validated if validated else (self.config or [])
+        self.config_by_vrf_name = {
+            vrf["vrf_name"]: vrf
+            for vrf in config
+            if vrf.get("vrf_name")
+        }
+        self.vrf_lite_vrf_names = {
+            vrf["vrf_name"]
+            for vrf in config
+            if vrf.get("vrf_name")
+            for attach in vrf.get("attach", []) or []
+            if attach.get("vrf_lite")
+        }
+        self.any_vrf_lite_in_config = bool(self.vrf_lite_vrf_names)
+
+    def _get_config_for_vrf(self, vrf_name):
+        return self.config_by_vrf_name.get(vrf_name)
+
     # pylint: disable=inconsistent-return-statements
     def to_bool(self, key, dict_with_key):
         """
@@ -1326,16 +1358,15 @@ class DcnmVrf:
 
         -   Call fail_json() if the value is not convertable to boolean.
         """
-        method_name = inspect.stack()[0][3]
-        caller = inspect.stack()[1][3]
+        method_name = "to_bool"
 
         value = dict_with_key.get(key)
 
-        msg = "ENTERED. "
-        msg += f"caller: {caller}. "
-        msg += f"key: {key}, "
-        msg += f"value: {value}"
-        self.log.debug(msg)
+        if self.log.isEnabledFor(logging.DEBUG):
+            msg = "ENTERED. "
+            msg += f"key: {key}, "
+            msg += f"value: {value}"
+            self.log.debug(msg)
 
         if value in ["false", "False", False]:
             return False
@@ -1343,7 +1374,6 @@ class DcnmVrf:
             return True
 
         msg = f"{self.class_name}.{method_name}: "
-        msg += f"caller: {caller}: "
         msg += f"key: {key}, "
         msg += f"value ({str(value)}), "
         msg += f"with type {type(value)} "
@@ -1382,239 +1412,212 @@ class DcnmVrf:
 
         None
         """
-        caller = inspect.stack()[1][3]
-
-        msg = "ENTERED. "
-        msg += f"caller: {caller}. "
-        msg += f"replace == {replace}"
-        self.log.debug(msg)
+        self.log.debug("ENTERED. replace == %s", replace)
 
         attach_list = []
 
         if not want_a:
-            return attach_list
+            return attach_list, False
 
         deploy_vrf = False
+        have_by_key = {
+            (have.get("serialNumber"), have.get("vrfName")): have
+            for have in have_a or []
+            if have.get("serialNumber") is not None and have.get("vrfName") is not None
+        }
+
         for want in want_a:
             found = False
             interface_match = False
-            if have_a:
-                for have in have_a:
-                    if want["serialNumber"] == have["serialNumber"] and want["vrfName"] == have["vrfName"]:
-                        # handle instanceValues first
-                        want.update(
-                            {"freeformConfig": have.get("freeformConfig", "")}
-                        )  # copy freeformConfig from have as module is not managing it
-                        want_inst_values = {}
-                        have_inst_values = {}
-                        if (
-                            (want["instanceValues"] is not None and want["instanceValues"] != "")
-                            and
-                            (have["instanceValues"] is not None and have["instanceValues"] != "")
-                        ):
-                            want_inst_values = ast.literal_eval(want["instanceValues"])
-                            have_inst_values = ast.literal_eval(have["instanceValues"])
+            have = have_by_key.get((want.get("serialNumber"), want.get("vrfName")))
+            if have:
+                # handle instanceValues first
+                want.update(
+                    {"freeformConfig": have.get("freeformConfig", "")}
+                )  # copy freeformConfig from have as module is not managing it
+                want_inst_values = {}
+                have_inst_values = {}
+                skip_matched_have = False
+                if (
+                    (want["instanceValues"] is not None and want["instanceValues"] != "")
+                    and
+                    (have["instanceValues"] is not None and have["instanceValues"] != "")
+                ):
+                    want_inst_values = ast.literal_eval(want["instanceValues"])
+                    have_inst_values = ast.literal_eval(have["instanceValues"])
 
-                            # update unsupported parameters using have
-                            # Only need ipv4 or ipv6. Don't require both, but both can be supplied (as per the GUI)
-                            if "loopbackId" in have_inst_values:
-                                want_inst_values.update(
-                                    {"loopbackId": have_inst_values["loopbackId"]}
-                                )
-                            if "loopbackIpAddress" in have_inst_values:
-                                want_inst_values.update(
-                                    {
-                                        "loopbackIpAddress": have_inst_values[
-                                            "loopbackIpAddress"
-                                        ]
-                                    }
-                                )
-                            if "loopbackIpV6Address" in have_inst_values:
-                                want_inst_values.update(
-                                    {
-                                        "loopbackIpV6Address": have_inst_values[
-                                            "loopbackIpV6Address"
-                                        ]
-                                    }
-                                )
+                    # update unsupported parameters using have
+                    # Only need ipv4 or ipv6. Don't require both, but both can be supplied (as per the GUI)
+                    if "loopbackId" in have_inst_values:
+                        want_inst_values.update(
+                            {"loopbackId": have_inst_values["loopbackId"]}
+                        )
+                    if "loopbackIpAddress" in have_inst_values:
+                        want_inst_values.update(
+                            {
+                                "loopbackIpAddress": have_inst_values[
+                                    "loopbackIpAddress"
+                                ]
+                            }
+                        )
+                    if "loopbackIpV6Address" in have_inst_values:
+                        want_inst_values.update(
+                            {
+                                "loopbackIpV6Address": have_inst_values[
+                                    "loopbackIpV6Address"
+                                ]
+                            }
+                        )
 
-                            want.update(
-                                {"instanceValues": json.dumps(want_inst_values)}
-                            )
-                        if (
-                            want["extensionValues"] != ""
-                            and have["extensionValues"] != ""
-                        ):
+                    want.update(
+                        {"instanceValues": json.dumps(want_inst_values)}
+                    )
+                if (
+                    want["extensionValues"] != ""
+                    and have["extensionValues"] != ""
+                ):
 
-                            msg = "want[extensionValues] != '' and "
-                            msg += "have[extensionValues] != ''"
-                            self.log.debug(msg)
+                    self.log.debug("want[extensionValues] != '' and have[extensionValues] != ''")
 
-                            want_ext_values = want["extensionValues"]
-                            want_ext_values = ast.literal_eval(want_ext_values)
-                            have_ext_values = have["extensionValues"]
-                            have_ext_values = ast.literal_eval(have_ext_values)
+                    want_ext_values = want["extensionValues"]
+                    want_ext_values = ast.literal_eval(want_ext_values)
+                    have_ext_values = have["extensionValues"]
+                    have_ext_values = ast.literal_eval(have_ext_values)
 
-                            want_e = ast.literal_eval(want_ext_values["VRF_LITE_CONN"])
-                            have_e = ast.literal_eval(have_ext_values["VRF_LITE_CONN"])
+                    want_e = ast.literal_eval(want_ext_values["VRF_LITE_CONN"])
+                    have_e = ast.literal_eval(have_ext_values["VRF_LITE_CONN"])
 
-                            if replace and (
-                                len(want_e["VRF_LITE_CONN"])
-                                != len(have_e["VRF_LITE_CONN"])
-                            ):
-                                # In case of replace/override if the length of want and have lite attach of a switch
-                                # is not same then we have to push the want to NDFC. No further check is required for
-                                # this switch
-                                break
+                    if replace and (
+                        len(want_e["VRF_LITE_CONN"])
+                        != len(have_e["VRF_LITE_CONN"])
+                    ):
+                        # In case of replace/override if the length of want and have lite attach of a switch
+                        # is not same then we have to push the want to NDFC. No further check is required for
+                        # this switch
+                        skip_matched_have = True
+                    else:
+                        for wlite in want_e["VRF_LITE_CONN"]:
+                            for hlite in have_e["VRF_LITE_CONN"]:
+                                found = False
+                                interface_match = False
+                                if wlite["IF_NAME"] != hlite["IF_NAME"]:
+                                    continue
+                                found = True
+                                interface_match = True
 
-                            for wlite in want_e["VRF_LITE_CONN"]:
-                                for hlite in have_e["VRF_LITE_CONN"]:
+                                # Copy VRF Lite properties from have to want to ensure proper idempotence comparison
+                                # This prevents false positives when user specifies minimal config (only interface name)
+                                # Captured in merged Idempotence test case
+                                for prop in self.vrf_lite_properties:
+                                    # Skip IF_NAME as it's already matched
+                                    if prop != "IF_NAME" and prop in hlite:
+                                        # Only copy if want property is empty/None and have has a value
+                                        if not wlite.get(prop) and hlite.get(prop):
+                                            wlite[prop] = hlite[prop]
+
+                                skip_prop = []
+                                if not wlite["DOT1Q_ID"]:
+                                    skip_prop.append("DOT1Q_ID")
+                                if not self.compare_properties(
+                                    wlite, hlite, self.vrf_lite_properties, skip_prop
+                                ):
                                     found = False
-                                    interface_match = False
-                                    if wlite["IF_NAME"] != hlite["IF_NAME"]:
-                                        continue
-                                    found = True
-                                    interface_match = True
+                                    break
 
-                                    # Copy VRF Lite properties from have to want to ensure proper idempotence comparison
-                                    # This prevents false positives when user specifies minimal config (only interface name)
-                                    # Captured in merged Idempotence test case
-                                    for prop in self.vrf_lite_properties:
-                                        # Skip IF_NAME as it's already matched
-                                        if prop != "IF_NAME" and prop in hlite:
-                                            # Only copy if want property is empty/None and have has a value
-                                            if not wlite.get(prop) and hlite.get(prop):
-                                                wlite[prop] = hlite[prop]
-
-                                    skip_prop = []
-                                    if not wlite["DOT1Q_ID"]:
-                                        skip_prop.append("DOT1Q_ID")
-                                    if not self.compare_properties(
-                                        wlite, hlite, self.vrf_lite_properties, skip_prop
-                                    ):
-                                        found = False
-                                        break
-
-                                    if found:
-                                        break
-
-                                    if interface_match and not found:
-                                        break
+                                if found:
+                                    break
 
                                 if interface_match and not found:
                                     break
 
-                            # After comparing VRF lite interfaces, check deployment status
-                            # only if all interfaces matched (found = True)
+                            if interface_match and not found:
+                                break
 
-                        elif (
-                            want["extensionValues"] != ""
-                            and have["extensionValues"] == ""
-                        ):
-                            found = False
-                        elif (
-                            want["extensionValues"] == ""
-                            and have["extensionValues"] != ""
-                        ):
-                            if replace:
-                                found = False
-                            else:
-                                found = True
-                        else:
-                            found = True
-                            msg = "want_is_deploy: "
-                            msg += f"{str(want.get('want_is_deploy'))}, "
-                            msg += "have_is_deploy: "
-                            msg += f"{str(want.get('have_is_deploy'))}"
-                            self.log.debug(msg)
+                    # After comparing VRF lite interfaces, check deployment status
+                    # only if all interfaces matched (found = True)
 
-                        if found:
-                            want_is_deploy = self.to_bool("is_deploy", want)
-                            have_is_deploy = self.to_bool("is_deploy", have)
+                elif (
+                    want["extensionValues"] != ""
+                    and have["extensionValues"] == ""
+                ):
+                    found = False
+                elif (
+                    want["extensionValues"] == ""
+                    and have["extensionValues"] != ""
+                ):
+                    if replace:
+                        found = False
+                    else:
+                        found = True
+                else:
+                    found = True
+                    self.log.debug(
+                        "want_is_deploy: %s, have_is_deploy: %s",
+                        str(want.get("want_is_deploy")),
+                        str(want.get("have_is_deploy")),
+                    )
 
-                            msg = "want_is_deploy: "
-                            msg += f"type {type(want_is_deploy)}, "
-                            msg += f"value {want_is_deploy}"
-                            self.log.debug(msg)
+                if found and not skip_matched_have:
+                    want_is_deploy = self.to_bool("is_deploy", want)
+                    have_is_deploy = self.to_bool("is_deploy", have)
 
-                            msg = "have_is_deploy: "
-                            msg += f"type {type(have_is_deploy)}, "
-                            msg += f"value {have_is_deploy}"
-                            self.log.debug(msg)
+                    self.log.debug("want_is_deploy: type %s, value %s", type(want_is_deploy), want_is_deploy)
+                    self.log.debug("have_is_deploy: type %s, value %s", type(have_is_deploy), have_is_deploy)
+                    self.log.debug(
+                        "want_is_attached: %s, want_is_attached: %s",
+                        str(want.get("want_is_attached")),
+                        str(want.get("want_is_attached")),
+                    )
 
-                            msg = "want_is_attached: "
-                            msg += f"{str(want.get('want_is_attached'))}, "
-                            msg += "want_is_attached: "
-                            msg += f"{str(want.get('want_is_attached'))}"
-                            self.log.debug(msg)
+                    want_is_attached = self.to_bool("isAttached", want)
+                    have_is_attached = self.to_bool("isAttached", have)
 
-                            want_is_attached = self.to_bool("isAttached", want)
-                            have_is_attached = self.to_bool("isAttached", have)
+                    self.log.debug("want_is_attached: type %s, value %s", type(want_is_attached), want_is_attached)
+                    self.log.debug("have_is_attached: type %s, value %s", type(have_is_attached), have_is_attached)
 
-                            msg = "want_is_attached: "
-                            msg += f"type {type(want_is_attached)}, "
-                            msg += f"value {want_is_attached}"
-                            self.log.debug(msg)
+                    if have_is_attached != want_is_attached:
+                        if "isAttached" in want:
+                            del want["isAttached"]
 
-                            msg = "have_is_attached: "
-                            msg += f"type {type(have_is_attached)}, "
-                            msg += f"value {have_is_attached}"
-                            self.log.debug(msg)
+                        want["deployment"] = True
+                        attach_list.append(want)
+                        if want_is_deploy is True:
+                            if "isAttached" in want:
+                                del want["isAttached"]
+                            deploy_vrf = True
+                        continue
 
-                            if have_is_attached != want_is_attached:
-                                if "isAttached" in want:
-                                    del want["isAttached"]
+                    self.log.debug(
+                        "want_deployment: %s, have_deployment: %s",
+                        str(want.get("want_deployment")),
+                        str(want.get("have_deployment")),
+                    )
 
-                                want["deployment"] = True
-                                attach_list.append(want)
-                                if want_is_deploy is True:
-                                    if "isAttached" in want:
-                                        del want["isAttached"]
-                                    deploy_vrf = True
-                                continue
+                    want_deployment = self.to_bool("deployment", want)
+                    have_deployment = self.to_bool("deployment", have)
 
-                            msg = "want_deployment: "
-                            msg += f"{str(want.get('want_deployment'))}, "
-                            msg += "have_deployment: "
-                            msg += f"{str(want.get('have_deployment'))}"
-                            self.log.debug(msg)
+                    self.log.debug("want_deployment: type %s, value %s", type(want_deployment), want_deployment)
+                    self.log.debug("have_deployment: type %s, value %s", type(have_deployment), have_deployment)
 
-                            want_deployment = self.to_bool("deployment", want)
-                            have_deployment = self.to_bool("deployment", have)
+                    if (want_deployment != have_deployment) or (
+                        want_is_deploy != have_is_deploy
+                    ):
+                        if want_is_deploy is True:
+                            deploy_vrf = True
 
-                            msg = "want_deployment: "
-                            msg += f"type {type(want_deployment)}, "
-                            msg += f"value {want_deployment}"
-                            self.log.debug(msg)
-
-                            msg = "have_deployment: "
-                            msg += f"type {type(have_deployment)}, "
-                            msg += f"value {have_deployment}"
-                            self.log.debug(msg)
-
-                            if (want_deployment != have_deployment) or (
-                                want_is_deploy != have_is_deploy
-                            ):
-                                if want_is_deploy is True:
-                                    deploy_vrf = True
-
-                        if self.dict_values_differ(want_inst_values, have_inst_values):
-                            msg = "dict values differ. Set found = False"
-                            self.log.debug(msg)
-                            found = False
-
-                        if found:
-                            break
-
-                    if interface_match and not found:
-                        break
+                if (
+                    not skip_matched_have
+                    and self.dict_values_differ(want_inst_values, have_inst_values)
+                ):
+                    self.log.debug("dict values differ. Set found = False")
+                    found = False
 
             if not found:
-                msg = "isAttached: "
-                msg += f"{str(want.get('isAttached'))}, "
-                msg += "is_deploy: "
-                msg += f"{str(want.get('is_deploy'))}"
-                self.log.debug(msg)
+                self.log.debug(
+                    "isAttached: %s, is_deploy: %s",
+                    str(want.get("isAttached")),
+                    str(want.get("is_deploy")),
+                )
 
                 if self.to_bool("isAttached", want):
                     del want["isAttached"]
@@ -1623,11 +1626,12 @@ class DcnmVrf:
                     if self.to_bool("is_deploy", want):
                         deploy_vrf = True
 
-        msg = "Returning "
-        msg += f"deploy_vrf: {deploy_vrf}, "
-        msg += "attach_list: "
-        msg += f"{json.dumps(attach_list, indent=4, sort_keys=True)}"
-        self.log.debug(msg)
+        if self.log.isEnabledFor(logging.DEBUG):
+            msg = "Returning "
+            msg += f"deploy_vrf: {deploy_vrf}, "
+            msg += "attach_list: "
+            msg += f"{json.dumps(attach_list, indent=4, sort_keys=True)}"
+            self.log.debug(msg)
         return attach_list, deploy_vrf
 
     def update_attach_params_extension_values(self, attach) -> dict:
@@ -1780,12 +1784,8 @@ class DcnmVrf:
         -   If the vrf_lite object is not null, and the switch is not
             a border switch
         """
-        caller = inspect.stack()[1][3]
-        method_name = inspect.stack()[0][3]
-
-        msg = "ENTERED. "
-        msg += f"caller: {caller}."
-        self.log.debug(msg)
+        method_name = "update_attach_params"
+        self.log.debug("ENTERED.")
 
         if not attach:
             msg = "Early return. No attachments to process."
@@ -1800,17 +1800,17 @@ class DcnmVrf:
 
         serial = self.ip_to_serial_number(attach["ip_address"])
 
-        msg = "ip_address: "
-        msg += f"{attach['ip_address']}, "
-        msg += "serial: "
-        msg += f"{serial}, "
-        msg += "attach: "
-        msg += f"{json.dumps(attach, indent=4, sort_keys=True)}"
-        self.log.debug(msg)
+        if self.log.isEnabledFor(logging.DEBUG):
+            msg = "ip_address: "
+            msg += f"{attach['ip_address']}, "
+            msg += "serial: "
+            msg += f"{serial}, "
+            msg += "attach: "
+            msg += f"{json.dumps(attach, indent=4, sort_keys=True)}"
+            self.log.debug(msg)
 
         if not serial:
             msg = f"{self.class_name}.{method_name}: "
-            msg += f"caller: {caller}. "
             msg += f"Fabric {self.fabric} does not contain switch "
             msg += f"{attach['ip_address']}"
             self.module.fail_json(msg=msg)
@@ -1819,7 +1819,6 @@ class DcnmVrf:
 
         if role.lower() in ("spine", "super spine"):
             msg = f"{self.class_name}.{method_name}: "
-            msg += f"caller: {caller}. "
             msg += "VRF attachments are not appropriate for "
             msg += "switches with Spine or Super Spine roles. "
             msg += "The playbook and/or controller settings for switch "
@@ -1867,9 +1866,10 @@ class DcnmVrf:
         if "ip_address" in attach:
             del attach["ip_address"]
 
-        msg = "Returning attach: "
-        msg += f"{json.dumps(attach, indent=4, sort_keys=True)}"
-        self.log.debug(msg)
+        if self.log.isEnabledFor(logging.DEBUG):
+            msg = "Returning attach: "
+            msg += f"{json.dumps(attach, indent=4, sort_keys=True)}"
+            self.log.debug(msg)
 
         return copy.deepcopy(attach)
 
@@ -2409,28 +2409,10 @@ class DcnmVrf:
         - True if vrf_lite configuration is found
         - False if no vrf_lite configuration is found, or if self.config is None/empty
         """
-        if not self.config:
-            # No config provided (e.g., query/deleted state without config)
-            # Return False to indicate we should call API (can't optimize)
-            return False
+        if vrf_name is None:
+            return self.any_vrf_lite_in_config
 
-        for vrf in self.config:
-            # If checking for a specific VRF, skip others
-            if vrf_name and vrf.get("vrf_name") != vrf_name:
-                continue
-
-            # Check if this VRF has attach list with vrf_lite
-            attach_list = vrf.get("attach", [])
-            if not attach_list:
-                continue
-
-            for attach in attach_list:
-                vrf_lite = attach.get("vrf_lite")
-                # Check if vrf_lite exists and is not empty/null
-                if vrf_lite:
-                    return True
-
-        return False
+        return vrf_name in self.vrf_lite_vrf_names
 
     def get_vrf_lite_objects(self, attach) -> dict:
         """
@@ -2491,7 +2473,7 @@ class DcnmVrf:
 
         targeted_states = {"merged", "replaced", "deleted"}
         if self.state in targeted_states and self.config:
-            wanted_vrf_names = {vrf.get("vrf_name") for vrf in self.config if vrf.get("vrf_name")}
+            wanted_vrf_names = set(self.config_by_vrf_name)
             vrf_data_to_process = [v for v in vrf_objects["DATA"] if v["vrfName"] in wanted_vrf_names]
             msg = (
                 f"Targeted get_have() for state '{self.state}': "
@@ -2754,23 +2736,24 @@ class DcnmVrf:
         self.have_deploy = have_deploy
         self.chg_deploy = chg_deploy
 
-        msg = "self.have_create: "
-        msg += f"{json.dumps(self.have_create, indent=4)}"
-        self.log.debug(msg)
+        if self.log.isEnabledFor(logging.DEBUG):
+            msg = "self.have_create: "
+            msg += f"{json.dumps(self.have_create, indent=4)}"
+            self.log.debug(msg)
 
-        # json.dumps() here breaks unit tests since self.have_attach is
-        # a MagicMock and not JSON serializable.
-        msg = "self.have_attach: "
-        msg += f"{self.have_attach}"
-        self.log.debug(msg)
+            # json.dumps() here breaks unit tests since self.have_attach is
+            # a MagicMock and not JSON serializable.
+            msg = "self.have_attach: "
+            msg += f"{self.have_attach}"
+            self.log.debug(msg)
 
-        msg = "self.have_deploy: "
-        msg += f"{json.dumps(self.have_deploy, indent=4)}"
-        self.log.debug(msg)
+            msg = "self.have_deploy: "
+            msg += f"{json.dumps(self.have_deploy, indent=4)}"
+            self.log.debug(msg)
 
-        msg = "self.chg_deploy: "
-        msg += f"{json.dumps(self.chg_deploy, indent=4)}"
-        self.log.debug(msg)
+            msg = "self.chg_deploy: "
+            msg += f"{json.dumps(self.chg_deploy, indent=4)}"
+            self.log.debug(msg)
 
     def get_want(self):
         method_name = inspect.stack()[0][3]
@@ -2784,15 +2767,17 @@ class DcnmVrf:
         want_attach = []
         want_deploy = {}
 
-        msg = "self.config "
-        msg += f"{json.dumps(self.config, indent=4)}"
-        self.log.debug(msg)
+        if self.log.isEnabledFor(logging.DEBUG):
+            msg = "self.config "
+            msg += f"{json.dumps(self.config, indent=4)}"
+            self.log.debug(msg)
 
         all_vrfs = []
 
-        msg = "self.validated: "
-        msg += f"{json.dumps(self.validated, indent=4, sort_keys=True)}"
-        self.log.debug(msg)
+        if self.log.isEnabledFor(logging.DEBUG):
+            msg = "self.validated: "
+            msg += f"{json.dumps(self.validated, indent=4, sort_keys=True)}"
+            self.log.debug(msg)
 
         for vrf in self.validated:
             vrf_name = vrf.get("vrf_name")
@@ -2847,19 +2832,21 @@ class DcnmVrf:
         # O(1) lookup dict for want_create
         self.want_create_by_name = {v["vrfName"]: v for v in self.want_create}
         self.want_attach = copy.deepcopy(want_attach)
+        self.want_attach_by_name = {v["vrfName"]: v for v in self.want_attach}
         self.want_deploy = copy.deepcopy(want_deploy)
 
-        msg = "self.want_create: "
-        msg += f"{json.dumps(self.want_create, indent=4)}"
-        self.log.debug(msg)
+        if self.log.isEnabledFor(logging.DEBUG):
+            msg = "self.want_create: "
+            msg += f"{json.dumps(self.want_create, indent=4)}"
+            self.log.debug(msg)
 
-        msg = "self.want_attach: "
-        msg += f"{json.dumps(self.want_attach, indent=4)}"
-        self.log.debug(msg)
+            msg = "self.want_attach: "
+            msg += f"{json.dumps(self.want_attach, indent=4)}"
+            self.log.debug(msg)
 
-        msg = "self.want_deploy: "
-        msg += f"{json.dumps(self.want_deploy, indent=4)}"
-        self.log.debug(msg)
+            msg = "self.want_deploy: "
+            msg += f"{json.dumps(self.want_deploy, indent=4)}"
+            self.log.debug(msg)
 
     def update_want(self):
 
@@ -2874,10 +2861,12 @@ class DcnmVrf:
         # processing deployments.
         if self.action_fabric_type == "multisite_child" or self.action_fabric_type == "multicluster_child":
             self.want_attach = copy.deepcopy(self.have_attach)
+            self.want_attach_by_name = {v["vrfName"]: v for v in self.want_attach}
 
-            msg = "self.want_attach: "
-            msg += f"{json.dumps(self.want_attach, indent=4)}"
-            self.log.debug(msg)
+            if self.log.isEnabledFor(logging.DEBUG):
+                msg = "self.want_attach: "
+                msg += f"{json.dumps(self.want_attach, indent=4)}"
+                self.log.debug(msg)
 
     def get_diff_delete(self):
         caller = inspect.stack()[1][3]
@@ -3057,29 +3046,24 @@ class DcnmVrf:
 
         for have_a in self.have_attach:
             replace_vrf_list = []
-            h_in_w = False
-            for want_a in self.want_attach:
-                if have_a["vrfName"] == want_a["vrfName"]:
-                    h_in_w = True
+            want_a = self.want_attach_by_name.get(have_a["vrfName"])
+            h_in_w = want_a is not None
+            if h_in_w:
+                want_serials = {
+                    a_w.get("serialNumber")
+                    for a_w in want_a.get("lanAttachList", []) or []
+                    if a_w.get("serialNumber") is not None
+                }
 
-                    for a_h in have_a["lanAttachList"]:
+                for a_h in have_a["lanAttachList"]:
+                    if "isAttached" in a_h:
+                        if not a_h["isAttached"]:
+                            continue
+                    if a_h["serialNumber"] not in want_serials:
                         if "isAttached" in a_h:
-                            if not a_h["isAttached"]:
-                                continue
-                        a_match = False
-
-                        if want_a.get("lanAttachList"):
-                            for a_w in want_a.get("lanAttachList"):
-                                if a_h["serialNumber"] == a_w["serialNumber"]:
-                                    # Have is already in diff, no need to continue looking for it.
-                                    a_match = True
-                                    break
-                        if not a_match:
-                            if "isAttached" in a_h:
-                                del a_h["isAttached"]
-                            a_h.update({"deployment": False})
-                            replace_vrf_list.append(a_h)
-                    break
+                            del a_h["isAttached"]
+                        a_h.update({"deployment": False})
+                        replace_vrf_list.append(a_h)
 
             if not h_in_w:
                 # O(1) lookup instead of find_dict_in_list_by_key_value
@@ -3119,7 +3103,7 @@ class DcnmVrf:
         modified_all_vrfs = copy.deepcopy(all_vrfs)
         for vrf in all_vrfs:
             # If the playbook sets the deploy key to False, then we need to remove the vrf from the deploy list.
-            want_vrf_data = find_dict_in_list_by_key_value(search=self.config, key="vrf_name", value=vrf)
+            want_vrf_data = self._get_config_for_vrf(vrf)
             if want_vrf_data.get('deploy', True) is False:
                 modified_all_vrfs.remove(vrf)
 
@@ -3407,9 +3391,7 @@ class DcnmVrf:
         for want_a in self.want_attach:
             # Check user intent for this VRF and don't add it to the deploy_vrf
             # list if the user has not requested a deploy.
-            want_config = self.find_dict_in_list_by_key_value(
-                search=self.config, key="vrf_name", value=want_a["vrfName"]
-            )
+            want_config = self._get_config_for_vrf(want_a["vrfName"])
             if not want_config:
                 continue
             deploy_vrf = ""
@@ -3464,7 +3446,7 @@ class DcnmVrf:
         modified_all_vrfs = copy.deepcopy(all_vrfs)
         for vrf in all_vrfs:
             # If the playbook sets the deploy key to False, then we need to remove the vrf from the deploy list.
-            want_vrf_data = find_dict_in_list_by_key_value(search=self.config, key="vrf_name", value=vrf)
+            want_vrf_data = self._get_config_for_vrf(vrf)
             if want_vrf_data.get("deploy", True) is False:
                 modified_all_vrfs.remove(vrf)
 
@@ -3506,14 +3488,15 @@ class DcnmVrf:
         already_deploying = set()
         if self.diff_deploy:
             already_deploying = set(self.diff_deploy["vrfNames"].split(","))
+        changed_vrfs = set(self.chg_deploy["vrfNames"].split(","))
 
         for vrf_name in self.want_deploy["vrfNames"].split(","):
             msg = f"VRF Name : {vrf_name}"
             self.log.debug(msg)
             if vrf_name in already_deploying:
                 continue
-            if not self.diff_attach and vrf_name in self.chg_deploy["vrfNames"].split(","):
-                want_vrf_data = find_dict_in_list_by_key_value(search=self.config, key="vrf_name", value=vrf_name)
+            if not self.diff_attach and vrf_name in changed_vrfs:
+                want_vrf_data = self._get_config_for_vrf(vrf_name)
                 if want_vrf_data.get("deploy", True) is True:
                     all_vrfs.append(vrf_name)
 
@@ -3570,33 +3553,34 @@ class DcnmVrf:
             self.diff_undeploy["vrfNames"].split(",") if self.diff_undeploy else []
         )
 
-        msg = "INPUT: diff_create: "
-        msg += f"{json.dumps(diff_create, indent=4, sort_keys=True)}"
-        self.log.debug(msg)
+        if self.log.isEnabledFor(logging.DEBUG):
+            msg = "INPUT: diff_create: "
+            msg += f"{json.dumps(diff_create, indent=4, sort_keys=True)}"
+            self.log.debug(msg)
 
-        msg = "INPUT: diff_create_quick: "
-        msg += f"{json.dumps(diff_create_quick, indent=4, sort_keys=True)}"
-        self.log.debug(msg)
+            msg = "INPUT: diff_create_quick: "
+            msg += f"{json.dumps(diff_create_quick, indent=4, sort_keys=True)}"
+            self.log.debug(msg)
 
-        msg = "INPUT: diff_create_update: "
-        msg += f"{json.dumps(diff_create_update, indent=4, sort_keys=True)}"
-        self.log.debug(msg)
+            msg = "INPUT: diff_create_update: "
+            msg += f"{json.dumps(diff_create_update, indent=4, sort_keys=True)}"
+            self.log.debug(msg)
 
-        msg = "INPUT: diff_attach: "
-        msg += f"{json.dumps(diff_attach, indent=4, sort_keys=True)}"
-        self.log.debug(msg)
+            msg = "INPUT: diff_attach: "
+            msg += f"{json.dumps(diff_attach, indent=4, sort_keys=True)}"
+            self.log.debug(msg)
 
-        msg = "INPUT: diff_detach: "
-        msg += f"{json.dumps(diff_detach, indent=4, sort_keys=True)}"
-        self.log.debug(msg)
+            msg = "INPUT: diff_detach: "
+            msg += f"{json.dumps(diff_detach, indent=4, sort_keys=True)}"
+            self.log.debug(msg)
 
-        msg = "INPUT: diff_deploy: "
-        msg += f"{json.dumps(diff_deploy, indent=4, sort_keys=True)}"
-        self.log.debug(msg)
+            msg = "INPUT: diff_deploy: "
+            msg += f"{json.dumps(diff_deploy, indent=4, sort_keys=True)}"
+            self.log.debug(msg)
 
-        msg = "INPUT: diff_undeploy: "
-        msg += f"{json.dumps(diff_undeploy, indent=4, sort_keys=True)}"
-        self.log.debug(msg)
+            msg = "INPUT: diff_undeploy: "
+            msg += f"{json.dumps(diff_undeploy, indent=4, sort_keys=True)}"
+            self.log.debug(msg)
 
         diff_create.extend(diff_create_quick)
         diff_create.extend(diff_create_update)
@@ -3606,29 +3590,33 @@ class DcnmVrf:
         # Get the VRF spec to determine which properties should be included in diff
         vrf_spec = self.get_vrf_spec()
 
-        msg = "vrf_spec for diff formatting: "
-        msg += f"{json.dumps(vrf_spec, indent=4, sort_keys=True)}"
-        self.log.debug(msg)
+        if self.log.isEnabledFor(logging.DEBUG):
+            msg = "vrf_spec for diff formatting: "
+            msg += f"{json.dumps(vrf_spec, indent=4, sort_keys=True)}"
+            self.log.debug(msg)
 
         for want_d in diff_create:
 
-            msg = "want_d: "
-            msg += f"{json.dumps(want_d, indent=4, sort_keys=True)}"
-            self.log.debug(msg)
+            if self.log.isEnabledFor(logging.DEBUG):
+                msg = "want_d: "
+                msg += f"{json.dumps(want_d, indent=4, sort_keys=True)}"
+                self.log.debug(msg)
 
             found_a = self.find_dict_in_list_by_key_value(
                 search=diff_attach, key="vrfName", value=want_d["vrfName"]
             )
 
-            msg = "found_a: "
-            msg += f"{json.dumps(found_a, indent=4, sort_keys=True)}"
-            self.log.debug(msg)
+            if self.log.isEnabledFor(logging.DEBUG):
+                msg = "found_a: "
+                msg += f"{json.dumps(found_a, indent=4, sort_keys=True)}"
+                self.log.debug(msg)
 
             found_c = copy.deepcopy(want_d)
 
-            msg = "found_c: PRE_UPDATE: "
-            msg += f"{json.dumps(found_c, indent=4, sort_keys=True)}"
-            self.log.debug(msg)
+            if self.log.isEnabledFor(logging.DEBUG):
+                msg = "found_c: PRE_UPDATE: "
+                msg += f"{json.dumps(found_c, indent=4, sort_keys=True)}"
+                self.log.debug(msg)
 
             # Extract template configuration
             json_to_dict = json.loads(found_c["vrfTemplateConfig"])
@@ -4433,12 +4421,13 @@ class DcnmVrf:
         if vrfs_to_delete and self.dcnm_version >= 12:
             self.log.debug("Sending Bulk VRF delete request")
             # Use retry logic for bulk delete
-            self.bulk_delete_with_retry(
-                vrfs_to_delete,
-                action,
-                verb,
-                is_rollback
-            )
+            for vrf_batch in self.get_list_of_lists(vrfs_to_delete, 30):
+                self.bulk_delete_with_retry(
+                    vrf_batch,
+                    action,
+                    verb,
+                    is_rollback
+                )
 
         if del_failure:
             msg = f"{self.class_name}.push_diff_delete: "
@@ -4874,11 +4863,7 @@ class DcnmVrf:
 
         If ip_address is not found, return None.
         """
-        caller = inspect.stack()[1][3]
-
-        msg = "ENTERED. "
-        msg += f"caller: {caller}"
-        self.log.debug(msg)
+        self.log.debug("ENTERED.")
 
         return self.ip_sn.get(ip_address)
 
@@ -5719,31 +5704,37 @@ class DcnmVrf:
         while pending_vrfs and retry_count > 0:
             retry_count -= 1
 
-            # Make ONE bulk API call for all pending VRFs
-            vrf_names = ",".join(pending_vrfs)
-            path = self.paths["GET_VRF_ATTACH"].format(self.fabric, vrf_names)
+            # Use batched bulk calls to keep query strings bounded at scale.
+            vrfs_by_name = {}
+            response_missing_data = False
+            for vrf_batch in self.get_list_of_lists(pending_vrfs, 30):
+                vrf_names = ",".join(vrf_batch)
+                path = self.paths["GET_VRF_ATTACH"].format(self.fabric, vrf_names)
 
-            resp = dcnm_send(self.module, "GET", path)
+                resp = dcnm_send(self.module, "GET", path)
 
-            if resp.get("DATA") is None:
+                if resp.get("DATA") is None:
+                    response_missing_data = True
+                    break
+
+                # VRF attachments API response structure: [{vrfName, lanAttachList: [...]}, ...]
+                # Each object contains vrfName and lanAttachList array
+
+                # Sanitize if multicluster_parent
+                if self.action_fabric_type == "multicluster_parent":
+                    sanitized_data = sanitize_lan_attach_list(resp["DATA"])
+                else:
+                    sanitized_data = resp["DATA"]
+
+                # Build lookup dictionary: {vrfName: lanAttachList}
+                for vrf_data in sanitized_data:
+                    vrf_name = vrf_data.get("vrfName")
+                    if vrf_name:
+                        vrfs_by_name[vrf_name] = vrf_data.get("lanAttachList", [])
+
+            if response_missing_data:
                 time.sleep(self.WAIT_TIME_FOR_DELETE_LOOP)
                 continue
-
-            # VRF attachments API response structure: [{vrfName, lanAttachList: [...]}, ...]
-            # Each object contains vrfName and lanAttachList array
-
-            # Sanitize if multicluster_parent
-            if self.action_fabric_type == "multicluster_parent":
-                sanitized_data = sanitize_lan_attach_list(resp["DATA"])
-            else:
-                sanitized_data = resp["DATA"]
-
-            # Build lookup dictionary: {vrfName: lanAttachList}
-            vrfs_by_name = {}
-            for vrf_data in sanitized_data:
-                vrf_name = vrf_data.get("vrfName")
-                if vrf_name:
-                    vrfs_by_name[vrf_name] = vrf_data.get("lanAttachList", [])
 
             # Process all pending VRFs
             vrfs_to_remove = []
@@ -6109,26 +6100,28 @@ class DcnmVrf:
         lite_spec = self.lite_spec()
         vrf_spec = self.get_vrf_spec()
 
-        msg = "attach_spec: "
-        msg += f"{json.dumps(attach_spec, indent=4, sort_keys=True)}"
-        self.log.debug(msg)
+        if self.log.isEnabledFor(logging.DEBUG):
+            msg = "attach_spec: "
+            msg += f"{json.dumps(attach_spec, indent=4, sort_keys=True)}"
+            self.log.debug(msg)
 
-        msg = "lite_spec: "
-        msg += f"{json.dumps(lite_spec, indent=4, sort_keys=True)}"
-        self.log.debug(msg)
+            msg = "lite_spec: "
+            msg += f"{json.dumps(lite_spec, indent=4, sort_keys=True)}"
+            self.log.debug(msg)
 
-        msg = "vrf_spec: "
-        msg += f"{json.dumps(vrf_spec, indent=4, sort_keys=True)}"
-        self.log.debug(msg)
+            msg = "vrf_spec: "
+            msg += f"{json.dumps(vrf_spec, indent=4, sort_keys=True)}"
+            self.log.debug(msg)
 
         if self.state in ("merged", "overridden", "replaced"):
             fail_msg_list = []
             if self.config:
                 for vrf in self.config:
-                    msg = f"state {self.state}: "
-                    msg += "self.config[vrf]: "
-                    msg += f"{json.dumps(vrf, indent=4, sort_keys=True)}"
-                    self.log.debug(msg)
+                    if self.log.isEnabledFor(logging.DEBUG):
+                        msg = f"state {self.state}: "
+                        msg += "self.config[vrf]: "
+                        msg += f"{json.dumps(vrf, indent=4, sort_keys=True)}"
+                        self.log.debug(msg)
                     # A few user provided vrf parameters need special handling
                     # Ignore user input for src and hard code it to None
                     vrf["source"] = None
@@ -6165,10 +6158,11 @@ class DcnmVrf:
                 )
                 for vrf in valid_vrf:
 
-                    msg = f"state {self.state}: "
-                    msg += "valid_vrf[vrf]: "
-                    msg += f"{json.dumps(vrf, indent=4, sort_keys=True)}"
-                    self.log.debug(msg)
+                    if self.log.isEnabledFor(logging.DEBUG):
+                        msg = f"state {self.state}: "
+                        msg += "valid_vrf[vrf]: "
+                        msg += f"{json.dumps(vrf, indent=4, sort_keys=True)}"
+                        self.log.debug(msg)
 
                     if vrf.get("attach"):
                         for entry in vrf.get("attach"):
@@ -6176,10 +6170,11 @@ class DcnmVrf:
                         valid_att, invalid_att = validate_list_of_dicts(
                             vrf["attach"], attach_spec
                         )
-                        msg = f"state {self.state}: "
-                        msg += "valid_att: "
-                        msg += f"{json.dumps(valid_att, indent=4, sort_keys=True)}"
-                        self.log.debug(msg)
+                        if self.log.isEnabledFor(logging.DEBUG):
+                            msg = f"state {self.state}: "
+                            msg += "valid_att: "
+                            msg += f"{json.dumps(valid_att, indent=4, sort_keys=True)}"
+                            self.log.debug(msg)
                         vrf["attach"] = valid_att
 
                         invalid_params.extend(invalid_att)
@@ -6188,15 +6183,16 @@ class DcnmVrf:
                                 valid_lite, invalid_lite = validate_list_of_dicts(
                                     lite["vrf_lite"], lite_spec
                                 )
-                                msg = f"state {self.state}: "
-                                msg += "valid_lite: "
-                                msg += f"{json.dumps(valid_lite, indent=4, sort_keys=True)}"
-                                self.log.debug(msg)
+                                if self.log.isEnabledFor(logging.DEBUG):
+                                    msg = f"state {self.state}: "
+                                    msg += "valid_lite: "
+                                    msg += f"{json.dumps(valid_lite, indent=4, sort_keys=True)}"
+                                    self.log.debug(msg)
 
-                                msg = f"state {self.state}: "
-                                msg += "invalid_lite: "
-                                msg += f"{json.dumps(invalid_lite, indent=4, sort_keys=True)}"
-                                self.log.debug(msg)
+                                    msg = f"state {self.state}: "
+                                    msg += "invalid_lite: "
+                                    msg += f"{json.dumps(invalid_lite, indent=4, sort_keys=True)}"
+                                    self.log.debug(msg)
 
                                 lite["vrf_lite"] = valid_lite
                                 invalid_params.extend(invalid_lite)
@@ -6227,15 +6223,16 @@ class DcnmVrf:
                                 valid_lite, invalid_lite = validate_list_of_dicts(
                                     lite["vrf_lite"], lite_spec
                                 )
-                                msg = f"state {self.state}: "
-                                msg += "valid_lite: "
-                                msg += f"{json.dumps(valid_lite, indent=4, sort_keys=True)}"
-                                self.log.debug(msg)
+                                if self.log.isEnabledFor(logging.DEBUG):
+                                    msg = f"state {self.state}: "
+                                    msg += "valid_lite: "
+                                    msg += f"{json.dumps(valid_lite, indent=4, sort_keys=True)}"
+                                    self.log.debug(msg)
 
-                                msg = f"state {self.state}: "
-                                msg += "invalid_lite: "
-                                msg += f"{json.dumps(invalid_lite, indent=4, sort_keys=True)}"
-                                self.log.debug(msg)
+                                    msg = f"state {self.state}: "
+                                    msg += "invalid_lite: "
+                                    msg += f"{json.dumps(invalid_lite, indent=4, sort_keys=True)}"
+                                    self.log.debug(msg)
 
                                 lite["vrf_lite"] = valid_lite
                                 invalid_params.extend(invalid_lite)
@@ -6247,6 +6244,8 @@ class DcnmVrf:
                     msg += "Invalid parameters in playbook: "
                     msg += f"{','.join(invalid_params)}"
                     self.module.fail_json(msg=msg)
+
+        self._refresh_config_indexes()
 
     def handle_response(self, res, op):
         self.log.debug("ENTERED")
@@ -6297,6 +6296,7 @@ class DcnmVrf:
         # rebuild lookup dict to match reassigned want_create
         self.want_create_by_name = {v["vrfName"]: v for v in self.want_create}
         self.want_attach = self.have_attach
+        self.want_attach_by_name = {v["vrfName"]: v for v in self.want_attach}
         self.want_deploy = self.have_deploy
 
         self.have_create = []

--- a/plugins/modules/dcnm_vrf.py
+++ b/plugins/modules/dcnm_vrf.py
@@ -1906,41 +1906,6 @@ class DcnmVrf:
         self.log.debug(msg)
         return False
 
-    def update_vrf_sn_detach_map(self):
-        """
-        Build/update centralized map of VRF-to-serial detachments.
-
-        Called after diff_detach is populated to create a single source of truth
-        for VRF detachment mappings during undeploy operations. Uses set() for
-        automatic deduplication.
-
-        Map format: {vrf_name: set(serial_numbers)}
-        """
-        caller = inspect.stack()[1][3]
-
-        msg = "ENTERED. "
-        msg += f"caller: {caller}."
-        self.log.debug(msg)
-
-        self.vrf_sn_detach_map.clear()
-
-        for vrf_detach in self.diff_detach:
-            vrf_name = vrf_detach.get("vrfName")
-            if not vrf_name:
-                continue
-
-            if vrf_name not in self.vrf_sn_detach_map:
-                self.vrf_sn_detach_map[vrf_name] = set()
-
-            for detach in vrf_detach.get("lanAttachList", []):
-                serial = detach.get("serialNumber")
-                if serial:
-                    self.vrf_sn_detach_map[vrf_name].add(serial)
-
-        msg = "self.vrf_sn_detach_map: "
-        msg += f"{json.dumps({k: list(v) for k, v in self.vrf_sn_detach_map.items()}, indent=4)}"
-        self.log.debug(msg)
-
     def get_deploy_switch_serials(self, vrf_names=None, is_undeploy=False):
         """
         Return ordered, unique switch serials affected by VRF deployments or undeployments.
@@ -3976,7 +3941,7 @@ class DcnmVrf:
             else:
                 # Use resource-level deploy: transform payload to serial number format
                 deploy_path = path.replace(f"/fabrics/{self.fabric}/vrfs", "/vrfs/deploy")
-                diff_undeploy = self.vrf_serial_payload_transform(self.diff_undeploy)
+                diff_undeploy = self.vrf_serial_payload_transform(self.diff_undeploy, is_undeploy=True)
                 self.send_to_controller(
                     action,
                     verb,
@@ -4019,11 +3984,11 @@ class DcnmVrf:
 
         # Check for OUT-OF-SYNC state and retry if needed
         if self.diff_undeploy:
-            delete_ready = self.wait_for_vrf_attachments_del_ready()
+            self.wait_for_vrf_attachments_del_ready()
             undeploy_retry_needed = any(
                 str(state).upper() == "OUT-OF-SYNC" for state in self.diff_delete.values()
             )
-            if delete_ready and undeploy_retry_needed:
+            if undeploy_retry_needed:
                 msg = "VRFs in OUT-OF-SYNC state detected. Retrying undeploy."
                 self.log.debug(msg)
 
@@ -4990,7 +4955,7 @@ class DcnmVrf:
             is_rollback=is_rollback,
         )
 
-    def vrf_serial_payload_transform(self, payload: dict) -> dict:
+    def vrf_serial_payload_transform(self, payload: dict, is_undeploy: bool = False) -> dict:
         """
         # Summary
 
@@ -5002,21 +4967,35 @@ class DcnmVrf:
         payload format for vrf_deploy operations.  This method
         transforms the standard payload into the required format.
 
-        Returns a dictionary mapping serial numbers to comma-separated VRF names.
+        ## Args
+
+        - payload: Dictionary with "vrfNames" key containing comma-separated VRF names
+        - is_undeploy: If True, uses vrf_sn_detach_map (undeploy). If False (default), uses vrf_sn_attach_map (deploy).
+
+        ## Returns
+
+        Dictionary mapping serial numbers to comma-separated VRF names.
         """
         caller = inspect.stack()[1][3]
 
         msg = "ENTERED. "
         msg += f"caller: {caller}. "
+        msg += f"is_undeploy: {is_undeploy}"
+        self.log.debug(msg)
+
+        # Select the appropriate map based on operation type
+        vrf_to_serial_map = self.vrf_sn_detach_map if is_undeploy else self.vrf_sn_attach_map
+        
+        map_type = "detach" if is_undeploy else "attach"
+        msg = f"Using vrf_sn_{map_type}_map for payload transformation."
         self.log.debug(msg)
 
         new_payload = {}
-        vrf_to_serial_attach = self.vrf_sn_attach_map
         payload_list = payload["vrfNames"].split(",")
 
         for vrf in payload_list:
-            # vrf_sn_attach_map stores sets of serial numbers per VRF
-            vrf_serial_set = vrf_to_serial_attach.get(vrf, set())
+            # Map stores sets of serial numbers per VRF
+            vrf_serial_set = vrf_to_serial_map.get(vrf, set())
 
             for serial in vrf_serial_set:
                 if serial not in new_payload:
@@ -5062,7 +5041,7 @@ class DcnmVrf:
             if self.deploy_mode == "switch":
                 diff_deploy = self.get_deploy_switch_serials(diff_deploy, is_undeploy=False)
             else:
-                diff_deploy = self.vrf_serial_payload_transform(diff_deploy)
+                diff_deploy = self.vrf_serial_payload_transform(diff_deploy, is_undeploy=False)
             # Wrap in structured format for type checking in action plugin
             self.deploy_payload = {"payload": diff_deploy}
             return
@@ -5076,7 +5055,7 @@ class DcnmVrf:
             else:
                 # Use resource-level deploy: standard /deployments path with vrfNames
                 deploy_path = path.replace(f"/fabrics/{self.fabric}/vrfs", "/vrfs/deploy")
-                diff_deploy = self.vrf_serial_payload_transform(self.diff_deploy)
+                diff_deploy = self.vrf_serial_payload_transform(self.diff_deploy, is_undeploy=False)
         else:
             # for dcnm versions < 12, use the original deploy path and payload format
             deploy_path = path + "/deployments"
@@ -5550,13 +5529,10 @@ class DcnmVrf:
         if pending_vrfs:
             msg = f"Timeout waiting for VRF attachments. Pending: {pending_vrfs}"
             self.log.debug(msg)
-            for vrf in pending_vrfs:
-                self.diff_delete.update({vrf: "TIMEOUT"})
-            return False
+            self.module.fail_json(msg=msg)
 
         msg = "All VRF attachments reached terminal state"
         self.log.debug(msg)
-        return True
 
     def attach_spec(self):
         """

--- a/plugins/modules/dcnm_vrf.py
+++ b/plugins/modules/dcnm_vrf.py
@@ -3908,7 +3908,7 @@ class DcnmVrf:
                             return
                         msg = f"{self.class_name}.{method_name}: "
                         msg += f"Bulk delete failed with 500 error after {max_retries} attempts. "
-                        msg += f"No failure details provided by controller."
+                        msg += "No failure details provided by controller."
                         self.log.debug(msg)
                         self.failure(response)
                     time.sleep(retry_delay)

--- a/plugins/modules/dcnm_vrf.py
+++ b/plugins/modules/dcnm_vrf.py
@@ -4182,7 +4182,7 @@ class DcnmVrf:
             if state == "OUT-OF-SYNC":
                 del_failure += vrf + ","
                 continue
-            if self.action_fabric_type == "multicluster_parent" or self.dcnm_version < 12:
+            if self.dcnm_version < 12:
                 self.log.debug("Sending individual VRF delete request")
                 path = self.paths["GET_VRF"].format(self.fabric)
                 delete_path = f"{path}/{vrf}"
@@ -4197,7 +4197,7 @@ class DcnmVrf:
             else:
                 vrfs_to_delete.append(vrf)
 
-        if self.action_fabric_type != "multicluster_parent" and vrfs_to_delete and self.dcnm_version >= 12:
+        if vrfs_to_delete and self.dcnm_version >= 12:
             self.log.debug("Sending Bulk VRF delete request")
             # Use retry logic for bulk delete
             self.bulk_delete_with_retry(

--- a/plugins/modules/dcnm_vrf.py
+++ b/plugins/modules/dcnm_vrf.py
@@ -3808,7 +3808,12 @@ class DcnmVrf:
         del_failure = ""
         vrfs_to_delete = []
 
+        # First, wait for attachments to be ready for deletion (lanAttachState = NA)
+        self.wait_for_vrf_attachments_del_ready()
+
+        # Then, wait for VRF itself to be ready for deletion (vrfStatus = NA/OUT-OF-SYNC/FAILED)
         self.wait_for_vrf_del_ready()
+
         for vrf, state in self.diff_delete.items():
             if state == "OUT-OF-SYNC":
                 del_failure += vrf + ","
@@ -4931,91 +4936,211 @@ class DcnmVrf:
         self.push_diff_attach(is_rollback)
         self.push_diff_deploy(is_rollback)
 
-    def wait_for_vrf_del_ready(self, vrf_name="not_supplied"):
+    def wait_for_vrf_del_ready(self):
         """
         # Summary
 
-        Wait for VRFs to be ready for deletion.
+        Wait for VRFs to reach a terminal state ready for deletion by checking vrfStatus.
+
+        Polls the GET /vrfs API once per retry iteration to check all VRFs.
+        Terminal states (ready for deletion):
+        - NA, OUT-OF-SYNC, FAILED: Can proceed with deletion
+        - DEPLOYED, PENDING: Must wait
 
         ## Raises
 
-        Calls fail_json if VRF has associated network attachments.
+        Calls fail_json if timeout is reached while waiting for VRF to reach terminal state.
         """
         caller = inspect.stack()[1][3]
         msg = "ENTERED. "
-        msg += f"caller: {caller}, "
-        msg += f"vrf_name: {vrf_name}"
+        msg += f"caller: {caller}"
         self.log.debug(msg)
 
-        for vrf in self.diff_delete:
-            ok_to_delete = False
-            path = self.paths["GET_VRF_ATTACH"].format(self.fabric, vrf)
-            retry_count = max(500 // self.WAIT_TIME_FOR_DELETE_LOOP, 1)
+        # Create a list of VRFs that still need to reach terminal state
+        pending_vrfs = list(self.diff_delete.keys())
 
-            # Initial quick-scan pass — check if VRF is already in a
-            # terminal state before entering the polling while-loop.
+        msg = f"Waiting for {len(pending_vrfs)} VRF(s) to reach terminal state: {pending_vrfs}"
+        self.log.debug(msg)
+
+        path = self.paths["GET_VRF"].format(self.fabric)
+        retry_count = max(500 // self.WAIT_TIME_FOR_DELETE_LOOP, 1)
+
+        while pending_vrfs and retry_count > 0:
+            retry_count -= 1
+
+            msg = f"Retry iteration, remaining: {retry_count}, pending VRFs: {len(pending_vrfs)}"
+            self.log.debug(msg)
+
+            # Make ONE API call to get all VRFs
             resp = dcnm_send(self.module, "GET", path)
-            if resp.get("DATA") is not None:
-                if self.action_fabric_type == "multicluster_parent":
-                    sanitized_data = sanitize_lan_attach_list(resp["DATA"])
-                    attach_list = sanitized_data[0]["lanAttachList"]
-                else:
-                    attach_list = resp["DATA"][0]["lanAttachList"]
 
-                initial_ready = True
-                for attach in attach_list:
-                    state = attach["lanAttachState"]
-                    if state in ("OUT-OF-SYNC", "FAILED"):
-                        self.diff_delete.update({vrf: "OUT-OF-SYNC"})
-                        ok_to_delete = True
-                        initial_ready = True
-                        break
-                    if state != "NA":
-                        initial_ready = False
-                        break
+            if resp.get("DATA") is None:
+                time.sleep(self.WAIT_TIME_FOR_DELETE_LOOP)
+                continue
+
+            # Build a lookup dict for faster access: {vrfName: vrfData}
+            vrfs_by_name = {vrf_data.get("vrfName"): vrf_data for vrf_data in resp["DATA"]}
+
+            # Check all pending VRFs in this response
+            vrfs_to_remove = []
+            for vrf in pending_vrfs:
+                vrf_data = vrfs_by_name.get(vrf)
+
+                if vrf_data is None:
+                    # VRF not found in response - it may have already been deleted
+                    msg = f"VRF {vrf} not found in GET /vrfs response, assuming already deleted"
+                    self.log.debug(msg)
                     self.diff_delete.update({vrf: "NA"})
-                if initial_ready:
-                    continue  # already in terminal state — skip polling loop
-
-            while not ok_to_delete:
-                resp = dcnm_send(self.module, "GET", path)
-                ok_to_delete = True
-                if resp.get("DATA") is None:
-                    time.sleep(self.WAIT_TIME_FOR_DELETE_LOOP)
+                    vrfs_to_remove.append(vrf)
                     continue
 
-                if self.action_fabric_type == "multicluster_parent":
-                    # Sanitize the lanAttachList entries
-                    sanitized_data = sanitize_lan_attach_list(
-                        resp["DATA"]
-                    )
-                    attach_list = sanitized_data[0]["lanAttachList"]
-                else:
-                    attach_list = resp["DATA"][0]["lanAttachList"]
+                vrf_status = vrf_data.get("vrfStatus", "")
 
-                msg = f"ok_to_delete: {ok_to_delete}, "
-                msg += f"attach_list: {json.dumps(attach_list, indent=4)}"
+                msg = f"vrf: {vrf}, vrfStatus: {vrf_status}"
                 self.log.debug(msg)
 
-                for attach in attach_list:
-                    if (
-                        attach["lanAttachState"] == "OUT-OF-SYNC"
-                        or attach["lanAttachState"] == "FAILED"
-                    ):
-                        self.diff_delete.update({vrf: "OUT-OF-SYNC"})
-                        break
-                    if attach["lanAttachState"] != "NA":
-                        time.sleep(self.WAIT_TIME_FOR_DELETE_LOOP)
-                        self.diff_delete.update({vrf: "DEPLOYED"})
-                        ok_to_delete = False
-                        break
+                # Check if VRF is in a terminal state ready for deletion
+                if vrf_status in ("OUT-OF-SYNC", "FAILED"):
+                    self.diff_delete.update({vrf: "OUT-OF-SYNC"})
+                    vrfs_to_remove.append(vrf)
+                elif vrf_status == "NA" or vrf_status == "":
                     self.diff_delete.update({vrf: "NA"})
-                if retry_count <= 0:
-                    msg = "Timeout waiting for VRF to be ready for deletion. "
-                    msg += f"vrf: {vrf}, "
-                    msg += f"resp: {resp}"
-                    self.module.fail_json(msg=msg)
-                retry_count -= 1
+                    vrfs_to_remove.append(vrf)
+                else:
+                    # VRF is still in DEPLOYED, PENDING, or other non-terminal state
+                    self.diff_delete.update({vrf: "DEPLOYED"})
+
+            # Remove VRFs that reached terminal state
+            for vrf in vrfs_to_remove:
+                pending_vrfs.remove(vrf)
+                msg = f"VRF {vrf} reached terminal state, removed from pending list"
+                self.log.debug(msg)
+
+            # If we still have pending VRFs, sleep before next retry
+            if pending_vrfs:
+                msg = f"Still waiting for {len(pending_vrfs)} VRF(s): {pending_vrfs}"
+                self.log.debug(msg)
+                time.sleep(self.WAIT_TIME_FOR_DELETE_LOOP)
+
+        # Check if we timed out
+        if pending_vrfs:
+            msg = "Timeout waiting for VRFs to be ready for deletion. "
+            msg += f"Pending VRFs: {pending_vrfs}, "
+            msg += f"States: {[(vrf, self.diff_delete.get(vrf)) for vrf in pending_vrfs]}"
+            self.module.fail_json(msg=msg)
+
+        msg = "All VRFs reached terminal state. Ready for deletion."
+        self.log.debug(msg)
+
+    def wait_for_vrf_attachments_del_ready(self):
+        """
+        # Summary
+
+        Wait for VRF attachments to be ready for deletion by checking lanAttachState.
+
+        Uses bulk GET_VRF_ATTACH API to check all VRFs in a single call per retry iteration.
+        Terminal states (ready for deletion):
+        - NA: Attachment has been removed
+        - OUT-OF-SYNC, FAILED: Can proceed with cleanup
+        - Other states: Must wait for undeployment to complete
+
+        ## Raises
+
+        Calls fail_json if timeout is reached while waiting for attachments.
+        """
+        caller = inspect.stack()[1][3]
+        msg = f"ENTERED. caller: {caller}"
+        self.log.debug(msg)
+
+        if not self.diff_delete:
+            return True
+
+        # Create list of VRFs pending deletion readiness
+        pending_vrfs = list(self.diff_delete.keys())
+        msg = f"Waiting for {len(pending_vrfs)} VRF(s) attachments to reach terminal state"
+        self.log.debug(msg)
+
+        retry_count = max(500 // self.WAIT_TIME_FOR_DELETE_LOOP, 1)
+
+        while pending_vrfs and retry_count > 0:
+            retry_count -= 1
+
+            # Make ONE bulk API call for all pending VRFs
+            vrf_names = ",".join(pending_vrfs)
+            path = self.paths["GET_VRF_ATTACH"].format(self.fabric, vrf_names)
+
+            resp = dcnm_send(self.module, "GET", path)
+
+            if resp.get("DATA") is None:
+                time.sleep(self.WAIT_TIME_FOR_DELETE_LOOP)
+                continue
+
+            # VRF attachments API response structure: [{vrfName, lanAttachList: [...]}, ...]
+            # Each object contains vrfName and lanAttachList array
+
+            # Sanitize if multicluster_parent
+            if self.action_fabric_type == "multicluster_parent":
+                sanitized_data = sanitize_lan_attach_list(resp["DATA"])
+            else:
+                sanitized_data = resp["DATA"]
+
+            # Build lookup dictionary: {vrfName: lanAttachList}
+            vrfs_by_name = {}
+            for vrf_data in sanitized_data:
+                vrf_name = vrf_data.get("vrfName")
+                if vrf_name:
+                    vrfs_by_name[vrf_name] = vrf_data.get("lanAttachList", [])
+
+            # Process all pending VRFs
+            vrfs_to_remove = []
+            for vrf in pending_vrfs:
+                attach_list = vrfs_by_name.get(vrf, [])
+
+                if not attach_list:
+                    # VRF not found in response, mark as ready
+                    self.diff_delete.update({vrf: "NA"})
+                    vrfs_to_remove.append(vrf)
+                    continue
+
+                # Check if all attachments are in terminal state
+                all_terminal = True
+                has_out_of_sync = False
+                for attach in attach_list:
+                    state = attach.get("lanAttachState", "")
+                    if state in ("OUT-OF-SYNC", "FAILED"):
+                        has_out_of_sync = True
+                    elif state != "NA":
+                        all_terminal = False
+                        break
+
+                if all_terminal:
+                    final_state = "OUT-OF-SYNC" if has_out_of_sync else "NA"
+                    self.diff_delete.update({vrf: final_state})
+                    vrfs_to_remove.append(vrf)
+                else:
+                    self.diff_delete.update({vrf: "DEPLOYED"})
+
+            # Remove VRFs that reached terminal state
+            for vrf in vrfs_to_remove:
+                pending_vrfs.remove(vrf)
+
+            # Sleep before next retry if there are still pending VRFs
+            if pending_vrfs:
+                msg = f"Still waiting for {len(pending_vrfs)} VRF(s): {pending_vrfs}"
+                self.log.debug(msg)
+                time.sleep(self.WAIT_TIME_FOR_DELETE_LOOP)
+
+        # Check if we timed out
+        if pending_vrfs:
+            msg = f"Timeout waiting for VRF attachments. Pending: {pending_vrfs}"
+            self.log.debug(msg)
+            for vrf in pending_vrfs:
+                self.diff_delete.update({vrf: "TIMEOUT"})
+            return False
+
+        msg = "All VRF attachments reached terminal state"
+        self.log.debug(msg)
+        return True
 
     def attach_spec(self):
         """

--- a/plugins/modules/dcnm_vrf.py
+++ b/plugins/modules/dcnm_vrf.py
@@ -5218,7 +5218,7 @@ class DcnmVrf:
 
         # Select the appropriate map based on operation type
         vrf_to_serial_map = self.vrf_sn_detach_map if is_undeploy else self.vrf_sn_attach_map
-        
+
         map_type = "detach" if is_undeploy else "attach"
         msg = f"Using vrf_sn_{map_type}_map for payload transformation."
         self.log.debug(msg)

--- a/plugins/modules/dcnm_vrf.py
+++ b/plugins/modules/dcnm_vrf.py
@@ -2003,6 +2003,212 @@ class DcnmVrf:
                     return
                 self.failure(resp)
 
+    def populate_sn_maps_from_diffs(self):
+        """
+        Populate vrf_sn_attach_map and vrf_sn_detach_map from calculated diff structures.
+
+        This function is called after all diffs have been calculated and before any
+        push operations. It ensures the serial number maps contain only switches
+        affected by the current operation.
+
+        Processing Logic:
+        1. Clear both maps for clean state
+        2. Process diff_attach:
+           - Both deployment:True and deployment:False → add to vrf_sn_attach_map
+           - Both attachment and detachment operations use the same config-deploy endpoint
+           - The 'deployment' flag in the attachment payload tells the controller what to do
+        3. Process diff_detach:
+           - All serials → add to vrf_sn_detach_map (state:deleted operations ONLY)
+           - diff_detach is only for VRF deletion, uses undeploy endpoint
+        4. Handle config-only changes (diff_create_update or conf_changed):
+           - Add ALL currently attached switches from have_attach to vrf_sn_attach_map
+           - Exclude any switches in vrf_sn_detach_map
+        5. Handle deploy-only operations (diff_deploy without attachment changes):
+           - VRFs from diff_merge_no_attach() (PENDING/OUT-OF-SYNC states)
+           - Add all attached switches to vrf_sn_attach_map
+
+        This approach ensures:
+        - New attachments: Deploy only to newly attached switches
+        - Detachments: Deploy removal config to detached switches (same endpoint as attach)
+        - Config changes: Deploy to all currently attached switches
+        - VRF deletion: Undeploy from all switches before deletion
+        - Mixed operations: Correct switch selection for each operation type
+        """
+        caller = inspect.stack()[1][3]
+
+        msg = "ENTERED. "
+        msg += f"caller: {caller}."
+        self.log.debug(msg)
+
+        # Step 1: Clear maps for clean state
+        self.vrf_sn_attach_map.clear()
+        self.vrf_sn_detach_map.clear()
+
+        msg = "Cleared vrf_sn_attach_map and vrf_sn_detach_map"
+        self.log.debug(msg)
+
+        # Step 2: Process diff_attach for attachments and detachments
+        # Both attachment (deployment:True) and detachment (deployment:False) operations
+        # use the SAME config-deploy endpoint. The deployment flag in the attachment payload
+        # tells the controller what to do. Therefore, BOTH need to be in vrf_sn_attach_map.
+        for vrf_attach in self.diff_attach:
+            vrf_name = vrf_attach.get("vrfName")
+            if not vrf_name:
+                continue
+
+            for attach in vrf_attach.get("lanAttachList", []):
+                serial = attach.get("serialNumber")
+                if not serial:
+                    continue
+
+                deployment = attach.get("deployment", True)
+
+                # Both attachment and detachment operations need config-deploy
+                if vrf_name not in self.vrf_sn_attach_map:
+                    self.vrf_sn_attach_map[vrf_name] = set()
+                self.vrf_sn_attach_map[vrf_name].add(serial)
+
+                deploy_type = "attachment" if deployment else "detachment"
+                msg = f"Added serial {serial} to vrf_sn_attach_map[{vrf_name}] from diff_attach ({deploy_type}, deployment:{deployment})"
+                self.log.debug(msg)
+
+        # Step 3: Process diff_detach (DELETE operations only)
+        # diff_detach is ONLY used for state:deleted operations where the entire VRF is being removed.
+        # Regular detachments (removing an attachment but keeping the VRF) go through diff_attach
+        # with deployment:False and use the regular config-deploy endpoint (handled in Step 2).
+        for vrf_detach in self.diff_detach:
+            vrf_name = vrf_detach.get("vrfName")
+            if not vrf_name:
+                continue
+
+            if vrf_name not in self.vrf_sn_detach_map:
+                self.vrf_sn_detach_map[vrf_name] = set()
+
+            for attach in vrf_detach.get("lanAttachList", []):
+                serial = attach.get("serialNumber")
+                if serial:
+                    self.vrf_sn_detach_map[vrf_name].add(serial)
+
+                    msg = f"Added serial {serial} to vrf_sn_detach_map[{vrf_name}] from diff_detach"
+                    self.log.debug(msg)
+
+        # Step 4: Handle config-only changes
+        # If there are VRF updates (config changes) but no attachment changes,
+        # we need to deploy to ALL currently attached switches
+
+        config_changed_vrfs = set()
+
+        # Check diff_create_update for VRF configuration changes
+        for vrf_update in self.diff_create_update:
+            vrf_name = vrf_update.get("vrfName")
+            if vrf_name:
+                config_changed_vrfs.add(vrf_name)
+
+        # Also check conf_changed dictionary
+        for vrf_name, changed in self.conf_changed.items():
+            if changed:
+                config_changed_vrfs.add(vrf_name)
+
+        # For each VRF with config changes, add all attached switches
+        for vrf_name in config_changed_vrfs:
+            # Find this VRF in have_attach
+            have_vrf = self.have_attach_by_name.get(vrf_name)
+            if not have_vrf:
+                continue
+
+            # Initialize map entry if needed
+            if vrf_name not in self.vrf_sn_attach_map:
+                self.vrf_sn_attach_map[vrf_name] = set()
+
+            # Add all attached switches, excluding any in detach_map
+            for attach in have_vrf.get("lanAttachList", []):
+                serial = attach.get("serialNumber")
+                is_attached = attach.get("isAttached", False)
+
+                if serial and is_attached:
+                    # Check if this switch is being detached
+                    if serial not in self.vrf_sn_detach_map.get(vrf_name, set()):
+                        self.vrf_sn_attach_map[vrf_name].add(serial)
+
+                        msg = f"Added serial {serial} to vrf_sn_attach_map[{vrf_name}] for config change (isAttached:True, not in detach_map)"
+                        self.log.debug(msg)
+
+        # Step 5: Handle VRFs in diff_deploy that need deployment but have no attachment changes
+        # This covers the case where diff_merge_no_attach() added VRFs (PENDING/OUT-OF-SYNC states)
+        # For VRFs in diff_deploy, we look for attachments with is_deploy=False (PENDING/OUT-OF-SYNC)
+        # Note: We do NOT skip VRFs already in the map because there may be additional PENDING serials
+        # Example: switch1 already PENDING from previous run, switch2 newly detached in current run
+        # Step 2 adds switch2, but we still need Step 5 to add switch1
+        if self.diff_deploy:
+            deploy_vrf_names = [v.strip() for v in self.diff_deploy.get("vrfNames", "").split(",") if v.strip()]
+
+            for vrf_name in deploy_vrf_names:
+                # Find this VRF in have_attach
+                have_vrf = self.have_attach_by_name.get(vrf_name)
+                if not have_vrf:
+                    continue
+
+                # Initialize map entry if needed (may already exist from Steps 2-4)
+                if vrf_name not in self.vrf_sn_attach_map:
+                    self.vrf_sn_attach_map[vrf_name] = set()
+
+                # Add ALL switches that are in PENDING/OUT-OF-SYNC state (is_deploy=False)
+                # Sets automatically handle duplicates, so safe to add even if already present
+                for attach in have_vrf.get("lanAttachList", []):
+                    serial = attach.get("serialNumber")
+                    is_deploy = attach.get("is_deploy", True)  # True=IN-SYNC/DEPLOYED, False=PENDING/OUT-OF-SYNC
+
+                    # Add switches that need deployment (is_deploy=False means PENDING or OUT-OF-SYNC)
+                    if serial and not is_deploy:
+                        # Check if this switch is being detached (state:deleted)
+                        if serial not in self.vrf_sn_detach_map.get(vrf_name, set()):
+                            # Only log if this is a new addition (avoid duplicate logs)
+                            if serial not in self.vrf_sn_attach_map[vrf_name]:
+                                is_attached = attach.get("isAttached", False)
+                                state = "PENDING-ATTACH" if is_attached else "PENDING-DETACH"
+                                msg = f"Added serial {serial} to vrf_sn_attach_map[{vrf_name}] from diff_deploy (state:{state}, is_deploy:False)"
+                                self.log.debug(msg)
+
+                            self.vrf_sn_attach_map[vrf_name].add(serial)
+        # diff_detach only contains isAttached switches, but undeploy needs ALL (pending, failed, out-of-sync, etc.)
+
+        # Determine which VRFs need undeploy
+        undeploy_vrfs = []
+        if self.diff_undeploy:
+            # Normal case: VRFs in diff_undeploy
+            undeploy_vrfs = [v.strip() for v in self.diff_undeploy.get("vrfNames", "").split(",") if v.strip()]
+        elif self.diff_delete:
+            # DELETE state with no isAttached attachments (all PENDING): use diff_delete
+            # This handles the case where attachments are in PENDING state and won't be in diff_undeploy
+            undeploy_vrfs = list(self.diff_delete.keys())
+
+        for vrf_name in undeploy_vrfs:
+            # Initialize detach_map if needed
+            if vrf_name not in self.vrf_sn_detach_map:
+                self.vrf_sn_detach_map[vrf_name] = set()
+
+            # Get ALL switches from have_attach, regardless of isAttached state
+            # This ensures undeploy happens for all attachment states
+            have_entry = self.have_attach_by_name.get(vrf_name)
+            if have_entry:
+                for attach in have_entry.get("lanAttachList", []):
+                    serial = attach.get("serialNumber")
+                    if serial:
+                        # Add ALL switches, regardless of isAttached state
+                        # This fixes the bug where pending/failed switches were excluded
+                        self.vrf_sn_detach_map[vrf_name].add(serial)
+
+                        msg = f"Added serial {serial} to vrf_sn_detach_map[{vrf_name}] from have_attach for undeploy (all states)"
+                        self.log.debug(msg)
+
+        msg = "Final vrf_sn_attach_map: "
+        msg += f"{json.dumps({k: list(v) for k, v in self.vrf_sn_attach_map.items()}, indent=4)}"
+        self.log.debug(msg)
+
+        msg = "Final vrf_sn_detach_map: "
+        msg += f"{json.dumps({k: list(v) for k, v in self.vrf_sn_detach_map.items()}, indent=4)}"
+        self.log.debug(msg)
+
     def diff_for_create(self, want, have):
         caller = inspect.stack()[1][3]
         method_name = inspect.stack()[0][3]
@@ -2273,7 +2479,6 @@ class DcnmVrf:
         have_create = []
         have_deploy = {}
         chg_deploy = {}
-        vrf_sn_attach_map = self.vrf_sn_attach_map
 
         curr_vrfs = ""
 
@@ -2304,7 +2509,6 @@ class DcnmVrf:
             self.have_attach = []
             self.have_deploy = have_deploy
             self.chg_deploy = chg_deploy
-            self.vrf_sn_attach_map = vrf_sn_attach_map
             return
 
         vrf_attach_objects = dcnm_get_url(
@@ -2420,10 +2624,8 @@ class DcnmVrf:
                 attach_state = bool(attach.get("isLanAttached", False))
                 deploy = attach_state
                 deployed = False
-                if attach_state and (
-                    attach["lanAttachState"] == "OUT-OF-SYNC"
-                    or attach["lanAttachState"] == "PENDING"
-                ):
+                # Check if attachment needs deployment: PENDING or OUT-OF-SYNC means not deployed
+                if attach["lanAttachState"] in ("OUT-OF-SYNC", "PENDING"):
                     deployed = False
                 else:
                     deployed = True
@@ -2432,10 +2634,6 @@ class DcnmVrf:
                     deploy_vrf = attach["vrfName"]
 
                 sn = attach["switchSerialNo"]
-
-                if attach["vrfName"] not in vrf_sn_attach_map:
-                    vrf_sn_attach_map[attach["vrfName"]] = set()
-                vrf_sn_attach_map[attach["vrfName"]].add(sn)
 
                 if attach["lanAttachState"] in ("OUT-OF-SYNC", "PENDING"):
                     change_vrf = attach["vrfName"]
@@ -2555,7 +2753,6 @@ class DcnmVrf:
         self.have_attach_by_name = {a["vrfName"]: a for a in have_attach}
         self.have_deploy = have_deploy
         self.chg_deploy = chg_deploy
-        self.vrf_sn_attach_map = vrf_sn_attach_map
 
         msg = "self.have_create: "
         msg += f"{json.dumps(self.have_create, indent=4)}"
@@ -2586,7 +2783,6 @@ class DcnmVrf:
         want_create = []
         want_attach = []
         want_deploy = {}
-        vrf_sn_attach_map = self.vrf_sn_attach_map
 
         msg = "self.config "
         msg += f"{json.dumps(self.config, indent=4)}"
@@ -2637,9 +2833,6 @@ class DcnmVrf:
                 deploy = vrf_deploy
                 vrf_attach_obj = self.update_attach_params(attach, vrf_name, deploy, vlan_id)
                 vrfs.append(vrf_attach_obj)
-                if vrf_sn_attach_map.get(vrf_name) is None:
-                    vrf_sn_attach_map[vrf_name] = set()
-                vrf_sn_attach_map[vrf_name].add(vrf_attach_obj["serialNumber"])
 
             if vrfs:
                 vrf_attach.update({"vrfName": vrf_name})
@@ -2655,7 +2848,6 @@ class DcnmVrf:
         self.want_create_by_name = {v["vrfName"]: v for v in self.want_create}
         self.want_attach = copy.deepcopy(want_attach)
         self.want_deploy = copy.deepcopy(want_deploy)
-        self.vrf_sn_attach_map = vrf_sn_attach_map
 
         msg = "self.want_create: "
         msg += f"{json.dumps(self.want_create, indent=4)}"
@@ -2722,18 +2914,8 @@ class DcnmVrf:
                     if not have_a:
                         continue
 
-                    # Build detach map inline while processing delete
-                    # Initialize VRF entry in detach map
-                    if vrf_name not in self.vrf_sn_detach_map:
-                        self.vrf_sn_detach_map[vrf_name] = set()
-
                     detach_items = []
                     for item in have_a["lanAttachList"]:
-                        # Add serial to detach map for all attachments (needed for undeploy)
-                        serial = item.get("serialNumber")
-                        if serial:
-                            self.vrf_sn_detach_map[vrf_name].add(serial)
-
                         # Only add to diff_detach if actually attached
                         if "isAttached" in item:
                             if item["isAttached"]:
@@ -2756,18 +2938,8 @@ class DcnmVrf:
                     vrf_name = have_a["vrfName"]
                     diff_delete.update({vrf_name: "DEPLOYED"})
 
-                    # Build detach map inline while processing delete
-                    # Initialize VRF entry in detach map
-                    if vrf_name not in self.vrf_sn_detach_map:
-                        self.vrf_sn_detach_map[vrf_name] = set()
-
                     detach_items = []
                     for item in have_a["lanAttachList"]:
-                        # Add serial to detach map for all attachments (needed for undeploy)
-                        serial = item.get("serialNumber")
-                        if serial:
-                            self.vrf_sn_detach_map[vrf_name].add(serial)
-
                         # Only add to diff_detach if actually attached
                         if "isAttached" in item:
                             if item["isAttached"]:
@@ -2829,17 +3001,7 @@ class DcnmVrf:
                 vrf_name = have_a["vrfName"]
 
                 if self.action_fabric_type != "multisite_child" and self.action_fabric_type != "multicluster_child":
-                    # Build detach map inline for VRFs being deleted in override
-                    # Initialize VRF entry in detach map
-                    if vrf_name not in self.vrf_sn_detach_map:
-                        self.vrf_sn_detach_map[vrf_name] = set()
-
                     for item in have_a["lanAttachList"]:
-                        # Add serial to detach map for all attachments (needed for undeploy)
-                        serial = item.get("serialNumber")
-                        if serial:
-                            self.vrf_sn_detach_map[vrf_name].add(serial)
-
                         # Only add to diff_detach if actually attached
                         if "isAttached" in item:
                             if item["isAttached"]:
@@ -5355,6 +5517,11 @@ class DcnmVrf:
         msg = "ENTERED. "
         msg += f"caller: {caller}."
         self.log.debug(msg)
+
+        # Populate serial number maps from calculated diffs before any push operations
+        # This ensures maps contain only switches affected by current operation
+        if self.action_fabric_type not in ["multisite_child", "multicluster_child"]:
+            self.populate_sn_maps_from_diffs()
 
         self.push_diff_create_update(is_rollback)
 

--- a/plugins/modules/dcnm_vrf.py
+++ b/plugins/modules/dcnm_vrf.py
@@ -3895,15 +3895,9 @@ class DcnmVrf:
 
             # Build payload based on API type
             if use_bulk:
-                # Bulk API: vrfTemplateConfig as dict, exclude serviceVrfTemplate/source
-                vrf_obj = {
-                    "fabric": vrf["fabric"],
-                    "vrfName": vrf["vrfName"],
-                    "vrfId": vrf["vrfId"],
-                    "vrfTemplate": vrf["vrfTemplate"],
-                    "vrfExtensionTemplate": vrf["vrfExtensionTemplate"],
-                    "vrfTemplateConfig": json_to_dict  # Dict object
-                }
+                # Bulk API: vrfTemplateConfig as dict
+                vrf_obj = vrf.copy()
+                vrf_obj["vrfTemplateConfig"] = json_to_dict
 
                 bulk_payload.append(vrf_obj)
             else:

--- a/plugins/modules/dcnm_vrf.py
+++ b/plugins/modules/dcnm_vrf.py
@@ -1016,9 +1016,16 @@ from ansible_collections.cisco.dcnm.plugins.module_utils.network.dcnm.dcnm impor
 
 from ..module_utils.common.log_v2 import Log
 
+# When the number of VRFs in the playbook config is below this threshold,
+# get_have() uses a targeted GET_VRF_TARGETED fetch (only the named VRFs) instead
+# of a full-fabric GET_VRF sweep.  Above the threshold, one bulk GET_VRF + local
+# filter is cheaper than many individual requests.
+BULK_GET_HAVE_VRF_THRESHOLD = 25
+
 dcnm_vrf_paths = {
     11: {
         "GET_VRF": "/rest/top-down/fabrics/{}/vrfs",
+        "GET_VRF_TARGETED": "/rest/top-down/fabrics/{}/vrfs?vrf-names={}",
         "GET_VRF_ATTACH": "/rest/top-down/fabrics/{}/vrfs/attachments?vrf-names={}",
         "GET_VRF_SWITCH": "/rest/top-down/fabrics/{}/vrfs/switches?vrf-names={}&serial-numbers={}",
         "GET_VRF_ID": "/rest/managed-pool/fabrics/{}/partitions/ids",
@@ -1028,6 +1035,7 @@ dcnm_vrf_paths = {
     12: {
         "GET_VRF_FAB": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{}",
         "GET_VRF": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{}/vrfs",
+        "GET_VRF_TARGETED": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{}/vrfs?vrf-names={}",
         "GET_VRF_BULK": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/bulk-create/vrfs",
         "GET_VRF_ATTACH": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{}/vrfs/attachments?vrf-names={}",
         "GET_VRF_SWITCH": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{}/vrfs/switches?vrf-names={}&serial-numbers={}",
@@ -1082,10 +1090,10 @@ class DcnmVrf:
         self.conf_changed = {}
         self.check_mode = False
         self.have_create = []
-        # OPT-03: O(1) lookup dicts populated by get_have()
+        # O(1) lookup dicts populated by get_have()
         self.have_create_by_name = {}
         self.want_create = []
-        # OPT-03: O(1) lookup dict populated by get_want()
+        # O(1) lookup dict populated by get_want()
         self.want_create_by_name = {}
         self.diff_create = []
         self.diff_create_update = []
@@ -1097,7 +1105,7 @@ class DcnmVrf:
         self.diff_create_quick = []
         self.vrf_sn_attach_map = {}
         self.have_attach = []
-        # OPT-03: O(1) lookup dict populated by get_have()
+        # O(1) lookup dict populated by get_have()
         self.have_attach_by_name = {}
         self.want_attach = []
         self.diff_attach = []
@@ -2155,27 +2163,62 @@ class DcnmVrf:
 
         curr_vrfs = ""
 
-        vrf_objects = self.get_vrf_objects()
-
-        if not vrf_objects.get("DATA"):
-            return
-
-        # OPT-01 / OPT-02: Targeted fetch — when the state is merged, replaced,
-        # or deleted AND the playbook provides an explicit config list, restrict
-        # the attachment query to only the VRFs named in the playbook.  The full-
-        # fabric sweep is preserved for overridden, query, and deleted-without-config.
+        # Hybrid targeted fetch:
+        # - targeted states (merged/replaced/deleted) with config < threshold:
+        #   use GET_VRF_TARGETED to fetch only the requested VRFs, skipping the
+        #   full-fabric GET_VRF call entirely.
+        # - targeted states with config >= threshold:
+        #   full-fabric GET_VRF + local filter (one bulk call is cheaper than many
+        #   individual targeted calls for large config lists).
+        # - non-targeted states (overridden/query/deleted-without-config):
+        #   full-fabric sweep unchanged.
         targeted_states = {"merged", "replaced", "deleted"}
+        wanted_vrf_names = None
+        vrf_data_to_process = None
+
         if self.state in targeted_states and self.config:
             wanted_vrf_names = {vrf.get("vrf_name") for vrf in self.config if vrf.get("vrf_name")}
-            vrf_data_to_process = [v for v in vrf_objects["DATA"] if v["vrfName"] in wanted_vrf_names]
-            msg = (
-                f"Targeted get_have() for state '{self.state}': "
-                f"requesting attachments for {len(vrf_data_to_process)} of "
-                f"{len(vrf_objects['DATA'])} fabric VRFs."
-            )
-            self.log.debug(msg)
-        else:
-            vrf_data_to_process = vrf_objects["DATA"]
+
+            if len(wanted_vrf_names) < BULK_GET_HAVE_VRF_THRESHOLD:
+                # Small config: targeted per-name GET avoids downloading the full fabric payload.
+                targeted_path = self.paths["GET_VRF_TARGETED"].format(
+                    self.fabric, ",".join(sorted(wanted_vrf_names))
+                )
+                msg = (
+                    f"Targeted get_have() for state '{self.state}': "
+                    f"fetching {len(wanted_vrf_names)} VRF(s) by name "
+                    f"(below threshold {BULK_GET_HAVE_VRF_THRESHOLD})."
+                )
+                self.log.debug(msg)
+                vrf_targeted = dcnm_send(self.module, "GET", targeted_path)
+                missing_fabric, not_ok = self.handle_response(vrf_targeted, "query_dcnm")
+                if missing_fabric or not_ok:
+                    msg0 = "caller: get_have. "
+                    msg1 = f"{msg0} Fabric {self.fabric} not present on the controller"
+                    msg2 = f"{msg0} Unable to find vrfs under fabric: {self.fabric}"
+                    self.module.fail_json(msg=msg1 if missing_fabric else msg2)
+                vrf_data_to_process = vrf_targeted.get("DATA") or []
+            # else: large config — fall through to full-fabric get_vrf_objects() below
+
+        if vrf_data_to_process is None:
+            # Large config (>= threshold) or non-targeted state: full fabric sweep.
+            vrf_objects = self.get_vrf_objects()
+
+            if not vrf_objects.get("DATA"):
+                return
+
+            if wanted_vrf_names:
+                # Large config in targeted state: filter the full-fabric response in memory.
+                vrf_data_to_process = [v for v in vrf_objects["DATA"] if v["vrfName"] in wanted_vrf_names]
+                msg = (
+                    f"Targeted get_have() for state '{self.state}': "
+                    f"requesting attachments for {len(vrf_data_to_process)} of "
+                    f"{len(vrf_objects['DATA'])} fabric VRFs "
+                    f"(at/above threshold {BULK_GET_HAVE_VRF_THRESHOLD})."
+                )
+                self.log.debug(msg)
+            else:
+                vrf_data_to_process = vrf_objects["DATA"]
 
         for vrf in vrf_data_to_process:
             curr_vrfs += vrf["vrfName"] + ","
@@ -2279,6 +2322,25 @@ class DcnmVrf:
             attach_list = vrf_attach["lanAttachList"]
             deploy_vrf = ""
             change_vrf = ""
+
+            # Batch GET_VRF_SWITCH: fetch VRF-Lite data for all switches of this VRF
+            # in one API call instead of one call per switch.
+            vrf_name_outer = vrf_attach.get("vrfName") or (
+                attach_list[0]["vrfName"] if attach_list else None
+            )
+            lite_by_sn = {}
+            if vrf_name_outer and self._has_vrf_lite_in_config(vrf_name_outer):
+                all_sns = sorted({a["switchSerialNo"] for a in attach_list})
+                batch_path = self.paths["GET_VRF_SWITCH"].format(
+                    self.fabric, vrf_name_outer, ",".join(all_sns)
+                )
+                bulk_lite = dcnm_send(self.module, "GET", batch_path)
+                for sdl in (bulk_lite.get("DATA") or []):
+                    for epv in sdl.get("switchDetailsList", []):
+                        sn = epv.get("serialNumber")
+                        if sn:
+                            lite_by_sn[sn] = epv
+
             for attach in attach_list:
                 attach_state = bool(attach.get("isLanAttached", False))
                 deploy = attach_state
@@ -2343,63 +2405,59 @@ class DcnmVrf:
                     # No VRF-Lite config for this VRF in the playbook
                     # Skip the expensive API call and set empty extensionValues
                     attach.update({"freeformConfig": ""})
-                    # extensionValues already set to "" at line 1766
                     continue
 
-                # VRF-Lite IS configured, making API call
-                lite_objects = self.get_vrf_lite_objects(attach)
+                # Use pre-fetched VRF-Lite data indexed by serial number.
+                epv = lite_by_sn.get(attach.get("serialNumber"))
 
-                if not lite_objects.get("DATA"):
+                if epv is None:
                     msg = "No VRF Lite extensions found, skipping attachment processing"
                     self.log.debug(msg)
                     attach.update({"freeformConfig": ""})
-                    # extensionValues already set to "" earlier at line 1781
                     continue
 
-                msg = f"lite_objects: {json.dumps(lite_objects, indent=4, sort_keys=True)}"
+                msg = f"epv: {json.dumps(epv, indent=4, sort_keys=True)}"
                 self.log.debug(msg)
 
-                for sdl in lite_objects["DATA"]:
-                    for epv in sdl["switchDetailsList"]:
-                        if not epv.get("extensionValues"):
-                            attach.update({"freeformConfig": ""})
-                            continue
-                        ext_values = ast.literal_eval(epv["extensionValues"])
-                        if ext_values.get("VRF_LITE_CONN") is None:
-                            continue
-                        ext_values = ast.literal_eval(ext_values["VRF_LITE_CONN"])
-                        extension_values = {}
-                        extension_values["VRF_LITE_CONN"] = []
+                if not epv.get("extensionValues"):
+                    attach.update({"freeformConfig": ""})
+                    continue
+                ext_values = ast.literal_eval(epv["extensionValues"])
+                if ext_values.get("VRF_LITE_CONN") is None:
+                    continue
+                ext_values = ast.literal_eval(ext_values["VRF_LITE_CONN"])
+                extension_values = {}
+                extension_values["VRF_LITE_CONN"] = []
 
-                        for ev in ext_values.get("VRF_LITE_CONN"):
-                            ev_dict = copy.deepcopy(ev)
-                            ev_dict.update({"AUTO_VRF_LITE_FLAG": "false"})
-                            ev_dict.update(
-                                {"VRF_LITE_JYTHON_TEMPLATE": "Ext_VRF_Lite_Jython"}
-                            )
+                for ev in ext_values.get("VRF_LITE_CONN"):
+                    ev_dict = copy.deepcopy(ev)
+                    ev_dict.update({"AUTO_VRF_LITE_FLAG": "false"})
+                    ev_dict.update(
+                        {"VRF_LITE_JYTHON_TEMPLATE": "Ext_VRF_Lite_Jython"}
+                    )
 
-                            if extension_values["VRF_LITE_CONN"]:
-                                extension_values["VRF_LITE_CONN"][
-                                    "VRF_LITE_CONN"
-                                ].extend([ev_dict])
-                            else:
-                                extension_values["VRF_LITE_CONN"] = {
-                                    "VRF_LITE_CONN": [ev_dict]
-                                }
+                    if extension_values["VRF_LITE_CONN"]:
+                        extension_values["VRF_LITE_CONN"][
+                            "VRF_LITE_CONN"
+                        ].extend([ev_dict])
+                    else:
+                        extension_values["VRF_LITE_CONN"] = {
+                            "VRF_LITE_CONN": [ev_dict]
+                        }
 
-                        extension_values["VRF_LITE_CONN"] = json.dumps(
-                            extension_values["VRF_LITE_CONN"]
-                        )
+                extension_values["VRF_LITE_CONN"] = json.dumps(
+                    extension_values["VRF_LITE_CONN"]
+                )
 
-                        ms_con = {}
-                        ms_con["MULTISITE_CONN"] = []
-                        extension_values["MULTISITE_CONN"] = json.dumps(ms_con)
-                        e_values = json.dumps(extension_values).replace(" ", "")
+                ms_con = {}
+                ms_con["MULTISITE_CONN"] = []
+                extension_values["MULTISITE_CONN"] = json.dumps(ms_con)
+                e_values = json.dumps(extension_values).replace(" ", "")
 
-                        attach.update({"extensionValues": e_values})
+                attach.update({"extensionValues": e_values})
 
-                        ff_config = epv.get("freeformConfig", "")
-                        attach.update({"freeformConfig": ff_config})
+                ff_config = epv.get("freeformConfig", "")
+                attach.update({"freeformConfig": ff_config})
 
             if deploy_vrf:
                 upd_vrfs += deploy_vrf + ","
@@ -2417,7 +2475,7 @@ class DcnmVrf:
 
         self.have_create = have_create
         self.have_attach = have_attach
-        # OPT-03: Build O(1) lookup dicts for use in diff methods.
+        # Build O(1) lookup dicts for use in diff methods.
         self.have_create_by_name = {v["vrfName"]: v for v in have_create}
         self.have_attach_by_name = {a["vrfName"]: a for a in have_attach}
         self.have_deploy = have_deploy
@@ -2518,7 +2576,7 @@ class DcnmVrf:
             want_deploy.update({"vrfNames": vrf_names})
 
         self.want_create = copy.deepcopy(want_create)
-        # OPT-03: O(1) lookup dict for want_create
+        # O(1) lookup dict for want_create
         self.want_create_by_name = {v["vrfName"]: v for v in self.want_create}
         self.want_attach = copy.deepcopy(want_attach)
         self.want_deploy = copy.deepcopy(want_deploy)
@@ -2582,14 +2640,14 @@ class DcnmVrf:
 
             for want_c in self.want_create:
 
-                # OPT-03: O(1) lookup instead of find_dict_in_list_by_key_value
+                # O(1) lookup instead of find_dict_in_list_by_key_value
                 if want_c["vrfName"] not in self.have_create_by_name:
                     continue
 
                 diff_delete.update({want_c["vrfName"]: "DEPLOYED"})
 
                 if self.action_fabric_type != "multisite_child" and self.action_fabric_type != "multicluster_child":
-                    # OPT-03: O(1) lookup instead of find_dict_in_list_by_key_value
+                    # O(1) lookup instead of find_dict_in_list_by_key_value
                     have_a = self.have_attach_by_name.get(want_c["vrfName"])
 
                     if not have_a:
@@ -2602,7 +2660,7 @@ class DcnmVrf:
                         all_vrfs.append(have_a["vrfName"])
 
             if len(all_vrfs) != 0 and self.action_fabric_type != "multisite_child" and self.action_fabric_type != "multicluster_child":
-                # OPT-09: deduplicate before joining
+                # deduplicate before joining
                 diff_undeploy.update({"vrfNames": ",".join(sorted(set(all_vrfs)))})
 
         else:
@@ -2616,7 +2674,7 @@ class DcnmVrf:
 
                     diff_delete.update({have_a["vrfName"]: "DEPLOYED"})
                 if len(all_vrfs) != 0:
-                    # OPT-09: deduplicate before joining
+                    # deduplicate before joining
                     diff_undeploy.update({"vrfNames": ",".join(sorted(set(all_vrfs)))})
 
         self.diff_detach = diff_detach
@@ -2651,7 +2709,7 @@ class DcnmVrf:
         diff_undeploy = self.diff_undeploy
 
         for have_a in self.have_attach:
-            # OPT-03: O(1) lookup instead of find_dict_in_list_by_key_value
+            # O(1) lookup instead of find_dict_in_list_by_key_value
             found = self.want_create_by_name.get(have_a["vrfName"])
 
             detach_list = []
@@ -2672,7 +2730,7 @@ class DcnmVrf:
                 diff_delete.update({have_a["vrfName"]: "DEPLOYED"})
 
         if len(all_vrfs) != 0 and self.action_fabric_type != "multisite_child" and self.action_fabric_type != "multicluster_child":
-            # OPT-09: deduplicate before joining
+            # deduplicate before joining
             diff_undeploy.update({"vrfNames": ",".join(sorted(set(all_vrfs)))})
 
         self.diff_delete = diff_delete
@@ -2732,7 +2790,7 @@ class DcnmVrf:
                     break
 
             if not h_in_w:
-                # OPT-03: O(1) lookup instead of find_dict_in_list_by_key_value
+                # O(1) lookup instead of find_dict_in_list_by_key_value
                 found = self.want_create_by_name.get(have_a["vrfName"])
 
                 if found:
@@ -2869,7 +2927,7 @@ class DcnmVrf:
         payload_list = []
 
         for want_c in self.want_create:
-            # OPT-03: O(1) lookup instead of inner for-loop over self.have_create
+            # O(1) lookup instead of inner for-loop over self.have_create
             have_c = self.have_create_by_name.get(want_c["vrfName"])
             if have_c is not None:
                 vrf_found = True
@@ -3064,7 +3122,7 @@ class DcnmVrf:
                 continue
             deploy_vrf = ""
             attach_found = False
-            # OPT-03: O(1) lookup instead of inner for-loop over self.have_attach
+            # O(1) lookup instead of inner for-loop over self.have_attach
             have_a = self.have_attach_by_name.get(want_a["vrfName"])
             if have_a is not None:
                 attach_found = True
@@ -3408,7 +3466,7 @@ class DcnmVrf:
         if self.config:
             query = []
 
-            # OPT-04: Single bulk GET_VRF_ATTACH instead of one call per VRF.
+            # Single bulk GET_VRF_ATTACH instead of one call per VRF.
             # Build a name→vrf_object dict for O(1) lookup and collect the VRF
             # names that are both wanted and present on the controller.
             vrf_objs_by_name = {v["vrfName"]: v for v in vrf_objects["DATA"]}
@@ -3455,6 +3513,27 @@ class DcnmVrf:
 
                 vrf_attach_records = attach_by_vrf.get(want_c["vrfName"], [])
 
+                # Batch GET_VRF_SWITCH: fetch VRF-Lite data for all switches of
+                # this VRF in one API call instead of one call per switch.
+                lite_by_sn = {}
+                if self._has_vrf_lite_in_config(want_c["vrfName"]):
+                    all_sns = sorted({
+                        a["switchSerialNo"]
+                        for va in vrf_attach_records
+                        if va.get("lanAttachList")
+                        for a in va["lanAttachList"]
+                    })
+                    if all_sns:
+                        batch_path = self.paths["GET_VRF_SWITCH"].format(
+                            self.fabric, want_c["vrfName"], ",".join(all_sns)
+                        )
+                        bulk_lite = dcnm_send(self.module, "GET", batch_path)
+                        for sdl in (bulk_lite.get("DATA") or []):
+                            for epv in sdl.get("switchDetailsList", []):
+                                sn = epv.get("serialNumber")
+                                if sn:
+                                    lite_by_sn[sn] = (sdl, epv)
+
                 for vrf_attach in vrf_attach_records:
                     if not vrf_attach.get("lanAttachList"):
                         continue
@@ -3473,31 +3552,29 @@ class DcnmVrf:
                         # in the playbook to avoid expensive API calls
                         use_minimal_attach = True
                         if self._has_vrf_lite_in_config(want_c["vrfName"]):
-                            lite_objects = self.get_vrf_lite_objects(
-                                attach_copy
-                            )
-                            # Check if DATA exists and is not empty
-                            has_lite_data = (
-                                lite_objects.get("DATA") is not None
-                                and len(lite_objects.get("DATA", [])) > 0
-                            )
-                            if has_lite_data:
-                                # VRF Lite extensions exist - use API response but ensure vlan field is correct
+                            sn = attach["switchSerialNo"]
+                            if sn in lite_by_sn:
+                                sdl_data, epv = lite_by_sn[sn]
+                                # Reconstruct a per-switch lite_attach from the pre-fetched
+                                # batch data so each attach entry has exactly one switch.
                                 use_minimal_attach = False
-                                lite_attach = lite_objects.get("DATA")[0]
-                                # The vlan field should be the VRF's L3VNI vlan, not the dot1q
+                                lite_attach = {
+                                    "vrfName": sdl_data.get("vrfName", want_c["vrfName"]),
+                                    "templateName": sdl_data.get("templateName", ""),
+                                    "switchDetailsList": [epv],
+                                }
+                                # Ensure vlan reflects the VRF's L3VNI vlan, not the dot1q.
                                 vlan_id = attach.get("vlanId")
                                 vlan_str = str(vlan_id) if vlan_id is not None else ""
                                 msg = f"Fixing vlan field in VRF lite attach for switch {attach['switchSerialNo']}: "
                                 msg += f"vlanId={vlan_id}, setting vlan={vlan_str}"
                                 self.log.debug(msg)
-                                # Update vlan in all switchDetailsList entries
                                 if lite_attach.get("switchDetailsList"):
                                     for switch_detail in lite_attach["switchDetailsList"]:
                                         switch_detail["vlan"] = vlan_str
                                 item["attach"].append(lite_attach)
                             else:
-                                # No VRF Lite extensions found - will use minimal attach
+                                # Switch not returned by batch call — no VRF-Lite data.
                                 msg = f"No VRF Lite extensions found for switch {attach['switchSerialNo']}"
                                 self.log.debug(msg)
 
@@ -3519,7 +3596,7 @@ class DcnmVrf:
         else:
             query = []
 
-            # OPT-05: Single bulk GET_VRF_ATTACH for all fabric VRFs instead of
+            # Single bulk GET_VRF_ATTACH for all fabric VRFs instead of
             # one API call per VRF in the loop.
             all_vrf_names = ",".join(v["vrfName"] for v in vrf_objects["DATA"])
             bulk_path = self.paths["GET_VRF_ATTACH"].format(
@@ -3553,6 +3630,26 @@ class DcnmVrf:
 
                 vrf_attach_records = attach_by_vrf.get(vrf["vrfName"], [])
 
+                # Batch GET_VRF_SWITCH: fetch VRF-Lite data for all switches of
+                # this VRF in one API call instead of one call per switch.
+                all_sns = sorted({
+                    a["switchSerialNo"]
+                    for va in vrf_attach_records
+                    if va.get("lanAttachList")
+                    for a in va["lanAttachList"]
+                })
+                lite_by_sn = {}
+                if all_sns:
+                    batch_path = self.paths["GET_VRF_SWITCH"].format(
+                        self.fabric, vrf["vrfName"], ",".join(all_sns)
+                    )
+                    bulk_lite = dcnm_send(self.module, "GET", batch_path)
+                    for sdl in (bulk_lite.get("DATA") or []):
+                        for epv in sdl.get("switchDetailsList", []):
+                            sn = epv.get("serialNumber")
+                            if sn:
+                                lite_by_sn[sn] = (sdl, epv)
+
                 for vrf_attach in vrf_attach_records:
                     if not vrf_attach.get("lanAttachList"):
                         continue
@@ -3565,21 +3662,28 @@ class DcnmVrf:
                         attach_copy.update({"fabric": self.fabric})
                         attach_copy.update({"serialNumber": attach["switchSerialNo"]})
 
-                        # Note: When querying without specific config (else branch),
-                        # we always call get_vrf_lite_objects() to provide complete
-                        # information in the query response, as the user expects to see
-                        # all VRF configuration including any VRF-Lite extensions present
-                        # on the controller.
-                        lite_objects = self.get_vrf_lite_objects(attach_copy)
-
-                        # Check if DATA exists and is not empty
-                        has_lite_data = (
-                            lite_objects.get("DATA") is not None
-                            and len(lite_objects.get("DATA", [])) > 0
-                        )
-                        if not has_lite_data:
-                            # No VRF Lite extensions exist - use minimal attach structure
-                            # Ensure extensionValues is set to empty string when no VRF Lite
+                        # When querying without specific config (else branch),
+                        # provide complete information for all VRF-Lite extensions.
+                        sn = attach["switchSerialNo"]
+                        if sn in lite_by_sn:
+                            sdl_data, epv = lite_by_sn[sn]
+                            # Reconstruct per-switch lite_attach from batch data.
+                            lite_attach = {
+                                "vrfName": sdl_data.get("vrfName", vrf["vrfName"]),
+                                "templateName": sdl_data.get("templateName", ""),
+                                "switchDetailsList": [epv],
+                            }
+                            vlan_id = attach.get("vlanId")
+                            vlan_str = str(vlan_id) if vlan_id is not None else ""
+                            msg = f"Fixing vlan field in VRF lite attach for switch {attach['switchSerialNo']}: "
+                            msg += f"vlanId={vlan_id}, setting vlan={vlan_str}"
+                            self.log.debug(msg)
+                            if lite_attach.get("switchDetailsList"):
+                                for switch_detail in lite_attach["switchDetailsList"]:
+                                    switch_detail["vlan"] = vlan_str
+                            item["attach"].append(lite_attach)
+                        else:
+                            # No VRF Lite extensions — use minimal attach structure.
                             attach["extensionValues"] = ""
                             minimal_attach = {
                                 "fabric": self.fabric,
@@ -3588,20 +3692,6 @@ class DcnmVrf:
                                 "switchDetailsList": [attach]
                             }
                             item["attach"].append(minimal_attach)
-                        else:
-                            # VRF Lite extensions exist - use API response but ensure vlan field is correct
-                            lite_attach = lite_objects.get("DATA")[0]
-                            # The vlan field should be the VRF's L3VNI vlan, not the dot1q
-                            vlan_id = attach.get("vlanId")
-                            vlan_str = str(vlan_id) if vlan_id is not None else ""
-                            msg = f"Fixing vlan field in VRF lite attach for switch {attach['switchSerialNo']}: "
-                            msg += f"vlanId={vlan_id}, setting vlan={vlan_str}"
-                            self.log.debug(msg)
-                            # Update vlan in all switchDetailsList entries
-                            if lite_attach.get("switchDetailsList"):
-                                for switch_detail in lite_attach["switchDetailsList"]:
-                                    switch_detail["vlan"] = vlan_str
-                            item["attach"].append(lite_attach)
                 query.append(item)
 
         self.query = query
@@ -4912,7 +5002,7 @@ class DcnmVrf:
             path = self.paths["GET_VRF_ATTACH"].format(self.fabric, vrf)
             retry_count = max(500 // self.WAIT_TIME_FOR_DELETE_LOOP, 1)
 
-            # OPT-06: Initial quick-scan pass — check if VRF is already in a
+            # Initial quick-scan pass — check if VRF is already in a
             # terminal state before entering the polling while-loop.
             resp = dcnm_send(self.module, "GET", path)
             if resp.get("DATA") is not None:
@@ -5477,7 +5567,7 @@ class DcnmVrf:
         # to the have state whenever there is a failure in any of the APIs.
         # The idea would be to run overridden state with want=have and have=dcnm_state
         self.want_create = self.have_create
-        # OPT-03: rebuild lookup dict to match reassigned want_create
+        # rebuild lookup dict to match reassigned want_create
         self.want_create_by_name = {v["vrfName"]: v for v in self.want_create}
         self.want_attach = self.have_attach
         self.want_deploy = self.have_deploy
@@ -5485,7 +5575,7 @@ class DcnmVrf:
         self.have_create = []
         self.have_attach = []
         self.have_deploy = {}
-        # OPT-03: reset have lookup dicts; get_have() will rebuild them
+        # reset have lookup dicts; get_have() will rebuild them
         self.have_create_by_name = {}
         self.have_attach_by_name = {}
         self.get_have()

--- a/plugins/modules/dcnm_vrf.py
+++ b/plugins/modules/dcnm_vrf.py
@@ -3540,14 +3540,6 @@ class DcnmVrf:
                     attach_list = vrf_attach["lanAttachList"]
 
                     for attach in attach_list:
-                        # copy attach and update it with the keys that
-                        # get_vrf_lite_objects() expects.
-                        attach_copy = copy.deepcopy(attach)
-                        attach_copy.update({"fabric": self.fabric})
-                        attach_copy.update(
-                            {"serialNumber": attach["switchSerialNo"]}
-                        )
-
                         # Only call get_vrf_lite_objects() if VRF-Lite is configured
                         # in the playbook to avoid expensive API calls
                         use_minimal_attach = True
@@ -3656,12 +3648,6 @@ class DcnmVrf:
                     attach_list = vrf_attach["lanAttachList"]
 
                     for attach in attach_list:
-                        # copy attach and update it with the keys that
-                        # get_vrf_lite_objects() expects.
-                        attach_copy = copy.deepcopy(attach)
-                        attach_copy.update({"fabric": self.fabric})
-                        attach_copy.update({"serialNumber": attach["switchSerialNo"]})
-
                         # When querying without specific config (else branch),
                         # provide complete information for all VRF-Lite extensions.
                         sn = attach["switchSerialNo"]

--- a/plugins/modules/dcnm_vrf.py
+++ b/plugins/modules/dcnm_vrf.py
@@ -6077,7 +6077,7 @@ class DcnmVrf:
 
         # Responses to all other operations POST and PUT are handled here.
         # Accept both 200 (OK) and 207 (Multi-Status) for bulk operations
-        if res.get("MESSAGE") != "OK" or res["RETURN_CODE"] not in [200, 207]:
+        if res.get("MESSAGE") not in ["OK", "Multi-Status"] or res["RETURN_CODE"] not in [200, 207]:
             fail = True
             changed = False
             return fail, changed

--- a/plugins/modules/dcnm_vrf.py
+++ b/plugins/modules/dcnm_vrf.py
@@ -5232,7 +5232,6 @@ class DcnmVrf:
         msg += f"vrf_count: {vrf_count}, base_timeout: {base_timeout}s, retry_count: {retry_count}"
         self.log.debug(msg)
 
-
         while pending_vrfs and retry_count > 0:
             retry_count -= 1
 

--- a/plugins/modules/dcnm_vrf.py
+++ b/plugins/modules/dcnm_vrf.py
@@ -1912,8 +1912,10 @@ class DcnmVrf:
         # vlan_id_want drives the conditional below, so we cannot
         # remove it here (as we did with the other params that are
         # compared in the call to self.dict_values_differ())
+        vlan_id_have = str(json_to_dict_have.get("vrfVlanId", ""))
         vlan_id_want = str(json_to_dict_want.get("vrfVlanId", ""))
         vrfSegmentId_want = json_to_dict_want.get("vrfSegmentId")
+        enable_l3vni_no_vlan = json_to_dict_want.get("enableL3VniNoVlan", False)
 
         skip_keys = []
         if vlan_id_want == "0" or vlan_id_want == "":
@@ -1923,16 +1925,10 @@ class DcnmVrf:
 
         # BGP password/key type special handling
         bgp_password_want = json_to_dict_want.get("bgpPassword")
-        bgp_password_have = json_to_dict_have.get("bgpPassword")
-        bgp_key_type_have = json_to_dict_have.get("bgpPasswordKeyType")
-        bgp_key_type_want = json_to_dict_want.get("bgpPasswordKeyType")
 
-        # Some ND versions give empty bgpPasswordKeyType. Skip comparison if:
-        # 1. Have keytype is empty/None (ND has no password configured)
-        # 2. Both passwords are empty (no password in want or have)
-        if ((bgp_key_type_have == "" and bgp_key_type_want == 3 and
-             bgp_password_want != "") or (bgp_password_want == ""
-                                          and bgp_password_have == "")):
+        # Skip bgpPasswordKeyType comparison when want has no password —
+        # key type is irrelevant regardless of have values.
+        if bgp_password_want == "":
             skip_keys.append("bgpPasswordKeyType")
 
         template_skip_keys = self.get_template_skip_keys()
@@ -1960,6 +1956,13 @@ class DcnmVrf:
                 # vrfId from the instance of the same vrf on DCNM.
                 want["vrfId"] = have["vrfId"]
             if skip_keys:
+                if "vrfVlanId" in skip_keys:
+                    if ((enable_l3vni_no_vlan) or
+                            (vlan_id_want == "0" and vlan_id_have == "")):
+                        # When enableL3VniNoVlan is True, vrfVlanId is not
+                        # applicable, additionally, if vlan_id_want is "0" and
+                        # vlan_id_have is "", vlan id should not be copied from want.
+                        skip_keys.remove("vrfVlanId")
                 for key in skip_keys:
                     if key in json_to_dict_have:
                         json_to_dict_want[key] = json_to_dict_have[key]
@@ -3209,9 +3212,17 @@ class DcnmVrf:
             self.log.debug(msg)
             return
 
+        # Build the set of VRFs already queued for deploy (added by
+        # diff_merge_attach) to prevent adding the same VRF twice.
+        already_deploying = set()
+        if self.diff_deploy:
+            already_deploying = set(self.diff_deploy["vrfNames"].split(","))
+
         for vrf_name in self.want_deploy["vrfNames"].split(","):
             msg = f"VRF Name : {vrf_name}"
             self.log.debug(msg)
+            if vrf_name in already_deploying:
+                continue
             if not self.diff_attach and vrf_name in self.chg_deploy["vrfNames"].split(","):
                 want_vrf_data = find_dict_in_list_by_key_value(search=self.config, key="vrf_name", value=vrf_name)
                 if want_vrf_data.get("deploy", True) is True:
@@ -5600,6 +5611,7 @@ def main():
     # Logging setup
     try:
         log = Log()
+        log.config = "/Users/achengam/Documents/Ansible_Dev/NAC_Performance/ansible_collections/cisco/dcnm/plugins/modules/ansible_cisco_log_r.json"
         log.commit()
     except (TypeError, ValueError):
         pass

--- a/plugins/modules/dcnm_vrf.py
+++ b/plugins/modules/dcnm_vrf.py
@@ -1036,7 +1036,8 @@ dcnm_vrf_paths = {
         "GET_VRF_SWITCH": "/rest/top-down/fabrics/{}/vrfs/switches?vrf-names={}&serial-numbers={}",
         "GET_VRF_ID": "/rest/managed-pool/fabrics/{}/partitions/ids",
         "GET_VLAN": "/rest/resource-manager/vlan/{}?vlanUsageType=TOP_DOWN_VRF_VLAN",
-        "GET_NET_VRF": "/rest/resource-manager/fabrics/{}/networks?vrf-name={}"
+        "GET_NET_VRF": "/rest/resource-manager/fabrics/{}/networks?vrf-name={}",
+        "GET_VRF_SWITCH_CONFIG_DEPLOY": "/rest/control/fabrics/{}/config-deploy/{}?forceShowRun=false",
     },
     12: {
         "GET_VRF_FAB": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{}",
@@ -1047,6 +1048,7 @@ dcnm_vrf_paths = {
         "GET_VRF_ID": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{}/vrfinfo",
         "GET_VLAN": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/resource-manager/vlan/{}?vlanUsageType=TOP_DOWN_VRF_VLAN",
         "GET_NET_VRF": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{}/networks?vrf-name={}",
+        "GET_VRF_SWITCH_CONFIG_DEPLOY": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{}/config-deploy/{}?forceShowRun=false",
         "RESERVE_ID": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/resource-manager/reserve-id",
     },
 }
@@ -1109,6 +1111,9 @@ class DcnmVrf:
         # "check_mode" and to print diffs[] in the output of each task.
         self.diff_create_quick = []
         self.vrf_sn_attach_map = {}
+        # Centralized map tracking VRF-to-serial detachments for undeploy operations
+        # Format: {vrf_name: set(serial_numbers)}
+        self.vrf_sn_detach_map = {}
         self.have_attach = []
         # O(1) lookup dict populated by get_have()
         self.have_attach_by_name = {}
@@ -1200,7 +1205,10 @@ class DcnmVrf:
             if self.dcnm_version >= 12.2:
                 proxy = "/onemanage"
             for path in self.paths:
-                self.paths[path] = proxy + self.paths[path].replace("lan-fabric/rest", "onemanage")
+                if path == "GET_VRF_SWITCH_CONFIG_DEPLOY":
+                    self.paths[path] = proxy + self.paths[path.replace("lan-fabric/rest/control", "onemanage")]
+                else:
+                    self.paths[path] = proxy + self.paths[path].replace("lan-fabric/rest", "onemanage")
             # onepath proxy paths
             if self.dcnm_version >= 12.4:
                 proxy = "/fedproxy/"
@@ -1898,6 +1906,130 @@ class DcnmVrf:
         self.log.debug(msg)
         return False
 
+    def update_vrf_sn_detach_map(self):
+        """
+        Build/update centralized map of VRF-to-serial detachments.
+
+        Called after diff_detach is populated to create a single source of truth
+        for VRF detachment mappings during undeploy operations. Uses set() for
+        automatic deduplication.
+
+        Map format: {vrf_name: set(serial_numbers)}
+        """
+        caller = inspect.stack()[1][3]
+
+        msg = "ENTERED. "
+        msg += f"caller: {caller}."
+        self.log.debug(msg)
+
+        self.vrf_sn_detach_map.clear()
+
+        for vrf_detach in self.diff_detach:
+            vrf_name = vrf_detach.get("vrfName")
+            if not vrf_name:
+                continue
+
+            if vrf_name not in self.vrf_sn_detach_map:
+                self.vrf_sn_detach_map[vrf_name] = set()
+
+            for detach in vrf_detach.get("lanAttachList", []):
+                serial = detach.get("serialNumber")
+                if serial:
+                    self.vrf_sn_detach_map[vrf_name].add(serial)
+
+        msg = "self.vrf_sn_detach_map: "
+        msg += f"{json.dumps({k: list(v) for k, v in self.vrf_sn_detach_map.items()}, indent=4)}"
+        self.log.debug(msg)
+
+    def get_deploy_switch_serials(self, vrf_names=None, is_undeploy=False):
+        """
+        Return ordered, unique switch serials affected by VRF deployments or undeployments.
+        
+        Uses centralized vrf_sn_attach_map for deploy operations and
+        vrf_sn_detach_map for undeploy operations. The is_undeploy parameter
+        explicitly controls which map to use.
+        
+        Args:
+            vrf_names: Can be dict with "vrfNames" key, string (comma-separated),
+                      or list of VRF names
+            is_undeploy: If True, reads from vrf_sn_detach_map (undeploy operations).
+                        If False (default), reads from vrf_sn_attach_map (deploy operations).
+        
+        Returns:
+            list: Ordered list of unique serial numbers
+        """
+
+        if isinstance(vrf_names, dict):
+            vrf_names = vrf_names.get("vrfNames")
+
+        wanted_vrfs = None
+        if vrf_names:
+            if isinstance(vrf_names, str):
+                wanted_vrfs = set(
+                    name.strip() for name in vrf_names.split(",") if name.strip()
+                )
+            else:
+                wanted_vrfs = set(vrf_names)
+
+        # Select the appropriate map based on operation type
+        serial_map = self.vrf_sn_detach_map if is_undeploy else self.vrf_sn_attach_map
+        
+        map_type = "detach" if is_undeploy else "attach"
+        msg = f"Using vrf_sn_{map_type}_map for serial lookup."
+        self.log.debug(msg)
+
+        serials = []
+        seen = set()
+        
+        # Iterate through all VRFs in the selected map
+        for vrf_name, serial_set in serial_map.items():
+            if wanted_vrfs and vrf_name not in wanted_vrfs:
+                continue
+            
+            for serial in serial_set:
+                if serial not in seen:
+                    seen.add(serial)
+                    serials.append(serial)
+
+        return serials
+
+    def deploy_vrf_switches(self, vrf_names=None, is_rollback=False, is_undeploy=False):
+        """
+        Trigger switch-level config deploy for switches affected by VRF operations.
+        
+        Uses VRF attachment/detachment data to determine affected switches.
+        Works for both deploy and undeploy operations.
+        Handles response internally and updates self.result.
+        
+        Args:
+            vrf_names: VRFs to deploy/undeploy
+            is_rollback: Whether this is a rollback operation
+            is_undeploy: If True, uses detach map for undeploy. If False, uses attach map for deploy.
+        """
+
+        serials = self.get_deploy_switch_serials(vrf_names, is_undeploy=is_undeploy)
+        if not serials:
+            msg = "No switch serials found for config deploy."
+            self.log.debug(msg)
+            return
+
+        method = "POST"
+        deploy_path = self.paths["GET_VRF_SWITCH_CONFIG_DEPLOY"].format(
+            self.fabric,
+            ",".join(serials)
+        )
+
+        resp = dcnm_send(self.module, method, deploy_path)
+        
+        if resp is not None:
+            self.result["response"].append(resp)
+            fail, self.result["changed"] = self.handle_response(resp, "deploy")
+            if fail:
+                if is_rollback:
+                    self.failed_to_rollback = True
+                    return
+                self.failure(resp)
+
     def diff_for_create(self, want, have):
         caller = inspect.stack()[1][3]
         method_name = inspect.stack()[0][3]
@@ -2589,22 +2721,15 @@ class DcnmVrf:
         msg += f"caller: {caller}. "
         self.log.debug(msg)
 
-        @staticmethod
-        def get_items_to_detach(attach_list):
-            detach_list = []
-            for item in attach_list:
-                if "isAttached" in item:
-                    if item["isAttached"]:
-                        del item["isAttached"]
-                        item.update({"deployment": False})
-                        detach_list.append(item)
-            return detach_list
-
         diff_detach = []
         diff_undeploy = {}
         diff_delete = {}
 
         all_vrfs = []
+
+        # Clear detach map at start of delete processing
+        if self.action_fabric_type != "multisite_child" and self.action_fabric_type != "multicluster_child":
+            self.vrf_sn_detach_map.clear()
 
         if self.config:
 
@@ -2614,16 +2739,35 @@ class DcnmVrf:
                 if want_c["vrfName"] not in self.have_create_by_name:
                     continue
 
-                diff_delete.update({want_c["vrfName"]: "DEPLOYED"})
+                vrf_name = want_c["vrfName"]
+                diff_delete.update({vrf_name: "DEPLOYED"})
 
                 if self.action_fabric_type != "multisite_child" and self.action_fabric_type != "multicluster_child":
                     # O(1) lookup instead of find_dict_in_list_by_key_value
-                    have_a = self.have_attach_by_name.get(want_c["vrfName"])
+                    have_a = self.have_attach_by_name.get(vrf_name)
 
                     if not have_a:
                         continue
 
-                    detach_items = get_items_to_detach(have_a["lanAttachList"])
+                    # Build detach map inline while processing delete
+                    # Initialize VRF entry in detach map
+                    if vrf_name not in self.vrf_sn_detach_map:
+                        self.vrf_sn_detach_map[vrf_name] = set()
+
+                    detach_items = []
+                    for item in have_a["lanAttachList"]:
+                        # Add serial to detach map for all attachments (needed for undeploy)
+                        serial = item.get("serialNumber")
+                        if serial:
+                            self.vrf_sn_detach_map[vrf_name].add(serial)
+
+                        # Only add to diff_detach if actually attached
+                        if "isAttached" in item:
+                            if item["isAttached"]:
+                                del item["isAttached"]
+                                item.update({"deployment": False})
+                                detach_items.append(item)
+
                     if detach_items:
                         have_a.update({"lanAttachList": detach_items})
                         diff_detach.append(have_a)
@@ -2636,13 +2780,33 @@ class DcnmVrf:
         else:
             if self.action_fabric_type != "multisite_child" and self.action_fabric_type != "multicluster_child":
                 for have_a in self.have_attach:
-                    detach_items = get_items_to_detach(have_a["lanAttachList"])
+                    vrf_name = have_a["vrfName"]
+                    diff_delete.update({vrf_name: "DEPLOYED"})
+
+                    # Build detach map inline while processing delete
+                    # Initialize VRF entry in detach map
+                    if vrf_name not in self.vrf_sn_detach_map:
+                        self.vrf_sn_detach_map[vrf_name] = set()
+
+                    detach_items = []
+                    for item in have_a["lanAttachList"]:
+                        # Add serial to detach map for all attachments (needed for undeploy)
+                        serial = item.get("serialNumber")
+                        if serial:
+                            self.vrf_sn_detach_map[vrf_name].add(serial)
+
+                        # Only add to diff_detach if actually attached
+                        if "isAttached" in item:
+                            if item["isAttached"]:
+                                del item["isAttached"]
+                                item.update({"deployment": False})
+                                detach_items.append(item)
+
                     if detach_items:
                         have_a.update({"lanAttachList": detach_items})
                         diff_detach.append(have_a)
                         all_vrfs.append(have_a["vrfName"])
 
-                    diff_delete.update({have_a["vrfName"]: "DEPLOYED"})
                 if len(all_vrfs) != 0:
                     # deduplicate before joining
                     diff_undeploy.update({"vrfNames": ",".join(sorted(set(all_vrfs)))})
@@ -2654,6 +2818,11 @@ class DcnmVrf:
         msg = "self.diff_detach: "
         msg += f"{json.dumps(self.diff_detach, indent=4)}"
         self.log.debug(msg)
+
+        if self.action_fabric_type != "multisite_child" and self.action_fabric_type != "multicluster_child":
+            msg = "self.vrf_sn_detach_map (built inline during DELETE processing): "
+            msg += f"{json.dumps({k: list(v) for k, v in self.vrf_sn_detach_map.items()}, indent=4)}"
+            self.log.debug(msg)
 
         msg = "self.diff_undeploy: "
         msg += f"{json.dumps(self.diff_undeploy, indent=4)}"
@@ -2684,8 +2853,21 @@ class DcnmVrf:
 
             detach_list = []
             if not found:
+                vrf_name = have_a["vrfName"]
+
                 if self.action_fabric_type != "multisite_child" and self.action_fabric_type != "multicluster_child":
+                    # Build detach map inline for VRFs being deleted in override
+                    # Initialize VRF entry in detach map
+                    if vrf_name not in self.vrf_sn_detach_map:
+                        self.vrf_sn_detach_map[vrf_name] = set()
+
                     for item in have_a["lanAttachList"]:
+                        # Add serial to detach map for all attachments (needed for undeploy)
+                        serial = item.get("serialNumber")
+                        if serial:
+                            self.vrf_sn_detach_map[vrf_name].add(serial)
+
+                        # Only add to diff_detach if actually attached
                         if "isAttached" in item:
                             if item["isAttached"]:
                                 del item["isAttached"]
@@ -2697,7 +2879,7 @@ class DcnmVrf:
                         diff_detach.append(have_a)
                         all_vrfs.append(have_a["vrfName"])
 
-                diff_delete.update({have_a["vrfName"]: "DEPLOYED"})
+                diff_delete.update({vrf_name: "DEPLOYED"})
 
         if len(all_vrfs) != 0 and self.action_fabric_type != "multisite_child" and self.action_fabric_type != "multicluster_child":
             # deduplicate before joining
@@ -2714,6 +2896,11 @@ class DcnmVrf:
         msg = "self.diff_detach: "
         msg += f"{json.dumps(self.diff_detach, indent=4)}"
         self.log.debug(msg)
+
+        if self.action_fabric_type != "multisite_child" and self.action_fabric_type != "multicluster_child":
+            msg = "self.vrf_sn_detach_map (built inline during OVERRIDE processing): "
+            msg += f"{json.dumps({k: list(v) for k, v in self.vrf_sn_detach_map.items()}, indent=4)}"
+            self.log.debug(msg)
 
         msg = "self.diff_undeploy: "
         msg += f"{json.dumps(self.diff_undeploy, indent=4)}"
@@ -3781,25 +3968,75 @@ class DcnmVrf:
         verb = "POST"
         diff_undeploy = self.diff_undeploy
 
-        # Determine deploy path and payload format
-        # For multicluster_parent, always use switch-level
-        # For all others, check deploy_mode parameter
-        if self.action_fabric_type == "multicluster_parent" or self.deploy_mode == "switch":
-            # Use switch-level deploy: transform payload to serial number format
-            deploy_path = path.replace(f"/fabrics/{self.fabric}/vrfs", "/vrfs/deploy")
-            diff_undeploy = self.vrf_serial_payload_transform(self.diff_undeploy)
+        if self.dcnm_version >= 12:
+            # Determine deploy path and payload format
+            if self.deploy_mode == "switch":
+                # Use switch-level config-deploy (undeploy operation)
+                self.deploy_vrf_switches(diff_undeploy, is_rollback, is_undeploy=True)
+            else:
+                # Use resource-level deploy: transform payload to serial number format
+                deploy_path = path.replace(f"/fabrics/{self.fabric}/vrfs", "/vrfs/deploy")
+                diff_undeploy = self.vrf_serial_payload_transform(self.diff_undeploy)
+                self.send_to_controller(
+                    action,
+                    verb,
+                    deploy_path,
+                    diff_undeploy,
+                    log_response=True,
+                    is_rollback=is_rollback,
+                )
         else:
-            # Use resource-level deploy: standard /deployments path with vrfNames
+            # for dcnm versions < 12, use the original deploy path and payload format
             deploy_path = path + "/deployments"
+            self.send_to_controller(
+                action,
+                verb,
+                deploy_path,
+                diff_undeploy,
+                log_response=True,
+                is_rollback=is_rollback,
+            )
 
-        self.send_to_controller(
-            action,
-            verb,
-            deploy_path,
-            diff_undeploy,
-            log_response=True,
-            is_rollback=is_rollback,
-        )
+    def push_diff_undeploy_with_retry(self, is_rollback=False):
+        """
+        # Summary
+
+        Send diff_undeploy to the controller with OUT-OF-SYNC retry logic.
+
+        ## Description
+
+        This wrapper method handles the undeploy operation and automatically
+        retries if VRFs are in OUT-OF-SYNC state after the initial undeploy.
+        """
+        caller = inspect.stack()[1][3]
+
+        msg = "ENTERED. "
+        msg += f"caller: {caller}."
+        self.log.debug(msg)
+
+        # Initial undeploy
+        self.push_diff_undeploy(is_rollback)
+
+        # Check for OUT-OF-SYNC state and retry if needed
+        if self.diff_undeploy:
+            delete_ready = self.wait_for_vrf_attachments_del_ready()
+            undeploy_retry_needed = any(
+                str(state).upper() == "OUT-OF-SYNC" for state in self.diff_delete.values()
+            )
+            if delete_ready and undeploy_retry_needed:
+                msg = "VRFs in OUT-OF-SYNC state detected. Retrying undeploy."
+                self.log.debug(msg)
+
+                use_delete_config_deploy = (
+                    self.action_fabric_type != "multicluster_parent"
+                    and self.deploy_mode == "switch"
+                    and bool(self.diff_delete)
+                )
+
+                if use_delete_config_deploy:
+                    self.deploy_vrf_switches(self.diff_undeploy, is_rollback, is_undeploy=True)
+                else:
+                    self.push_diff_undeploy(is_rollback)
 
     def bulk_delete_with_retry(self, vrfs_to_delete, action, verb, is_rollback=False):
         """
@@ -4808,9 +5045,9 @@ class DcnmVrf:
         msg += "ENTERED."
         self.log.debug(msg)
 
-        if not self.diff_deploy:
+        if not self.diff_deploy or self.action_fabric_type == "multisite_child" or self.action_fabric_type == "multicluster_child":
             msg = f"Early return. Fabric Type:{self.action_fabric_type}"
-            msg += f"diff_deploy: {json.dumps(self.diff_attach, indent=4, sort_keys=True)}"
+            msg += f"diff_deploy: {json.dumps(self.diff_deploy, indent=4, sort_keys=True)}"
             self.log.debug(msg)
             return
 
@@ -4819,20 +5056,30 @@ class DcnmVrf:
         path = self.paths["GET_VRF"].format(self.fabric)
         diff_deploy = self.diff_deploy
 
-        # Determine deploy path and payload format
-        # For multicluster_parent, always use switch-level
-        # For all others, check deploy_mode parameter
-        if self.action_fabric_type == "multicluster_parent" or self.deploy_mode == "switch":
-            # Use switch-level deploy: transform payload to serial number format
-            deploy_path = path.replace(f"/fabrics/{self.fabric}/vrfs", "/vrfs/deploy")
-            diff_deploy = self.vrf_serial_payload_transform(diff_deploy)
-        else:
-            # Use resource-level deploy: standard /deployments path with vrfNames
-            deploy_path = path + "/deployments"
-
         if self.action_fabric_type == "multicluster_parent" or self.action_fabric_type == "multisite_parent":
-            self.deploy_payload = diff_deploy
+            # For multisite/multicluster parent, set deploy_payload and return
+            # Deployment will be handled differently for these fabric types
+            if self.deploy_mode == "switch":
+                diff_deploy = self.get_deploy_switch_serials(diff_deploy, is_undeploy=False)
+            else:
+                diff_deploy = self.vrf_serial_payload_transform(diff_deploy)
+            # Wrap in structured format for type checking in action plugin
+            self.deploy_payload = {"payload": diff_deploy}
             return
+
+        if self.dcnm_version >= 12:
+            # Determine deploy path and payload format
+            if self.deploy_mode == "switch":
+                # Use switch-level config-deploy (normal deploy operation)
+                self.deploy_vrf_switches(diff_deploy, is_rollback, is_undeploy=False)
+                return
+            else:
+                # Use resource-level deploy: standard /deployments path with vrfNames
+                deploy_path = path.replace(f"/fabrics/{self.fabric}/vrfs", "/vrfs/deploy")
+                diff_deploy = self.vrf_serial_payload_transform(self.diff_deploy)
+        else:
+            # for dcnm versions < 12, use the original deploy path and payload format
+            deploy_path = path + "/deployments"
 
         self.send_to_controller(
             action,
@@ -5080,7 +5327,7 @@ class DcnmVrf:
                 self.module.fail_json(msg=msg)
 
         self.push_diff_detach(is_rollback)
-        self.push_diff_undeploy(is_rollback)
+        self.push_diff_undeploy_with_retry(is_rollback)
 
         msg = "Calling self.push_diff_delete"
         self.log.debug(msg)
@@ -5125,12 +5372,11 @@ class DcnmVrf:
         base_timeout = max(vrf_count * 30, 500)
         retry_count = max(base_timeout // self.WAIT_TIME_FOR_DELETE_LOOP, 1)
 
-        msg = f"Waiting for {len(pending_vrfs)} VRF(s) attachments to reach terminal state. "
+        msg = f"Waiting for {len(pending_vrfs)} VRF(s) to reach terminal state. "
         msg += f"vrf_count: {vrf_count}, base_timeout: {base_timeout}s, retry_count: {retry_count}"
         self.log.debug(msg)
 
         path = self.paths["GET_VRF"].format(self.fabric)
-        retry_count = max(500 // self.WAIT_TIME_FOR_DELETE_LOOP, 1)
 
         while pending_vrfs and retry_count > 0:
             retry_count -= 1

--- a/plugins/modules/dcnm_vrf.py
+++ b/plugins/modules/dcnm_vrf.py
@@ -5564,7 +5564,6 @@ def main():
     # Logging setup
     try:
         log = Log()
-        log.config = "/Users/achengam/Documents/Ansible_Dev/NAC_Performance/ansible_collections/cisco/dcnm/plugins/modules/ansible_cisco_log_r.json"
         log.commit()
     except (TypeError, ValueError):
         pass

--- a/plugins/modules/dcnm_vrf.py
+++ b/plugins/modules/dcnm_vrf.py
@@ -5121,8 +5121,12 @@ class DcnmVrf:
 
         # Create a list of VRFs that still need to reach terminal state
         pending_vrfs = list(self.diff_delete.keys())
+        vrf_count = len(pending_vrfs)
+        base_timeout = max(vrf_count * 30, 500)
+        retry_count = max(base_timeout // self.WAIT_TIME_FOR_DELETE_LOOP, 1)
 
-        msg = f"Waiting for {len(pending_vrfs)} VRF(s) to reach terminal state: {pending_vrfs}"
+        msg = f"Waiting for {len(pending_vrfs)} VRF(s) attachments to reach terminal state. "
+        msg += f"vrf_count: {vrf_count}, base_timeout: {base_timeout}s, retry_count: {retry_count}"
         self.log.debug(msg)
 
         path = self.paths["GET_VRF"].format(self.fabric)
@@ -5220,10 +5224,14 @@ class DcnmVrf:
 
         # Create list of VRFs pending deletion readiness
         pending_vrfs = list(self.diff_delete.keys())
-        msg = f"Waiting for {len(pending_vrfs)} VRF(s) attachments to reach terminal state"
+        vrf_count = len(pending_vrfs)
+        base_timeout = max(vrf_count * 30, 500)
+        retry_count = max(base_timeout // self.WAIT_TIME_FOR_DELETE_LOOP, 1)
+
+        msg = f"Waiting for {len(pending_vrfs)} VRF(s) attachments to reach terminal state. "
+        msg += f"vrf_count: {vrf_count}, base_timeout: {base_timeout}s, retry_count: {retry_count}"
         self.log.debug(msg)
 
-        retry_count = max(500 // self.WAIT_TIME_FOR_DELETE_LOOP, 1)
 
         while pending_vrfs and retry_count > 0:
             retry_count -= 1

--- a/plugins/modules/dcnm_vrf.py
+++ b/plugins/modules/dcnm_vrf.py
@@ -1016,16 +1016,9 @@ from ansible_collections.cisco.dcnm.plugins.module_utils.network.dcnm.dcnm impor
 
 from ..module_utils.common.log_v2 import Log
 
-# When the number of VRFs in the playbook config is below this threshold,
-# get_have() uses a targeted GET_VRF_TARGETED fetch (only the named VRFs) instead
-# of a full-fabric GET_VRF sweep.  Above the threshold, one bulk GET_VRF + local
-# filter is cheaper than many individual requests.
-BULK_GET_HAVE_VRF_THRESHOLD = 25
-
 dcnm_vrf_paths = {
     11: {
         "GET_VRF": "/rest/top-down/fabrics/{}/vrfs",
-        "GET_VRF_TARGETED": "/rest/top-down/fabrics/{}/vrfs?vrf-names={}",
         "GET_VRF_ATTACH": "/rest/top-down/fabrics/{}/vrfs/attachments?vrf-names={}",
         "GET_VRF_SWITCH": "/rest/top-down/fabrics/{}/vrfs/switches?vrf-names={}&serial-numbers={}",
         "GET_VRF_ID": "/rest/managed-pool/fabrics/{}/partitions/ids",
@@ -1035,7 +1028,6 @@ dcnm_vrf_paths = {
     12: {
         "GET_VRF_FAB": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{}",
         "GET_VRF": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{}/vrfs",
-        "GET_VRF_TARGETED": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{}/vrfs?vrf-names={}",
         "GET_VRF_BULK": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/bulk-create/vrfs",
         "GET_VRF_ATTACH": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{}/vrfs/attachments?vrf-names={}",
         "GET_VRF_SWITCH": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{}/vrfs/switches?vrf-names={}&serial-numbers={}",
@@ -2166,62 +2158,23 @@ class DcnmVrf:
 
         curr_vrfs = ""
 
-        # Hybrid targeted fetch:
-        # - targeted states (merged/replaced/deleted) with config < threshold:
-        #   use GET_VRF_TARGETED to fetch only the requested VRFs, skipping the
-        #   full-fabric GET_VRF call entirely.
-        # - targeted states with config >= threshold:
-        #   full-fabric GET_VRF + local filter (one bulk call is cheaper than many
-        #   individual targeted calls for large config lists).
-        # - non-targeted states (overridden/query/deleted-without-config):
-        #   full-fabric sweep unchanged.
-        targeted_states = {"merged", "replaced", "deleted"}
-        wanted_vrf_names = None
-        vrf_data_to_process = None
+        vrf_objects = self.get_vrf_objects()
 
+        if not vrf_objects.get("DATA"):
+            return
+
+        vrf_data_to_process = vrf_objects["DATA"]
+
+        targeted_states = {"merged", "replaced", "deleted"}
         if self.state in targeted_states and self.config:
             wanted_vrf_names = {vrf.get("vrf_name") for vrf in self.config if vrf.get("vrf_name")}
-
-            if len(wanted_vrf_names) < BULK_GET_HAVE_VRF_THRESHOLD:
-                # Small config: targeted per-name GET avoids downloading the full fabric payload.
-                targeted_path = self.paths["GET_VRF_TARGETED"].format(
-                    self.fabric, ",".join(sorted(wanted_vrf_names))
-                )
-                msg = (
-                    f"Targeted get_have() for state '{self.state}': "
-                    f"fetching {len(wanted_vrf_names)} VRF(s) by name "
-                    f"(below threshold {BULK_GET_HAVE_VRF_THRESHOLD})."
-                )
-                self.log.debug(msg)
-                vrf_targeted = dcnm_send(self.module, "GET", targeted_path)
-                missing_fabric, not_ok = self.handle_response(vrf_targeted, "query_dcnm")
-                if missing_fabric or not_ok:
-                    msg0 = "caller: get_have. "
-                    msg1 = f"{msg0} Fabric {self.fabric} not present on the controller"
-                    msg2 = f"{msg0} Unable to find vrfs under fabric: {self.fabric}"
-                    self.module.fail_json(msg=msg1 if missing_fabric else msg2)
-                vrf_data_to_process = vrf_targeted.get("DATA") or []
-            # else: large config — fall through to full-fabric get_vrf_objects() below
-
-        if vrf_data_to_process is None:
-            # Large config (>= threshold) or non-targeted state: full fabric sweep.
-            vrf_objects = self.get_vrf_objects()
-
-            if not vrf_objects.get("DATA"):
-                return
-
-            if wanted_vrf_names:
-                # Large config in targeted state: filter the full-fabric response in memory.
-                vrf_data_to_process = [v for v in vrf_objects["DATA"] if v["vrfName"] in wanted_vrf_names]
-                msg = (
-                    f"Targeted get_have() for state '{self.state}': "
-                    f"requesting attachments for {len(vrf_data_to_process)} of "
-                    f"{len(vrf_objects['DATA'])} fabric VRFs "
-                    f"(at/above threshold {BULK_GET_HAVE_VRF_THRESHOLD})."
-                )
-                self.log.debug(msg)
-            else:
-                vrf_data_to_process = vrf_objects["DATA"]
+            vrf_data_to_process = [v for v in vrf_objects["DATA"] if v["vrfName"] in wanted_vrf_names]
+            msg = (
+                f"Targeted get_have() for state '{self.state}': "
+                f"scoping GET_VRF_ATTACH to {len(vrf_data_to_process)} of "
+                f"{len(vrf_objects['DATA'])} fabric VRF(s)."
+            )
+            self.log.debug(msg)
 
         for vrf in vrf_data_to_process:
             curr_vrfs += vrf["vrfName"] + ","

--- a/plugins/modules/dcnm_vrf.py
+++ b/plugins/modules/dcnm_vrf.py
@@ -5583,8 +5583,19 @@ class DcnmVrf:
         msg += f"caller: {caller}"
         self.log.debug(msg)
 
-        # Create a list of VRFs that still need to reach terminal state
-        pending_vrfs = list(self.diff_delete.keys())
+        # Create a list of VRFs that still need to reach terminal state.
+        # VRFs already marked OUT-OF-SYNC/FAILED by the attachment readiness
+        # check are terminal for this workflow and should not consume another
+        # controller poll here.
+        pending_vrfs = [
+            vrf for vrf, state in self.diff_delete.items()
+            if str(state).upper() not in ("OUT-OF-SYNC", "FAILED")
+        ]
+        if not pending_vrfs:
+            msg = "No VRFs pending vrfStatus readiness check."
+            self.log.debug(msg)
+            return
+
         vrf_count = len(pending_vrfs)
         base_timeout = max(vrf_count * 30, 500)
         retry_count = max(base_timeout // self.WAIT_TIME_FOR_DELETE_LOOP, 1)
@@ -5685,8 +5696,18 @@ class DcnmVrf:
         if not self.diff_delete:
             return True
 
-        # Create list of VRFs pending deletion readiness
-        pending_vrfs = list(self.diff_delete.keys())
+        # Create list of VRFs pending deletion readiness.  This method may be
+        # called after push_diff_undeploy_with_retry() has already polled and
+        # marked attachments terminal, so avoid duplicate GET_VRF_ATTACH calls.
+        pending_vrfs = [
+            vrf for vrf, state in self.diff_delete.items()
+            if str(state).upper() not in ("NA", "OUT-OF-SYNC", "FAILED")
+        ]
+        if not pending_vrfs:
+            msg = "No VRFs pending attachment deletion readiness check."
+            self.log.debug(msg)
+            return True
+
         vrf_count = len(pending_vrfs)
         base_timeout = max(vrf_count * 30, 500)
         retry_count = max(base_timeout // self.WAIT_TIME_FOR_DELETE_LOOP, 1)

--- a/plugins/modules/dcnm_vrf.py
+++ b/plugins/modules/dcnm_vrf.py
@@ -1198,7 +1198,7 @@ class DcnmVrf:
         self.result = {"changed": False, "diff": [], "response": []}
 
         self.failed_to_rollback = False
-        self.WAIT_TIME_FOR_DELETE_LOOP = 5  # in seconds
+        self.WAIT_TIME_FOR_DELETE_LOOP = 10  # in seconds
 
         self.vrf_lite_properties = [
             "DOT1Q_ID",
@@ -3782,6 +3782,149 @@ class DcnmVrf:
             is_rollback=is_rollback,
         )
 
+    def bulk_delete_with_retry(self, vrfs_to_delete, action, verb, is_rollback=False):
+        """
+        # Summary
+
+        Perform bulk delete with retry logic for controller sync issues.
+
+        ## Description
+
+        The controller sometimes returns a 500 error with message
+        "Please do a Fabric Re-sync and try Again" for certain VRFs.
+        This method retries the bulk delete operation up to 3 times
+        with 30-second delays, retrying only the failed VRFs.
+
+        ## Parameters
+
+        - vrfs_to_delete: List of VRF names to delete
+        - action: Action string for logging ("delete")
+        - verb: HTTP verb ("DELETE")
+        - is_rollback: Whether this is a rollback operation
+
+        ## Raises
+
+        Calls fail_json if deletion fails after all retry attempts
+        """
+        caller = inspect.stack()[1][3]
+        method_name = inspect.stack()[0][3]
+
+        msg = "ENTERED. "
+        msg += f"caller: {caller}. "
+        msg += f"vrfs_to_delete: {vrfs_to_delete}"
+        self.log.debug(msg)
+
+        max_retries = 3
+        retry_delay = 30  # seconds
+        all_successful_vrfs = []
+        vrfs_to_retry = vrfs_to_delete.copy()
+
+        for attempt in range(1, max_retries + 1):
+            if not vrfs_to_retry:
+                # All VRFs deleted successfully
+                msg = "All VRFs deleted successfully."
+                self.log.debug(msg)
+                return
+
+            msg = f"Bulk delete attempt {attempt}/{max_retries} "
+            msg += f"for VRFs: {','.join(vrfs_to_retry)}"
+            self.log.debug(msg)
+
+            # Build the bulk delete path
+            path = self.paths["GET_VRF_FAB"].format(self.fabric)
+            delete_path = f"{path}/bulk-delete/vrfs?vrf-names={','.join(vrfs_to_retry)}"
+
+            msg = f"Attempt {attempt}: "
+            msg += f"verb: {verb}, path: {delete_path}"
+            self.log.debug(msg)
+
+            # Send the request
+            response = dcnm_send(self.module, verb, delete_path)
+
+            msg = f"Attempt {attempt} response: "
+            msg += f"{json.dumps(response, indent=4, sort_keys=True)}"
+            self.log.debug(msg)
+
+            # Always append response for visibility
+            self.result["response"].append(response)
+
+            return_code = response.get("RETURN_CODE", 0)
+
+            # Check if request was successful
+            if return_code == 200:
+                msg = f"Attempt {attempt}: Bulk delete succeeded for all VRFs."
+                self.log.debug(msg)
+                # Mark as changed if not in check mode
+                if not self.module.check_mode:
+                    self.result["changed"] = True
+                return
+
+            # Handle partial success (500 error with failureList)
+            if return_code == 500:
+                data = response.get("DATA", {})
+                success_list = data.get("successList", [])
+                failure_list = data.get("failureList", [])
+
+                # Track successful deletions
+                if success_list:
+                    all_successful_vrfs.extend(success_list)
+                    msg = f"Attempt {attempt}: Successfully deleted VRFs: "
+                    msg += f"{','.join(success_list)}"
+                    self.log.debug(msg)
+                    if not self.module.check_mode:
+                        self.result["changed"] = True
+
+                # Extract failed VRF names for retry
+                if failure_list:
+                    vrfs_to_retry = [item.get("name") for item in failure_list if item.get("name")]
+                    failure_messages = [
+                        f"{item.get('name')}: {item.get('message')}"
+                        for item in failure_list
+                    ]
+                    msg = f"Attempt {attempt}: Failed VRFs: {', '.join(failure_messages)}"
+                    self.log.debug(msg)
+
+                    # If this is the last attempt, fail
+                    if attempt == max_retries:
+                        if is_rollback:
+                            self.failed_to_rollback = True
+                            return
+                        msg = f"{self.class_name}.{method_name}: "
+                        msg += f"Bulk delete failed after {max_retries} attempts. "
+                        msg += f"Successfully deleted: {','.join(all_successful_vrfs) if all_successful_vrfs else 'None'}. "
+                        msg += f"Failed: {', '.join(failure_messages)}"
+                        self.log.debug(msg)
+                        self.failure(response)
+
+                    # Wait before retrying
+                    msg = f"Waiting {retry_delay} seconds before retry {attempt + 1}..."
+                    self.log.debug(msg)
+                    time.sleep(retry_delay)
+                else:
+                    # No failure list but 500 error - this shouldn't happen but handle it
+                    if attempt == max_retries:
+                        if is_rollback:
+                            self.failed_to_rollback = True
+                            return
+                        msg = f"{self.class_name}.{method_name}: "
+                        msg += f"Bulk delete failed with 500 error after {max_retries} attempts. "
+                        msg += f"No failure details provided by controller."
+                        self.log.debug(msg)
+                        self.failure(response)
+                    time.sleep(retry_delay)
+            else:
+                # Other error codes - let handle_response deal with it
+                fail, self.result["changed"] = self.handle_response(response, action)
+                if fail:
+                    if is_rollback:
+                        self.failed_to_rollback = True
+                        return
+                    msg = f"{self.class_name}.{method_name}: "
+                    msg += f"Bulk delete failed with return code {return_code}"
+                    self.log.debug(msg)
+                    self.failure(response)
+                return
+
     def push_diff_delete(self, is_rollback=False):
         """
         # Summary
@@ -3835,16 +3978,12 @@ class DcnmVrf:
 
         if self.action_fabric_type != "multicluster_parent" and vrfs_to_delete and self.dcnm_version >= 12:
             self.log.debug("Sending Bulk VRF delete request")
-            # Build the bulk delete path with comma-separated VRF names
-            path = self.paths["GET_VRF_FAB"].format(self.fabric)
-            delete_path = f"{path}/bulk-delete/vrfs?vrf-names={','.join(vrfs_to_delete)}"
-            self.send_to_controller(
+            # Use retry logic for bulk delete
+            self.bulk_delete_with_retry(
+                vrfs_to_delete,
                 action,
                 verb,
-                delete_path,
-                None,  # Bulk delete uses query params, not payload
-                log_response=True,
-                is_rollback=is_rollback,
+                is_rollback
             )
 
         if del_failure:

--- a/plugins/modules/dcnm_vrf.py
+++ b/plugins/modules/dcnm_vrf.py
@@ -1915,17 +1915,17 @@ class DcnmVrf:
     def get_deploy_switch_serials(self, vrf_names=None, is_undeploy=False):
         """
         Return ordered, unique switch serials affected by VRF deployments or undeployments.
-        
+
         Uses centralized vrf_sn_attach_map for deploy operations and
         vrf_sn_detach_map for undeploy operations. The is_undeploy parameter
         explicitly controls which map to use.
-        
+
         Args:
             vrf_names: Can be dict with "vrfNames" key, string (comma-separated),
                       or list of VRF names
             is_undeploy: If True, reads from vrf_sn_detach_map (undeploy operations).
                         If False (default), reads from vrf_sn_attach_map (deploy operations).
-        
+
         Returns:
             list: Ordered list of unique serial numbers
         """
@@ -1944,34 +1944,36 @@ class DcnmVrf:
 
         # Select the appropriate map based on operation type
         serial_map = self.vrf_sn_detach_map if is_undeploy else self.vrf_sn_attach_map
-        
+
         map_type = "detach" if is_undeploy else "attach"
         msg = f"Using vrf_sn_{map_type}_map for serial lookup."
         self.log.debug(msg)
 
         serials = []
         seen = set()
-        
+
         # Iterate through all VRFs in the selected map
         for vrf_name, serial_set in serial_map.items():
             if wanted_vrfs and vrf_name not in wanted_vrfs:
                 continue
-            
+
             for serial in serial_set:
                 if serial not in seen:
                     seen.add(serial)
                     serials.append(serial)
 
+        msg = f"Returning serials: {serials}"
+        self.log.debug(msg)
         return serials
 
     def deploy_vrf_switches(self, vrf_names=None, is_rollback=False, is_undeploy=False):
         """
         Trigger switch-level config deploy for switches affected by VRF operations.
-        
+
         Uses VRF attachment/detachment data to determine affected switches.
         Works for both deploy and undeploy operations.
         Handles response internally and updates self.result.
-        
+
         Args:
             vrf_names: VRFs to deploy/undeploy
             is_rollback: Whether this is a rollback operation
@@ -1991,7 +1993,7 @@ class DcnmVrf:
         )
 
         resp = dcnm_send(self.module, method, deploy_path)
-        
+
         if resp is not None:
             self.result["response"].append(resp)
             fail, self.result["changed"] = self.handle_response(resp, "deploy")
@@ -3822,13 +3824,17 @@ class DcnmVrf:
         """
         # Summary
 
-        Wrapper method to send diff_create_update to the controller.
-        Delegates to appropriate method based on dcnm_version.
+        Send diff_create_update to the controller.
 
-        ## Behavior:
-        - dcnm_version == -1: Calls _push_diff_create_update_bulk() for v2 bulk API
-        - Other versions: Calls _push_diff_create_update() for per-VRF updates
+        ## Behavior by Version:
+        - dcnm_version == -1: Use v2 bulk-update API (PUT to bulk endpoint)
+        - Other versions: Use individual PUT per VRF (existing behavior)
+
+        ## Key Differences:
+        - Bulk API: vrfTemplateConfig as dict, array payload, exclude serviceVrfTemplate/source
+        - Individual API: vrfTemplateConfig as JSON string, single payload per VRF
         """
+        method_name = inspect.stack()[0][3]
         caller = inspect.stack()[1][3]
 
         msg = "ENTERED. "
@@ -3840,59 +3846,32 @@ class DcnmVrf:
             self.log.debug(msg)
             return
 
-        # Route to appropriate method based on version
-        if self.has_bulk_api:
-            msg = "Routing to _push_diff_create_update_bulk() for bulk API"
-            self.log.debug(msg)
-            self._push_diff_create_update_bulk(is_rollback)
+        use_bulk = self.has_bulk_api and self.fabric_type != "multicluster_parent"
+        # Initialize based on API type
+        if use_bulk:
+            bulk_payload = []
+            action = "bulk_update"
+            verb = "PUT"
+            path = self.paths["UPDATE_VRF_BULK"]
         else:
-            msg = f"Routing to _push_diff_create_update() for dcnm_version {self.dcnm_version}"
-            self.log.debug(msg)
-            self._push_diff_create_update(is_rollback)
+            action = "create"
+            verb = "PUT"
+            base_path = self.paths["GET_VRF"].format(self.fabric)
 
-    def _push_diff_create_update_bulk(self, is_rollback=False):
-        """
-        # Summary
-
-        Send diff_create_update to the controller using v2 bulk-update API.
-        Used exclusively when bulk API is available.
-
-        ## V2 Bulk Update API:
-        - Method: PUT
-        - Path: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/v2/bulk-update/vrfs
-        - Payload: Array of VRF objects
-        - vrfTemplateConfig: dict object (not JSON string)
-        - Excludes: serviceVrfTemplate, source fields
-
-        ## Response Format:
-        {
-          "successList": [
-            {"name": "vrf1", "id": 50001, "message": "VRF is successfully updated.", "status": "Success"}
-          ]
-        }
-        """
-        method_name = inspect.stack()[0][3]
-        caller = inspect.stack()[1][3]
-
-        msg = "ENTERED. "
-        msg += f"caller: {caller}. "
-        self.log.debug(msg)
-
-        bulk_payload = []
-
+        # Process each VRF
         for vrf in self.diff_create_update:
-            # Parse JSON string template config
+            # Parse JSON string template config (common to both)
             json_to_dict = json.loads(vrf["vrfTemplateConfig"])
             vrf_name = json_to_dict.get("vrfName")
 
-            msg = f"Processing VRF {vrf_name} for bulk update"
+            msg = f"Processing VRF {vrf_name}"
             self.log.debug(msg)
 
             msg = f"VRF {vrf_name} template config: "
             msg += f"{json.dumps(json_to_dict, indent=4, sort_keys=True)}"
             self.log.debug(msg)
 
-            # Handle VLAN ID auto-allocation if needed
+            # Handle VLAN ID auto-allocation (common to both)
             vlan_id = json_to_dict.get("vrfVlanId", 0)
             if vlan_id == 0:
                 msg = f"VRF {vrf_name}: auto-allocating VLAN ID"
@@ -3914,34 +3893,39 @@ class DcnmVrf:
                 msg = f"VRF {vrf_name}: allocated VLAN ID {vlan_id}"
                 self.log.debug(msg)
 
-            # Build VRF object for v2 bulk API
-            # Key difference: vrfTemplateConfig is dict, NOT JSON string
-            # Also: exclude serviceVrfTemplate and source fields
-            vrf_obj = {
-                "fabric": vrf["fabric"],
-                "vrfName": vrf["vrfName"],
-                "vrfId": vrf["vrfId"],
-                "vrfTemplate": vrf["vrfTemplate"],
-                "vrfExtensionTemplate": vrf["vrfExtensionTemplate"],
-                "vrfTemplateConfig": json_to_dict  # Dict object, not JSON string
-            }
+            # Build payload based on API type
+            if use_bulk:
+                # Bulk API: vrfTemplateConfig as dict, exclude serviceVrfTemplate/source
+                vrf_obj = {
+                    "fabric": vrf["fabric"],
+                    "vrfName": vrf["vrfName"],
+                    "vrfId": vrf["vrfId"],
+                    "vrfTemplate": vrf["vrfTemplate"],
+                    "vrfExtensionTemplate": vrf["vrfExtensionTemplate"],
+                    "vrfTemplateConfig": json_to_dict  # Dict object
+                }
 
-            msg = f"VRF {vrf_name} bulk payload object: "
-            msg += f"{json.dumps(vrf_obj, indent=4, sort_keys=True)}"
-            self.log.debug(msg)
+                bulk_payload.append(vrf_obj)
+            else:
+                # Individual API: vrfTemplateConfig as JSON string, keep all fields
+                vrf["vrfTemplateConfig"] = json.dumps(json_to_dict)
+                update_path = f"{base_path}/{vrf['vrfName']}"
 
-            bulk_payload.append(vrf_obj)
+                msg = f"Sending individual update for VRF {vrf_name}"
+                self.log.debug(msg)
 
-        if bulk_payload:
-            action = "bulk_update"
-            verb = "PUT"
-            path = self.paths["UPDATE_VRF_BULK"]
+                self.send_to_controller(
+                    action,
+                    verb,
+                    update_path,
+                    vrf,
+                    log_response=True,
+                    is_rollback=is_rollback,
+                )
 
+        # Send bulk request if using bulk API
+        if use_bulk and bulk_payload:
             msg = f"Sending v2 bulk-update request with {len(bulk_payload)} VRF(s)"
-            self.log.debug(msg)
-
-            msg = "Complete bulk update payload: "
-            msg += f"{json.dumps(bulk_payload, indent=4, sort_keys=True)}"
             self.log.debug(msg)
 
             self.send_to_controller(
@@ -3953,201 +3937,6 @@ class DcnmVrf:
                 is_rollback=is_rollback,
             )
 
-    def _push_diff_create_update(self, is_rollback=False):
-        """
-        # Summary
-
-        Send diff_create_update to the controller using individual PUT per VRF.
-        Used for all versions except dcnm_version == -1.
-
-        ## Individual Update API:
-        - Method: PUT
-        - Path: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{fabric}/vrfs/{vrfName}
-        - Payload: Single VRF object
-        - vrfTemplateConfig: JSON string
-        - Includes: serviceVrfTemplate, source fields
-        """
-        method_name = inspect.stack()[0][3]
-        caller = inspect.stack()[1][3]
-
-        msg = "ENTERED. "
-        msg += f"caller: {caller}. "
-        self.log.debug(msg)
-
-        action = "create"
-        path = self.paths["GET_VRF"].format(self.fabric)
-        verb = "PUT"
-
-        msg = "Pushing diff_create_update to controller (individual updates): "
-        msg += f"{json.dumps(self.diff_create_update, indent=4, sort_keys=True)}"
-        self.log.debug(msg)
-
-        for vrf in self.diff_create_update:
-            update_path = f"{path}/{vrf['vrfName']}"
-
-            # Check for VRF VLAN ID in the template
-            json_to_dict = json.loads(vrf["vrfTemplateConfig"])
-
-            msg = f"VRF {vrf['vrfName']} template config: "
-            msg += f"{json.dumps(json_to_dict, indent=4, sort_keys=True)}"
-            self.log.debug(msg)
-
-            vlan_id = json_to_dict.get("vrfVlanId", "0")
-
-            if vlan_id == 0:
-                # Get the next available VLAN ID, vlan 0 shouldn't be pushed
-                # to the controller
-                vlan_path = self.paths["GET_VLAN"].format(self.fabric)
-                vlan_data = dcnm_send(self.module, "GET", vlan_path)
-
-                if vlan_data["RETURN_CODE"] != 200:
-                    msg = f"{self.class_name}.{method_name}: "
-                    msg += f"caller: {caller}, "
-                    msg += f"vrf_name: {vrf['vrfName']}. "
-                    msg += f"Failure getting autogenerated vlan_id {vlan_data}"
-                    self.module.fail_json(msg=msg)
-
-                vlan_id = vlan_data["DATA"]
-                json_to_dict.update({"vrfVlanId": vlan_id})
-                vrf.update({"vrfTemplateConfig": json.dumps(json_to_dict)})
-
-            self.send_to_controller(
-                action,
-                verb,
-                update_path,
-                vrf,
-                log_response=True,
-                is_rollback=is_rollback,
-            )
-    # def push_diff_create_update(self, is_rollback=False):
-    #     """
-    #     # Summary
-
-    #     Send diff_create_update to the controller.
-        
-    #     ## Behavior by Version:
-    #     - dcnm_version == -1: Use v2 bulk-update API (PUT to bulk endpoint)
-    #     - Other versions: Use individual PUT per VRF (existing behavior)
-        
-    #     ## Key Differences:
-    #     - Bulk API: vrfTemplateConfig as dict, array payload, exclude serviceVrfTemplate/source
-    #     - Individual API: vrfTemplateConfig as JSON string, single payload per VRF
-    #     """
-    #     method_name = inspect.stack()[0][3]
-    #     caller = inspect.stack()[1][3]
-
-    #     msg = "ENTERED. "
-    #     msg += f"caller: {caller}. "
-    #     self.log.debug(msg)
-
-    #     if not self.diff_create_update:
-    #         msg = "Early return. self.diff_create_update is empty."
-    #         self.log.debug(msg)
-    #         return
-
-    #     # Determine if using bulk API
-    #     use_bulk_api = (self.dcnm_version == -1)
-        
-    #     msg = f"Using {'v2 bulk-update' if use_bulk_api else 'individual update'} API"
-    #     self.log.debug(msg)
-
-    #     # Initialize based on API type
-    #     if use_bulk_api:
-    #         bulk_payload = []
-    #         action = "bulk_update"
-    #         verb = "PUT"
-    #         path = self.paths["UPDATE_VRF_BULK"]
-    #     else:
-    #         action = "create"
-    #         verb = "PUT"
-    #         base_path = self.paths["GET_VRF"].format(self.fabric)
-
-    #     # Process each VRF
-    #     for vrf in self.diff_create_update:
-    #         # Parse JSON string template config (common to both)
-    #         json_to_dict = json.loads(vrf["vrfTemplateConfig"])
-    #         vrf_name = json_to_dict.get("vrfName")
-            
-    #         msg = f"Processing VRF {vrf_name}"
-    #         self.log.debug(msg)
-
-    #         msg = f"VRF {vrf_name} template config: "
-    #         msg += f"{json.dumps(json_to_dict, indent=4, sort_keys=True)}"
-    #         self.log.debug(msg)
-
-    #         # Handle VLAN ID auto-allocation (common to both)
-    #         vlan_id = json_to_dict.get("vrfVlanId", 0)
-    #         if vlan_id == 0:
-    #             msg = f"VRF {vrf_name}: auto-allocating VLAN ID"
-    #             self.log.debug(msg)
-                
-    #             vlan_path = self.paths["GET_VLAN"].format(self.fabric)
-    #             vlan_data = dcnm_send(self.module, "GET", vlan_path)
-
-    #             if vlan_data["RETURN_CODE"] != 200:
-    #                 msg = f"{self.class_name}.{method_name}: "
-    #                 msg += f"caller: {caller}, "
-    #                 msg += f"vrf_name: {vrf_name}. "
-    #                 msg += f"Failure getting autogenerated vlan_id {vlan_data}"
-    #                 self.module.fail_json(msg=msg)
-
-    #             vlan_id = vlan_data["DATA"]
-    #             json_to_dict["vrfVlanId"] = vlan_id
-                
-    #             msg = f"VRF {vrf_name}: allocated VLAN ID {vlan_id}"
-    #             self.log.debug(msg)
-
-    #         # Build payload based on API type
-    #         if use_bulk_api:
-    #             # Bulk API: vrfTemplateConfig as dict, exclude serviceVrfTemplate/source
-    #             vrf_obj = {
-    #                 "fabric": vrf["fabric"],
-    #                 "vrfName": vrf["vrfName"],
-    #                 "vrfId": vrf["vrfId"],
-    #                 "vrfTemplate": vrf["vrfTemplate"],
-    #                 "vrfExtensionTemplate": vrf["vrfExtensionTemplate"],
-    #                 "vrfTemplateConfig": json_to_dict  # Dict object
-    #             }
-                
-    #             msg = f"VRF {vrf_name} bulk payload: "
-    #             msg += f"{json.dumps(vrf_obj, indent=4, sort_keys=True)}"
-    #             self.log.debug(msg)
-                
-    #             bulk_payload.append(vrf_obj)
-    #         else:
-    #             # Individual API: vrfTemplateConfig as JSON string, keep all fields
-    #             vrf["vrfTemplateConfig"] = json.dumps(json_to_dict)
-    #             update_path = f"{base_path}/{vrf['vrfName']}"
-                
-    #             msg = f"Sending individual update for VRF {vrf_name}"
-    #             self.log.debug(msg)
-                
-    #             self.send_to_controller(
-    #                 action,
-    #                 verb,
-    #                 update_path,
-    #                 vrf,
-    #                 log_response=True,
-    #                 is_rollback=is_rollback,
-    #             )
-
-    #     # Send bulk request if using bulk API
-    #     if use_bulk_api and bulk_payload:
-    #         msg = f"Sending v2 bulk-update request with {len(bulk_payload)} VRF(s)"
-    #         self.log.debug(msg)
-            
-    #         msg = "Complete bulk update payload: "
-    #         msg += f"{json.dumps(bulk_payload, indent=4, sort_keys=True)}"
-    #         self.log.debug(msg)
-            
-    #         self.send_to_controller(
-    #             action,
-    #             verb,
-    #             path,
-    #             bulk_payload,
-    #             log_response=True,
-    #             is_rollback=is_rollback,
-    #         )
     def push_diff_detach(self, is_rollback=False):
         """
         # Summary
@@ -6293,7 +6082,8 @@ class DcnmVrf:
             return False, False
 
         # Responses to all other operations POST and PUT are handled here.
-        if res.get("MESSAGE") != "OK" or res["RETURN_CODE"] != 200:
+        # Accept both 200 (OK) and 207 (Multi-Status) for bulk operations
+        if res.get("MESSAGE") != "OK" or res["RETURN_CODE"] not in [200, 207]:
             fail = True
             changed = False
             return fail, changed

--- a/plugins/modules/dcnm_vrf.py
+++ b/plugins/modules/dcnm_vrf.py
@@ -1022,7 +1022,7 @@ import time
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.dcnm.plugins.module_utils.network.dcnm.dcnm import (
-    dcnm_get_ip_addr_info, dcnm_get_url, dcnm_send, dcnm_version_supported,
+    dcnm_get_bulk_api_support, dcnm_get_ip_addr_info, dcnm_get_url, dcnm_send, dcnm_version_supported,
     get_nd_fabric_details, get_nd_fabric_inventory_details, get_ip_sn_dict,
     get_sn_fabric_dict, validate_list_of_dicts, search_nested_json,
     find_dict_in_list_by_key_value, sanitize_lan_attach_list)
@@ -1045,6 +1045,7 @@ dcnm_vrf_paths = {
         "GET_VRF_BULK": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/bulk-create/vrfs",
         "GET_VRF_ATTACH": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{}/vrfs/attachments?vrf-names={}",
         "GET_VRF_SWITCH": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{}/vrfs/switches?vrf-names={}&serial-numbers={}",
+        "UPDATE_VRF_BULK": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/v2/bulk-update/vrfs",
         "GET_VRF_ID": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{}/vrfinfo",
         "GET_VLAN": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/resource-manager/vlan/{}?vlanUsageType=TOP_DOWN_VRF_VLAN",
         "GET_NET_VRF": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{}/networks?vrf-name={}",
@@ -1148,6 +1149,11 @@ class DcnmVrf:
             self.dcnm_version = self.action_nd_version
 
         msg = f"self.dcnm_version: {self.dcnm_version}"
+        self.log.debug(msg)
+
+        # Check for bulk API support
+        self.has_bulk_api = dcnm_get_bulk_api_support(self.module)
+        msg = f"Bulk API support detected: {self.has_bulk_api}"
         self.log.debug(msg)
 
         self.action_fabric_type = self.action_fabric_details.get("fabric_type")
@@ -3816,7 +3822,150 @@ class DcnmVrf:
         """
         # Summary
 
-        Send diff_create_update to the controller
+        Wrapper method to send diff_create_update to the controller.
+        Delegates to appropriate method based on dcnm_version.
+
+        ## Behavior:
+        - dcnm_version == -1: Calls _push_diff_create_update_bulk() for v2 bulk API
+        - Other versions: Calls _push_diff_create_update() for per-VRF updates
+        """
+        caller = inspect.stack()[1][3]
+
+        msg = "ENTERED. "
+        msg += f"caller: {caller}. "
+        self.log.debug(msg)
+
+        if not self.diff_create_update:
+            msg = "Early return. self.diff_create_update is empty."
+            self.log.debug(msg)
+            return
+
+        # Route to appropriate method based on version
+        if self.has_bulk_api:
+            msg = "Routing to _push_diff_create_update_bulk() for bulk API"
+            self.log.debug(msg)
+            self._push_diff_create_update_bulk(is_rollback)
+        else:
+            msg = f"Routing to _push_diff_create_update() for dcnm_version {self.dcnm_version}"
+            self.log.debug(msg)
+            self._push_diff_create_update(is_rollback)
+
+    def _push_diff_create_update_bulk(self, is_rollback=False):
+        """
+        # Summary
+
+        Send diff_create_update to the controller using v2 bulk-update API.
+        Used exclusively when bulk API is available.
+
+        ## V2 Bulk Update API:
+        - Method: PUT
+        - Path: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/v2/bulk-update/vrfs
+        - Payload: Array of VRF objects
+        - vrfTemplateConfig: dict object (not JSON string)
+        - Excludes: serviceVrfTemplate, source fields
+
+        ## Response Format:
+        {
+          "successList": [
+            {"name": "vrf1", "id": 50001, "message": "VRF is successfully updated.", "status": "Success"}
+          ]
+        }
+        """
+        method_name = inspect.stack()[0][3]
+        caller = inspect.stack()[1][3]
+
+        msg = "ENTERED. "
+        msg += f"caller: {caller}. "
+        self.log.debug(msg)
+
+        bulk_payload = []
+
+        for vrf in self.diff_create_update:
+            # Parse JSON string template config
+            json_to_dict = json.loads(vrf["vrfTemplateConfig"])
+            vrf_name = json_to_dict.get("vrfName")
+
+            msg = f"Processing VRF {vrf_name} for bulk update"
+            self.log.debug(msg)
+
+            msg = f"VRF {vrf_name} template config: "
+            msg += f"{json.dumps(json_to_dict, indent=4, sort_keys=True)}"
+            self.log.debug(msg)
+
+            # Handle VLAN ID auto-allocation if needed
+            vlan_id = json_to_dict.get("vrfVlanId", 0)
+            if vlan_id == 0:
+                msg = f"VRF {vrf_name}: auto-allocating VLAN ID"
+                self.log.debug(msg)
+
+                vlan_path = self.paths["GET_VLAN"].format(self.fabric)
+                vlan_data = dcnm_send(self.module, "GET", vlan_path)
+
+                if vlan_data["RETURN_CODE"] != 200:
+                    msg = f"{self.class_name}.{method_name}: "
+                    msg += f"caller: {caller}, "
+                    msg += f"vrf_name: {vrf_name}. "
+                    msg += f"Failure getting autogenerated vlan_id {vlan_data}"
+                    self.module.fail_json(msg=msg)
+
+                vlan_id = vlan_data["DATA"]
+                json_to_dict["vrfVlanId"] = vlan_id
+
+                msg = f"VRF {vrf_name}: allocated VLAN ID {vlan_id}"
+                self.log.debug(msg)
+
+            # Build VRF object for v2 bulk API
+            # Key difference: vrfTemplateConfig is dict, NOT JSON string
+            # Also: exclude serviceVrfTemplate and source fields
+            vrf_obj = {
+                "fabric": vrf["fabric"],
+                "vrfName": vrf["vrfName"],
+                "vrfId": vrf["vrfId"],
+                "vrfTemplate": vrf["vrfTemplate"],
+                "vrfExtensionTemplate": vrf["vrfExtensionTemplate"],
+                "vrfTemplateConfig": json_to_dict  # Dict object, not JSON string
+            }
+
+            msg = f"VRF {vrf_name} bulk payload object: "
+            msg += f"{json.dumps(vrf_obj, indent=4, sort_keys=True)}"
+            self.log.debug(msg)
+
+            bulk_payload.append(vrf_obj)
+
+        if bulk_payload:
+            action = "bulk_update"
+            verb = "PUT"
+            path = self.paths["UPDATE_VRF_BULK"]
+
+            msg = f"Sending v2 bulk-update request with {len(bulk_payload)} VRF(s)"
+            self.log.debug(msg)
+
+            msg = "Complete bulk update payload: "
+            msg += f"{json.dumps(bulk_payload, indent=4, sort_keys=True)}"
+            self.log.debug(msg)
+
+            self.send_to_controller(
+                action,
+                verb,
+                path,
+                bulk_payload,
+                log_response=True,
+                is_rollback=is_rollback,
+            )
+
+    def _push_diff_create_update(self, is_rollback=False):
+        """
+        # Summary
+
+        Send diff_create_update to the controller using individual PUT per VRF.
+        Used for all versions except dcnm_version == -1.
+
+        ## Individual Update API:
+        - Method: PUT
+        - Path: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{fabric}/vrfs/{vrfName}
+        - Payload: Single VRF object
+        - vrfTemplateConfig: JSON string
+        - Includes: serviceVrfTemplate, source fields
         """
         method_name = inspect.stack()[0][3]
         caller = inspect.stack()[1][3]
@@ -3829,37 +3978,176 @@ class DcnmVrf:
         path = self.paths["GET_VRF"].format(self.fabric)
         verb = "PUT"
 
-        if self.diff_create_update:
-            for vrf in self.diff_create_update:
-                update_path = f"{path}/{vrf['vrfName']}"
-                # Check for VRF VLAN ID in the template
-                json_to_dict = json.loads(vrf["vrfTemplateConfig"])
-                vlan_id = json_to_dict.get("vrfVlanId", "0")
-                if vlan_id == 0:
-                    # Get the next available VLAN ID, vlan 0 shouldn't be pushed
-                    # to the controller
-                    vlan_path = self.paths["GET_VLAN"].format(self.fabric)
-                    vlan_data = dcnm_send(self.module, "GET", vlan_path)
-                    if vlan_data["RETURN_CODE"] != 200:
-                        msg = f"{self.class_name}.{method_name}: "
-                        msg += f"caller: {caller}, "
-                        msg += f"vrf_name: {vrf['vrfName']}. "
-                        msg += f"Failure getting autogenerated vlan_id {vlan_data}"
-                        self.module.fail_json(msg=msg)
+        msg = "Pushing diff_create_update to controller (individual updates): "
+        msg += f"{json.dumps(self.diff_create_update, indent=4, sort_keys=True)}"
+        self.log.debug(msg)
 
-                    vlan_id = vlan_data["DATA"]
-                    json_to_dict.update({"vrfVlanId": vlan_id})
-                    vrf.update({"vrfTemplateConfig": json.dumps(json_to_dict)})
+        for vrf in self.diff_create_update:
+            update_path = f"{path}/{vrf['vrfName']}"
 
-                self.send_to_controller(
-                    action,
-                    verb,
-                    update_path,
-                    vrf,
-                    log_response=True,
-                    is_rollback=is_rollback,
-                )
+            # Check for VRF VLAN ID in the template
+            json_to_dict = json.loads(vrf["vrfTemplateConfig"])
 
+            msg = f"VRF {vrf['vrfName']} template config: "
+            msg += f"{json.dumps(json_to_dict, indent=4, sort_keys=True)}"
+            self.log.debug(msg)
+
+            vlan_id = json_to_dict.get("vrfVlanId", "0")
+
+            if vlan_id == 0:
+                # Get the next available VLAN ID, vlan 0 shouldn't be pushed
+                # to the controller
+                vlan_path = self.paths["GET_VLAN"].format(self.fabric)
+                vlan_data = dcnm_send(self.module, "GET", vlan_path)
+
+                if vlan_data["RETURN_CODE"] != 200:
+                    msg = f"{self.class_name}.{method_name}: "
+                    msg += f"caller: {caller}, "
+                    msg += f"vrf_name: {vrf['vrfName']}. "
+                    msg += f"Failure getting autogenerated vlan_id {vlan_data}"
+                    self.module.fail_json(msg=msg)
+
+                vlan_id = vlan_data["DATA"]
+                json_to_dict.update({"vrfVlanId": vlan_id})
+                vrf.update({"vrfTemplateConfig": json.dumps(json_to_dict)})
+
+            self.send_to_controller(
+                action,
+                verb,
+                update_path,
+                vrf,
+                log_response=True,
+                is_rollback=is_rollback,
+            )
+    # def push_diff_create_update(self, is_rollback=False):
+    #     """
+    #     # Summary
+
+    #     Send diff_create_update to the controller.
+        
+    #     ## Behavior by Version:
+    #     - dcnm_version == -1: Use v2 bulk-update API (PUT to bulk endpoint)
+    #     - Other versions: Use individual PUT per VRF (existing behavior)
+        
+    #     ## Key Differences:
+    #     - Bulk API: vrfTemplateConfig as dict, array payload, exclude serviceVrfTemplate/source
+    #     - Individual API: vrfTemplateConfig as JSON string, single payload per VRF
+    #     """
+    #     method_name = inspect.stack()[0][3]
+    #     caller = inspect.stack()[1][3]
+
+    #     msg = "ENTERED. "
+    #     msg += f"caller: {caller}. "
+    #     self.log.debug(msg)
+
+    #     if not self.diff_create_update:
+    #         msg = "Early return. self.diff_create_update is empty."
+    #         self.log.debug(msg)
+    #         return
+
+    #     # Determine if using bulk API
+    #     use_bulk_api = (self.dcnm_version == -1)
+        
+    #     msg = f"Using {'v2 bulk-update' if use_bulk_api else 'individual update'} API"
+    #     self.log.debug(msg)
+
+    #     # Initialize based on API type
+    #     if use_bulk_api:
+    #         bulk_payload = []
+    #         action = "bulk_update"
+    #         verb = "PUT"
+    #         path = self.paths["UPDATE_VRF_BULK"]
+    #     else:
+    #         action = "create"
+    #         verb = "PUT"
+    #         base_path = self.paths["GET_VRF"].format(self.fabric)
+
+    #     # Process each VRF
+    #     for vrf in self.diff_create_update:
+    #         # Parse JSON string template config (common to both)
+    #         json_to_dict = json.loads(vrf["vrfTemplateConfig"])
+    #         vrf_name = json_to_dict.get("vrfName")
+            
+    #         msg = f"Processing VRF {vrf_name}"
+    #         self.log.debug(msg)
+
+    #         msg = f"VRF {vrf_name} template config: "
+    #         msg += f"{json.dumps(json_to_dict, indent=4, sort_keys=True)}"
+    #         self.log.debug(msg)
+
+    #         # Handle VLAN ID auto-allocation (common to both)
+    #         vlan_id = json_to_dict.get("vrfVlanId", 0)
+    #         if vlan_id == 0:
+    #             msg = f"VRF {vrf_name}: auto-allocating VLAN ID"
+    #             self.log.debug(msg)
+                
+    #             vlan_path = self.paths["GET_VLAN"].format(self.fabric)
+    #             vlan_data = dcnm_send(self.module, "GET", vlan_path)
+
+    #             if vlan_data["RETURN_CODE"] != 200:
+    #                 msg = f"{self.class_name}.{method_name}: "
+    #                 msg += f"caller: {caller}, "
+    #                 msg += f"vrf_name: {vrf_name}. "
+    #                 msg += f"Failure getting autogenerated vlan_id {vlan_data}"
+    #                 self.module.fail_json(msg=msg)
+
+    #             vlan_id = vlan_data["DATA"]
+    #             json_to_dict["vrfVlanId"] = vlan_id
+                
+    #             msg = f"VRF {vrf_name}: allocated VLAN ID {vlan_id}"
+    #             self.log.debug(msg)
+
+    #         # Build payload based on API type
+    #         if use_bulk_api:
+    #             # Bulk API: vrfTemplateConfig as dict, exclude serviceVrfTemplate/source
+    #             vrf_obj = {
+    #                 "fabric": vrf["fabric"],
+    #                 "vrfName": vrf["vrfName"],
+    #                 "vrfId": vrf["vrfId"],
+    #                 "vrfTemplate": vrf["vrfTemplate"],
+    #                 "vrfExtensionTemplate": vrf["vrfExtensionTemplate"],
+    #                 "vrfTemplateConfig": json_to_dict  # Dict object
+    #             }
+                
+    #             msg = f"VRF {vrf_name} bulk payload: "
+    #             msg += f"{json.dumps(vrf_obj, indent=4, sort_keys=True)}"
+    #             self.log.debug(msg)
+                
+    #             bulk_payload.append(vrf_obj)
+    #         else:
+    #             # Individual API: vrfTemplateConfig as JSON string, keep all fields
+    #             vrf["vrfTemplateConfig"] = json.dumps(json_to_dict)
+    #             update_path = f"{base_path}/{vrf['vrfName']}"
+                
+    #             msg = f"Sending individual update for VRF {vrf_name}"
+    #             self.log.debug(msg)
+                
+    #             self.send_to_controller(
+    #                 action,
+    #                 verb,
+    #                 update_path,
+    #                 vrf,
+    #                 log_response=True,
+    #                 is_rollback=is_rollback,
+    #             )
+
+    #     # Send bulk request if using bulk API
+    #     if use_bulk_api and bulk_payload:
+    #         msg = f"Sending v2 bulk-update request with {len(bulk_payload)} VRF(s)"
+    #         self.log.debug(msg)
+            
+    #         msg = "Complete bulk update payload: "
+    #         msg += f"{json.dumps(bulk_payload, indent=4, sort_keys=True)}"
+    #         self.log.debug(msg)
+            
+    #         self.send_to_controller(
+    #             action,
+    #             verb,
+    #             path,
+    #             bulk_payload,
+    #             log_response=True,
+    #             is_rollback=is_rollback,
+    #         )
     def push_diff_detach(self, is_rollback=False):
         """
         # Summary

--- a/plugins/modules/dcnm_vrf.py
+++ b/plugins/modules/dcnm_vrf.py
@@ -1082,7 +1082,11 @@ class DcnmVrf:
         self.conf_changed = {}
         self.check_mode = False
         self.have_create = []
+        # OPT-03: O(1) lookup dicts populated by get_have()
+        self.have_create_by_name = {}
         self.want_create = []
+        # OPT-03: O(1) lookup dict populated by get_want()
+        self.want_create_by_name = {}
         self.diff_create = []
         self.diff_create_update = []
         # self.diff_create_quick holds all the create payloads which are
@@ -1093,6 +1097,8 @@ class DcnmVrf:
         self.diff_create_quick = []
         self.vrf_sn_attach_map = {}
         self.have_attach = []
+        # OPT-03: O(1) lookup dict populated by get_have()
+        self.have_attach_by_name = {}
         self.want_attach = []
         self.diff_attach = []
         self.validated = []
@@ -2154,8 +2160,34 @@ class DcnmVrf:
         if not vrf_objects.get("DATA"):
             return
 
-        for vrf in vrf_objects["DATA"]:
+        # OPT-01 / OPT-02: Targeted fetch — when the state is merged, replaced,
+        # or deleted AND the playbook provides an explicit config list, restrict
+        # the attachment query to only the VRFs named in the playbook.  The full-
+        # fabric sweep is preserved for overridden, query, and deleted-without-config.
+        targeted_states = {"merged", "replaced", "deleted"}
+        if self.state in targeted_states and self.config:
+            wanted_vrf_names = {vrf.get("vrf_name") for vrf in self.config if vrf.get("vrf_name")}
+            vrf_data_to_process = [v for v in vrf_objects["DATA"] if v["vrfName"] in wanted_vrf_names]
+            msg = (
+                f"Targeted get_have() for state '{self.state}': "
+                f"requesting attachments for {len(vrf_data_to_process)} of "
+                f"{len(vrf_objects['DATA'])} fabric VRFs."
+            )
+            self.log.debug(msg)
+        else:
+            vrf_data_to_process = vrf_objects["DATA"]
+
+        for vrf in vrf_data_to_process:
             curr_vrfs += vrf["vrfName"] + ","
+
+        if not curr_vrfs:
+            # All wanted VRFs are new (not on controller yet) — nothing to fetch.
+            self.have_create = have_create
+            self.have_attach = []
+            self.have_deploy = have_deploy
+            self.chg_deploy = chg_deploy
+            self.vrf_sn_attach_map = vrf_sn_attach_map
+            return
 
         vrf_attach_objects = dcnm_get_url(
             self.module,
@@ -2173,7 +2205,7 @@ class DcnmVrf:
                 vrf_attach_objects.get("DATA")
             )
 
-        for vrf in vrf_objects["DATA"]:
+        for vrf in vrf_data_to_process:
             json_to_dict = json.loads(vrf["vrfTemplateConfig"])
             t_conf = {
                 "vrfSegmentId": vrf["vrfId"],
@@ -2385,6 +2417,9 @@ class DcnmVrf:
 
         self.have_create = have_create
         self.have_attach = have_attach
+        # OPT-03: Build O(1) lookup dicts for use in diff methods.
+        self.have_create_by_name = {v["vrfName"]: v for v in have_create}
+        self.have_attach_by_name = {a["vrfName"]: a for a in have_attach}
         self.have_deploy = have_deploy
         self.chg_deploy = chg_deploy
         self.vrf_sn_attach_map = vrf_sn_attach_map
@@ -2483,6 +2518,8 @@ class DcnmVrf:
             want_deploy.update({"vrfNames": vrf_names})
 
         self.want_create = copy.deepcopy(want_create)
+        # OPT-03: O(1) lookup dict for want_create
+        self.want_create_by_name = {v["vrfName"]: v for v in self.want_create}
         self.want_attach = copy.deepcopy(want_attach)
         self.want_deploy = copy.deepcopy(want_deploy)
         self.vrf_sn_attach_map = vrf_sn_attach_map
@@ -2545,17 +2582,15 @@ class DcnmVrf:
 
             for want_c in self.want_create:
 
-                if not self.find_dict_in_list_by_key_value(
-                    search=self.have_create, key="vrfName", value=want_c["vrfName"]
-                ):
+                # OPT-03: O(1) lookup instead of find_dict_in_list_by_key_value
+                if want_c["vrfName"] not in self.have_create_by_name:
                     continue
 
                 diff_delete.update({want_c["vrfName"]: "DEPLOYED"})
 
                 if self.action_fabric_type != "multisite_child" and self.action_fabric_type != "multicluster_child":
-                    have_a = self.find_dict_in_list_by_key_value(
-                        search=self.have_attach, key="vrfName", value=want_c["vrfName"]
-                    )
+                    # OPT-03: O(1) lookup instead of find_dict_in_list_by_key_value
+                    have_a = self.have_attach_by_name.get(want_c["vrfName"])
 
                     if not have_a:
                         continue
@@ -2567,7 +2602,8 @@ class DcnmVrf:
                         all_vrfs.append(have_a["vrfName"])
 
             if len(all_vrfs) != 0 and self.action_fabric_type != "multisite_child" and self.action_fabric_type != "multicluster_child":
-                diff_undeploy.update({"vrfNames": ",".join(all_vrfs)})
+                # OPT-09: deduplicate before joining
+                diff_undeploy.update({"vrfNames": ",".join(sorted(set(all_vrfs)))})
 
         else:
             if self.action_fabric_type != "multisite_child" and self.action_fabric_type != "multicluster_child":
@@ -2580,7 +2616,8 @@ class DcnmVrf:
 
                     diff_delete.update({have_a["vrfName"]: "DEPLOYED"})
                 if len(all_vrfs) != 0:
-                    diff_undeploy.update({"vrfNames": ",".join(all_vrfs)})
+                    # OPT-09: deduplicate before joining
+                    diff_undeploy.update({"vrfNames": ",".join(sorted(set(all_vrfs)))})
 
         self.diff_detach = diff_detach
         self.diff_undeploy = diff_undeploy
@@ -2614,9 +2651,8 @@ class DcnmVrf:
         diff_undeploy = self.diff_undeploy
 
         for have_a in self.have_attach:
-            found = self.find_dict_in_list_by_key_value(
-                search=self.want_create, key="vrfName", value=have_a["vrfName"]
-            )
+            # OPT-03: O(1) lookup instead of find_dict_in_list_by_key_value
+            found = self.want_create_by_name.get(have_a["vrfName"])
 
             detach_list = []
             if not found:
@@ -2636,7 +2672,8 @@ class DcnmVrf:
                 diff_delete.update({have_a["vrfName"]: "DEPLOYED"})
 
         if len(all_vrfs) != 0 and self.action_fabric_type != "multisite_child" and self.action_fabric_type != "multicluster_child":
-            diff_undeploy.update({"vrfNames": ",".join(all_vrfs)})
+            # OPT-09: deduplicate before joining
+            diff_undeploy.update({"vrfNames": ",".join(sorted(set(all_vrfs)))})
 
         self.diff_delete = diff_delete
         self.diff_detach = diff_detach
@@ -2695,9 +2732,8 @@ class DcnmVrf:
                     break
 
             if not h_in_w:
-                found = self.find_dict_in_list_by_key_value(
-                    search=self.want_create, key="vrfName", value=have_a["vrfName"]
-                )
+                # OPT-03: O(1) lookup instead of find_dict_in_list_by_key_value
+                found = self.want_create_by_name.get(have_a["vrfName"])
 
                 if found:
                     atch_h = have_a["lanAttachList"]
@@ -2833,33 +2869,34 @@ class DcnmVrf:
         payload_list = []
 
         for want_c in self.want_create:
-            vrf_found = False
-            for have_c in self.have_create:
-                if want_c["vrfName"] == have_c["vrfName"]:
-                    vrf_found = True
-                    msg = "Calling diff_for_create with: "
-                    msg += f"want_c: {json.dumps(want_c, indent=4, sort_keys=True)}, "
-                    msg += f"have_c: {json.dumps(have_c, indent=4, sort_keys=True)}"
+            # OPT-03: O(1) lookup instead of inner for-loop over self.have_create
+            have_c = self.have_create_by_name.get(want_c["vrfName"])
+            if have_c is not None:
+                vrf_found = True
+                msg = "Calling diff_for_create with: "
+                msg += f"want_c: {json.dumps(want_c, indent=4, sort_keys=True)}, "
+                msg += f"have_c: {json.dumps(have_c, indent=4, sort_keys=True)}"
+                self.log.debug(msg)
+
+                diff, conf_chg = self.diff_for_create(want_c, have_c)
+
+                msg = "diff_for_create() returned with: "
+                msg += f"conf_chg {conf_chg}, "
+                msg += f"diff {json.dumps(diff, indent=4, sort_keys=True)}, "
+                self.log.debug(msg)
+
+                msg = f"Updating self.conf_changed[{want_c['vrfName']}] "
+                msg += f"with {conf_chg}"
+                self.log.debug(msg)
+                self.conf_changed.update({want_c["vrfName"]: conf_chg})
+
+                if diff:
+                    msg = "Appending diff_create_update with "
+                    msg += f"{json.dumps(diff, indent=4, sort_keys=True)}"
                     self.log.debug(msg)
-
-                    diff, conf_chg = self.diff_for_create(want_c, have_c)
-
-                    msg = "diff_for_create() returned with: "
-                    msg += f"conf_chg {conf_chg}, "
-                    msg += f"diff {json.dumps(diff, indent=4, sort_keys=True)}, "
-                    self.log.debug(msg)
-
-                    msg = f"Updating self.conf_changed[{want_c['vrfName']}] "
-                    msg += f"with {conf_chg}"
-                    self.log.debug(msg)
-                    self.conf_changed.update({want_c["vrfName"]: conf_chg})
-
-                    if diff:
-                        msg = "Appending diff_create_update with "
-                        msg += f"{json.dumps(diff, indent=4, sort_keys=True)}"
-                        self.log.debug(msg)
-                        diff_create_update.append(diff)
-                    break
+                    diff_create_update.append(diff)
+            else:
+                vrf_found = False
 
             if not vrf_found:
                 vrf_id = want_c.get("vrfId", None)
@@ -3027,28 +3064,29 @@ class DcnmVrf:
                 continue
             deploy_vrf = ""
             attach_found = False
-            for have_a in self.have_attach:
-                if want_a["vrfName"] == have_a["vrfName"]:
-                    attach_found = True
-                    diff, deploy_vrf_bool = self.diff_for_attach_deploy(
-                        want_a["lanAttachList"], have_a["lanAttachList"], replace
-                    )
-                    if diff:
-                        base = want_a.copy()
-                        del base["lanAttachList"]
-                        base.update({"lanAttachList": diff})
+            # OPT-03: O(1) lookup instead of inner for-loop over self.have_attach
+            have_a = self.have_attach_by_name.get(want_a["vrfName"])
+            if have_a is not None:
+                attach_found = True
+                diff, deploy_vrf_bool = self.diff_for_attach_deploy(
+                    want_a["lanAttachList"], have_a["lanAttachList"], replace
+                )
+                if diff:
+                    base = want_a.copy()
+                    del base["lanAttachList"]
+                    base.update({"lanAttachList": diff})
 
-                        diff_attach.append(base)
-                        if (want_config["deploy"] is True) and (
-                            deploy_vrf_bool is True
-                        ):
-                            deploy_vrf = want_a["vrfName"]
-                    else:
-                        if want_config["deploy"] is True and (
-                            deploy_vrf_bool
-                            or self.conf_changed.get(want_a["vrfName"], False)
-                        ):
-                            deploy_vrf = want_a["vrfName"]
+                    diff_attach.append(base)
+                    if (want_config["deploy"] is True) and (
+                        deploy_vrf_bool is True
+                    ):
+                        deploy_vrf = want_a["vrfName"]
+                else:
+                    if want_config["deploy"] is True and (
+                        deploy_vrf_bool
+                        or self.conf_changed.get(want_a["vrfName"], False)
+                    ):
+                        deploy_vrf = want_a["vrfName"]
 
             msg = f"attach_found: {attach_found}"
             self.log.debug(msg)
@@ -3369,140 +3407,153 @@ class DcnmVrf:
 
         if self.config:
             query = []
+
+            # OPT-04: Single bulk GET_VRF_ATTACH instead of one call per VRF.
+            # Build a name→vrf_object dict for O(1) lookup and collect the VRF
+            # names that are both wanted and present on the controller.
+            vrf_objs_by_name = {v["vrfName"]: v for v in vrf_objects["DATA"]}
+            wanted_names = [
+                wc["vrfName"]
+                for wc in self.want_create
+                if wc["vrfName"] in vrf_objs_by_name
+            ]
+
+            if wanted_names:
+                bulk_path = self.paths["GET_VRF_ATTACH"].format(
+                    self.fabric, ",".join(wanted_names)
+                )
+                bulk_attach_objects = dcnm_send(self.module, "GET", bulk_path)
+                missing_fabric, not_ok = self.handle_response(
+                    bulk_attach_objects, "query_dcnm"
+                )
+                if missing_fabric or not_ok:
+                    msg0 = f"{self.class_name}.{method_name}: caller: {caller}. "
+                    msg1 = f"{msg0} Fabric {self.fabric} not present on the controller"
+                    msg2 = f"{msg0} Unable to find attachments for vrfs: "
+                    msg2 += f"{wanted_names} under fabric: {self.fabric}"
+                    self.module.fail_json(msg=msg1 if missing_fabric else msg2)
+
+                if self.action_fabric_type == "multicluster_parent":
+                    bulk_attach_objects["DATA"] = sanitize_lan_attach_list(
+                        bulk_attach_objects.get("DATA")
+                    )
+
+                # Index attachment records by vrfName for O(1) lookup below
+                attach_by_vrf = {}
+                for rec in (bulk_attach_objects.get("DATA") or []):
+                    attach_by_vrf.setdefault(rec["vrfName"], []).append(rec)
+            else:
+                attach_by_vrf = {}
+
             for want_c in self.want_create:
-                # Query the VRF
-                for vrf in vrf_objects["DATA"]:
+                vrf = vrf_objs_by_name.get(want_c["vrfName"])
+                if vrf is None:
+                    continue
 
-                    if want_c["vrfName"] == vrf["vrfName"]:
+                item = {"parent": {}, "attach": []}
+                item["parent"] = vrf
 
-                        item = {"parent": {}, "attach": []}
-                        item["parent"] = vrf
+                vrf_attach_records = attach_by_vrf.get(want_c["vrfName"], [])
 
-                        # Query the Attachment for the found VRF
-                        path = self.paths["GET_VRF_ATTACH"].format(
-                            self.fabric, vrf["vrfName"]
+                for vrf_attach in vrf_attach_records:
+                    if not vrf_attach.get("lanAttachList"):
+                        continue
+                    attach_list = vrf_attach["lanAttachList"]
+
+                    for attach in attach_list:
+                        # copy attach and update it with the keys that
+                        # get_vrf_lite_objects() expects.
+                        attach_copy = copy.deepcopy(attach)
+                        attach_copy.update({"fabric": self.fabric})
+                        attach_copy.update(
+                            {"serialNumber": attach["switchSerialNo"]}
                         )
 
-                        vrf_attach_objects = dcnm_send(self.module, "GET", path)
-
-                        missing_fabric, not_ok = self.handle_response(
-                            vrf_attach_objects, "query_dcnm"
-                        )
-
-                        if missing_fabric or not_ok:
-                            # arobel: TODO: Not covered by UT
-                            msg0 = f"{self.class_name}.{method_name}:"
-                            msg0 += f"caller: {caller}. "
-                            msg1 = f"{msg0} Fabric {self.fabric} not present on the controller"
-                            msg2 = f"{msg0} Unable to find attachments for "
-                            msg2 += f"vrfs: {vrf['vrfName']} under "
-                            msg2 += f"fabric: {self.fabric}"
-                            self.module.fail_json(msg=msg1 if missing_fabric else msg2)
-
-                        if not vrf_attach_objects["DATA"]:
-                            return
-
-                        if self.action_fabric_type == "multicluster_parent":
-                            vrf_attach_objects["DATA"] = sanitize_lan_attach_list(
-                                vrf_attach_objects.get("DATA")
+                        # Only call get_vrf_lite_objects() if VRF-Lite is configured
+                        # in the playbook to avoid expensive API calls
+                        use_minimal_attach = True
+                        if self._has_vrf_lite_in_config(want_c["vrfName"]):
+                            lite_objects = self.get_vrf_lite_objects(
+                                attach_copy
                             )
+                            # Check if DATA exists and is not empty
+                            has_lite_data = (
+                                lite_objects.get("DATA") is not None
+                                and len(lite_objects.get("DATA", [])) > 0
+                            )
+                            if has_lite_data:
+                                # VRF Lite extensions exist - use API response but ensure vlan field is correct
+                                use_minimal_attach = False
+                                lite_attach = lite_objects.get("DATA")[0]
+                                # The vlan field should be the VRF's L3VNI vlan, not the dot1q
+                                vlan_id = attach.get("vlanId")
+                                vlan_str = str(vlan_id) if vlan_id is not None else ""
+                                msg = f"Fixing vlan field in VRF lite attach for switch {attach['switchSerialNo']}: "
+                                msg += f"vlanId={vlan_id}, setting vlan={vlan_str}"
+                                self.log.debug(msg)
+                                # Update vlan in all switchDetailsList entries
+                                if lite_attach.get("switchDetailsList"):
+                                    for switch_detail in lite_attach["switchDetailsList"]:
+                                        switch_detail["vlan"] = vlan_str
+                                item["attach"].append(lite_attach)
+                            else:
+                                # No VRF Lite extensions found - will use minimal attach
+                                msg = f"No VRF Lite extensions found for switch {attach['switchSerialNo']}"
+                                self.log.debug(msg)
 
-                        for vrf_attach in vrf_attach_objects["DATA"]:
-                            if want_c["vrfName"] == vrf_attach["vrfName"]:
-                                if not vrf_attach.get("lanAttachList"):
-                                    continue
-                                attach_list = vrf_attach["lanAttachList"]
-
-                                for attach in attach_list:
-                                    # copy attach and update it with the keys that
-                                    # get_vrf_lite_objects() expects.
-                                    attach_copy = copy.deepcopy(attach)
-                                    attach_copy.update({"fabric": self.fabric})
-                                    attach_copy.update(
-                                        {"serialNumber": attach["switchSerialNo"]}
-                                    )
-
-                                    # Only call get_vrf_lite_objects() if VRF-Lite is configured
-                                    # in the playbook to avoid expensive API calls
-                                    use_minimal_attach = True
-                                    if self._has_vrf_lite_in_config(want_c["vrfName"]):
-                                        lite_objects = self.get_vrf_lite_objects(
-                                            attach_copy
-                                        )
-                                        # Check if DATA exists and is not empty
-                                        has_lite_data = (
-                                            lite_objects.get("DATA") is not None
-                                            and len(lite_objects.get("DATA", [])) > 0
-                                        )
-                                        if has_lite_data:
-                                            # VRF Lite extensions exist - use API response but ensure vlan field is correct
-                                            use_minimal_attach = False
-                                            lite_attach = lite_objects.get("DATA")[0]
-                                            # The vlan field should be the VRF's L3VNI vlan, not the dot1q
-                                            vlan_id = attach.get("vlanId")
-                                            vlan_str = str(vlan_id) if vlan_id is not None else ""
-                                            msg = f"Fixing vlan field in VRF lite attach for switch {attach['switchSerialNo']}: "
-                                            msg += f"vlanId={vlan_id}, setting vlan={vlan_str}"
-                                            self.log.debug(msg)
-                                            # Update vlan in all switchDetailsList entries
-                                            if lite_attach.get("switchDetailsList"):
-                                                for switch_detail in lite_attach["switchDetailsList"]:
-                                                    switch_detail["vlan"] = vlan_str
-                                            item["attach"].append(lite_attach)
-                                        else:
-                                            # No VRF Lite extensions found - will use minimal attach
-                                            msg = f"No VRF Lite extensions found for switch {attach['switchSerialNo']}"
-                                            self.log.debug(msg)
-
-                                    # Use minimal attach structure when:
-                                    # 1. VRF-Lite is not configured in playbook, OR
-                                    # 2. VRF-Lite is configured but no extensions exist on controller
-                                    if use_minimal_attach:
-                                        # Ensure extensionValues is set to empty string when no VRF Lite
-                                        attach["extensionValues"] = ""
-                                        minimal_attach = {
-                                            "fabric": self.fabric,
-                                            "vrfName": want_c["vrfName"],
-                                            "serialNumber": attach["switchSerialNo"],
-                                            "switchDetailsList": [attach]
-                                        }
-                                        item["attach"].append(minimal_attach)
-                                query.append(item)
+                        # Use minimal attach structure when:
+                        # 1. VRF-Lite is not configured in playbook, OR
+                        # 2. VRF-Lite is configured but no extensions exist on controller
+                        if use_minimal_attach:
+                            # Ensure extensionValues is set to empty string when no VRF Lite
+                            attach["extensionValues"] = ""
+                            minimal_attach = {
+                                "fabric": self.fabric,
+                                "vrfName": want_c["vrfName"],
+                                "serialNumber": attach["switchSerialNo"],
+                                "switchDetailsList": [attach]
+                            }
+                            item["attach"].append(minimal_attach)
+                query.append(item)
 
         else:
             query = []
+
+            # OPT-05: Single bulk GET_VRF_ATTACH for all fabric VRFs instead of
+            # one API call per VRF in the loop.
+            all_vrf_names = ",".join(v["vrfName"] for v in vrf_objects["DATA"])
+            bulk_path = self.paths["GET_VRF_ATTACH"].format(
+                self.fabric, all_vrf_names
+            )
+            bulk_attach_objects = dcnm_send(self.module, "GET", bulk_path)
+            missing_fabric, not_ok = self.handle_response(
+                bulk_attach_objects, "query_dcnm"
+            )
+            if missing_fabric or not_ok:
+                msg0 = f"caller: {caller}. "
+                msg1 = f"{msg0} Fabric {self.fabric} not present on DCNM"
+                msg2 = f"{msg0} Unable to find attachments for "
+                msg2 += f"vrfs under fabric: {self.fabric}"
+                self.module.fail_json(msg=msg1 if missing_fabric else msg2)
+
+            if self.action_fabric_type == "multicluster_parent":
+                bulk_attach_objects["DATA"] = sanitize_lan_attach_list(
+                    bulk_attach_objects.get("DATA")
+                )
+
+            # Index attachment records by vrfName
+            attach_by_vrf = {}
+            for rec in (bulk_attach_objects.get("DATA") or []):
+                attach_by_vrf.setdefault(rec["vrfName"], []).append(rec)
+
             # Query the VRF
             for vrf in vrf_objects["DATA"]:
                 item = {"parent": {}, "attach": []}
                 item["parent"] = vrf
 
-                # Query the Attachment for the found VRF
-                path = self.paths["GET_VRF_ATTACH"].format(self.fabric, vrf["vrfName"])
+                vrf_attach_records = attach_by_vrf.get(vrf["vrfName"], [])
 
-                vrf_attach_objects = dcnm_send(self.module, "GET", path)
-
-                missing_fabric, not_ok = self.handle_response(vrf_objects, "query_dcnm")
-
-                if missing_fabric or not_ok:
-                    msg0 = f"caller: {caller}. "
-                    msg1 = f"{msg0} Fabric {self.fabric} not present on DCNM"
-                    msg2 = f"{msg0} Unable to find attachments for "
-                    msg2 += f"vrfs: {vrf['vrfName']} under fabric: {self.fabric}"
-
-                    self.module.fail_json(msg=msg1 if missing_fabric else msg2)
-                    # TODO: add a _pylint_: disable=inconsistent-return
-                    # at the top and remove this return
-                    return
-
-                if not vrf_attach_objects["DATA"]:
-                    return
-
-                if self.action_fabric_type == "multicluster_parent":
-                    vrf_attach_objects["DATA"] = sanitize_lan_attach_list(
-                        vrf_attach_objects.get("DATA")
-                    )
-
-                for vrf_attach in vrf_attach_objects["DATA"]:
+                for vrf_attach in vrf_attach_records:
                     if not vrf_attach.get("lanAttachList"):
                         continue
                     attach_list = vrf_attach["lanAttachList"]
@@ -3551,7 +3602,7 @@ class DcnmVrf:
                                 for switch_detail in lite_attach["switchDetailsList"]:
                                     switch_detail["vlan"] = vlan_str
                             item["attach"].append(lite_attach)
-                    query.append(item)
+                query.append(item)
 
         self.query = query
 
@@ -4860,6 +4911,32 @@ class DcnmVrf:
             ok_to_delete = False
             path = self.paths["GET_VRF_ATTACH"].format(self.fabric, vrf)
             retry_count = max(500 // self.WAIT_TIME_FOR_DELETE_LOOP, 1)
+
+            # OPT-06: Initial quick-scan pass — check if VRF is already in a
+            # terminal state before entering the polling while-loop.
+            resp = dcnm_send(self.module, "GET", path)
+            if resp.get("DATA") is not None:
+                if self.action_fabric_type == "multicluster_parent":
+                    sanitized_data = sanitize_lan_attach_list(resp["DATA"])
+                    attach_list = sanitized_data[0]["lanAttachList"]
+                else:
+                    attach_list = resp["DATA"][0]["lanAttachList"]
+
+                initial_ready = True
+                for attach in attach_list:
+                    state = attach["lanAttachState"]
+                    if state in ("OUT-OF-SYNC", "FAILED"):
+                        self.diff_delete.update({vrf: "OUT-OF-SYNC"})
+                        ok_to_delete = True
+                        initial_ready = True
+                        break
+                    if state != "NA":
+                        initial_ready = False
+                        break
+                    self.diff_delete.update({vrf: "NA"})
+                if initial_ready:
+                    continue  # already in terminal state — skip polling loop
+
             while not ok_to_delete:
                 resp = dcnm_send(self.module, "GET", path)
                 ok_to_delete = True
@@ -5400,12 +5477,17 @@ class DcnmVrf:
         # to the have state whenever there is a failure in any of the APIs.
         # The idea would be to run overridden state with want=have and have=dcnm_state
         self.want_create = self.have_create
+        # OPT-03: rebuild lookup dict to match reassigned want_create
+        self.want_create_by_name = {v["vrfName"]: v for v in self.want_create}
         self.want_attach = self.have_attach
         self.want_deploy = self.have_deploy
 
         self.have_create = []
         self.have_attach = []
         self.have_deploy = {}
+        # OPT-03: reset have lookup dicts; get_have() will rebuild them
+        self.have_create_by_name = {}
+        self.have_attach_by_name = {}
         self.get_have()
         self.get_diff_override()
 

--- a/plugins/modules/dcnm_vrf.py
+++ b/plugins/modules/dcnm_vrf.py
@@ -1025,7 +1025,7 @@ from ansible_collections.cisco.dcnm.plugins.module_utils.network.dcnm.dcnm impor
     dcnm_get_bulk_api_support, dcnm_get_ip_addr_info, dcnm_get_url, dcnm_send, dcnm_version_supported,
     get_nd_fabric_details, get_nd_fabric_inventory_details, get_ip_sn_dict,
     get_sn_fabric_dict, validate_list_of_dicts, search_nested_json,
-    find_dict_in_list_by_key_value, sanitize_lan_attach_list)
+    sanitize_lan_attach_list)
 
 from ..module_utils.common.log_v2 import Log
 

--- a/tests/integration/targets/dcnm_network/tests/dcnm/standalone/merged.yaml
+++ b/tests/integration/targets/dcnm_network/tests/dcnm/standalone/merged.yaml
@@ -933,6 +933,153 @@
       - result.changed == false
   tags: merged
 
+# TC13
+# Regression: merged TOR-only updates must preserve existing TOR ports even
+# when the playbook omits leaf-side attachment ports.
+- name: MERGED - TC13 - DELETED - Clean up any existing network
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ test_data_common.fabric }}"
+    state: deleted
+  tags: merged
+
+- name: MERGED - TC13 - MERGED - Create network with TOR-only attachment
+  cisco.dcnm.dcnm_network: &conf6
+    fabric: "{{ test_data_common.fabric }}"
+    state: merged
+    config:
+      - net_name: ansible-net13
+        vrf_name: Tenant-1
+        net_id: 7005
+        net_template: Default_Network_Universal
+        net_extension_template: Default_Network_Extension_Universal
+        vlan_id: 1500
+        gw_ip_subnet: '192.168.30.1/24'
+        attach:
+          - ip_address: "{{ ansible_switch1 }}"
+          - ip_address: "{{ ansible_switch2 }}"
+            tor_ports:
+              - ip_address: "{{ ansible_tor_switch1 }}"
+                ports: ["{{ ansible_tor_int1 }}"]
+        deploy: false
+  register: result
+  tags: merged
+
+- name: MERGED - TC13 - ASSERT - Check initial TOR-only merge result
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.response[0].RETURN_CODE == 200
+      - result.response[1].RETURN_CODE == 200
+  tags: merged
+
+- name: MERGED - TC13 - QUERY - Wait for initial TOR-only attachment state
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ test_data_common.fabric }}"
+    state: query
+  register: verify_result
+  until:
+    - "verify_result.response[0].parent.networkStatus is search('DEPLOYED|PENDING')"
+  retries: 30
+  delay: 2
+  tags: merged
+
+- name: MERGED - TC13 - Capture initial switch2 TOR port names
+  ansible.builtin.set_fact:
+    merged_tc13_switch2_port_names: >-
+      {{ (verify_result.response[0].attach
+      | selectattr('ipAddress', 'equalto', ansible_switch2)
+      | map(attribute='portNames')
+      | first) | default('') }}
+  delegate_to: localhost
+  tags: merged
+
+- name: MERGED - TC13 - ASSERT - Verify initial TOR-only attachment in NDFC
+  ansible.builtin.assert:
+    that:
+      - "'{{ ansible_tor_int1 }}' in merged_tc13_switch2_port_names"
+  tags: merged
+
+- name: MERGED - TC13 - MERGED - Add second TOR port without leaf ports
+  cisco.dcnm.dcnm_network: &conf7
+    fabric: "{{ test_data_common.fabric }}"
+    state: merged
+    config:
+      - net_name: ansible-net13
+        vrf_name: Tenant-1
+        net_id: 7005
+        net_template: Default_Network_Universal
+        net_extension_template: Default_Network_Extension_Universal
+        vlan_id: 1500
+        gw_ip_subnet: '192.168.30.1/24'
+        attach:
+          - ip_address: "{{ ansible_switch1 }}"
+          - ip_address: "{{ ansible_switch2 }}"
+            tor_ports:
+              - ip_address: "{{ ansible_tor_switch1 }}"
+                ports: ["{{ ansible_tor_int2 }}"]
+        deploy: false
+  register: result
+  tags: merged
+
+- name: MERGED - TC13 - Capture merged TOR port diff
+  ansible.builtin.set_fact:
+    merged_tc13_diff_tor_ports: >-
+      {{ (result.diff[0].attach
+      | selectattr('ip_address', 'equalto', ansible_switch2)
+      | map(attribute='tor_ports')
+      | first) | default('') }}
+  delegate_to: localhost
+  tags: merged
+
+- name: MERGED - TC13 - ASSERT - Verify merged diff preserves existing TOR ports
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.response[0].RETURN_CODE == 200
+      - "'{{ ansible_tor_int1 }}' in merged_tc13_diff_tor_ports"
+      - "'{{ ansible_tor_int2 }}' in merged_tc13_diff_tor_ports"
+  tags: merged
+
+- name: MERGED - TC13 - QUERY - Wait for merged TOR-only attachment state
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ test_data_common.fabric }}"
+    state: query
+  register: verify_result
+  until:
+    - "verify_result.response[0].parent.networkStatus is search('DEPLOYED|PENDING')"
+  retries: 30
+  delay: 2
+  tags: merged
+
+- name: MERGED - TC13 - Capture updated switch2 TOR port names
+  ansible.builtin.set_fact:
+    merged_tc13_switch2_port_names: >-
+      {{ (verify_result.response[0].attach
+      | selectattr('ipAddress', 'equalto', ansible_switch2)
+      | map(attribute='portNames')
+      | first) | default('') }}
+  delegate_to: localhost
+  tags: merged
+
+- name: MERGED - TC13 - ASSERT - Verify NDFC preserved both TOR ports
+  ansible.builtin.assert:
+    that:
+      - "'{{ ansible_tor_int1 }}' in merged_tc13_switch2_port_names"
+      - "'{{ ansible_tor_int2 }}' in merged_tc13_switch2_port_names"
+  tags: merged
+
+- name: MERGED - TC13 - conf7 - Idempotence
+  cisco.dcnm.dcnm_network: *conf7
+  register: result
+  tags: merged
+
+- name: MERGED - TC13 - ASSERT - Check if changed flag is false
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.response | length == 0
+  tags: merged
+
 ##############################################
 ##                 CLEAN-UP                 ##
 ##############################################

--- a/tests/integration/targets/dcnm_network/tests/dcnm/standalone/merged.yaml
+++ b/tests/integration/targets/dcnm_network/tests/dcnm/standalone/merged.yaml
@@ -934,8 +934,9 @@
   tags: merged
 
 # TC13
-# Regression: merged TOR-only updates must preserve existing TOR ports even
-# when the playbook omits leaf-side attachment ports.
+# Scenario 2: VPC leaf pair connected to a single TOR switch. Regression:
+# merged TOR-only updates must preserve existing TOR ports even when the
+# playbook omits leaf-side attachment ports.
 - name: MERGED - TC13 - DELETED - Clean up any existing network
   cisco.dcnm.dcnm_network:
     fabric: "{{ test_data_common.fabric }}"
@@ -1074,6 +1075,360 @@
   tags: merged
 
 - name: MERGED - TC13 - ASSERT - Check if changed flag is false
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.response | length == 0
+  tags: merged
+
+# TC14
+# Scenario 1: VPC leaf pair connected to a TOR pair. Keep this conditional so
+# the suite still runs in labs that only expose one TOR test switch.
+- block:
+    - name: MERGED - TC14 - DELETED - Clean up any existing network
+      cisco.dcnm.dcnm_network:
+        fabric: "{{ test_data_common.fabric }}"
+        state: deleted
+
+    - name: MERGED - TC14 - MERGED - Create network with VPC-to-TOR-pair attachment
+      cisco.dcnm.dcnm_network: &conf8
+        fabric: "{{ test_data_common.fabric }}"
+        state: merged
+        config:
+          - net_name: ansible-net14
+            vrf_name: Tenant-1
+            net_id: 7006
+            net_template: Default_Network_Universal
+            net_extension_template: Default_Network_Extension_Universal
+            vlan_id: 1501
+            gw_ip_subnet: '192.168.31.1/24'
+            attach:
+              - ip_address: "{{ ansible_switch1 }}"
+              - ip_address: "{{ ansible_switch2 }}"
+                tor_ports:
+                  - ip_address: "{{ merged_tc14_tor_switch1 }}"
+                    ports: ["{{ ansible_tor_int1 }}"]
+                  - ip_address: "{{ merged_tc14_tor_switch2 }}"
+                    ports: ["{{ ansible_tor_int1 }}"]
+            deploy: false
+      register: result
+
+    - name: MERGED - TC14 - ASSERT - Check initial TOR-pair merge result
+      ansible.builtin.assert:
+        that:
+          - result.changed == true
+          - result.response[0].RETURN_CODE == 200
+          - result.response[1].RETURN_CODE == 200
+
+    - name: MERGED - TC14 - QUERY - Wait for initial TOR-pair attachment state
+      cisco.dcnm.dcnm_network:
+        fabric: "{{ test_data_common.fabric }}"
+        state: query
+      register: verify_result
+      until:
+        - "verify_result.response[0].parent.networkStatus is search('DEPLOYED|PENDING')"
+      retries: 30
+      delay: 2
+
+    - name: MERGED - TC14 - Capture initial VPC peer TOR port names
+      ansible.builtin.set_fact:
+        merged_tc14_switch1_port_names: >-
+          {{ (verify_result.response[0].attach
+          | selectattr('ipAddress', 'equalto', ansible_switch1)
+          | map(attribute='portNames')
+          | first) | default('') }}
+        merged_tc14_switch2_port_names: >-
+          {{ (verify_result.response[0].attach
+          | selectattr('ipAddress', 'equalto', ansible_switch2)
+          | map(attribute='portNames')
+          | first) | default('') }}
+        merged_tc14_switch1_entries: >-
+          {{ ((verify_result.response[0].attach
+          | selectattr('ipAddress', 'equalto', ansible_switch1)
+          | map(attribute='portNames')
+          | first) | default('')) | regex_findall('\\S+\\([^)]*\\)') }}
+        merged_tc14_switch2_entries: >-
+          {{ ((verify_result.response[0].attach
+          | selectattr('ipAddress', 'equalto', ansible_switch2)
+          | map(attribute='portNames')
+          | first) | default('')) | regex_findall('\\S+\\([^)]*\\)') }}
+      delegate_to: localhost
+
+    - name: MERGED - TC14 - ASSERT - Verify both VPC peers carry both TOR attachments
+      ansible.builtin.assert:
+        that:
+          - merged_tc14_switch1_entries | length == 2
+          - merged_tc14_switch2_entries | length == 2
+          - "'{{ ansible_tor_int1 }}' in merged_tc14_switch1_port_names"
+          - "'{{ ansible_tor_int1 }}' in merged_tc14_switch2_port_names"
+
+    - name: MERGED - TC14 - MERGED - Add second TOR port on both TOR peers
+      cisco.dcnm.dcnm_network: &conf9
+        fabric: "{{ test_data_common.fabric }}"
+        state: merged
+        config:
+          - net_name: ansible-net14
+            vrf_name: Tenant-1
+            net_id: 7006
+            net_template: Default_Network_Universal
+            net_extension_template: Default_Network_Extension_Universal
+            vlan_id: 1501
+            gw_ip_subnet: '192.168.31.1/24'
+            attach:
+              - ip_address: "{{ ansible_switch1 }}"
+              - ip_address: "{{ ansible_switch2 }}"
+                tor_ports:
+                  - ip_address: "{{ merged_tc14_tor_switch1 }}"
+                    ports: ["{{ ansible_tor_int2 }}"]
+                  - ip_address: "{{ merged_tc14_tor_switch2 }}"
+                    ports: ["{{ ansible_tor_int2 }}"]
+            deploy: false
+      register: result
+
+    - name: MERGED - TC14 - Capture merged TOR-pair diff
+      ansible.builtin.set_fact:
+        merged_tc14_switch1_diff_tor_ports: >-
+          {{ (result.diff[0].attach
+          | selectattr('ip_address', 'equalto', ansible_switch1)
+          | map(attribute='tor_ports')
+          | first) | default('') }}
+        merged_tc14_switch2_diff_tor_ports: >-
+          {{ (result.diff[0].attach
+          | selectattr('ip_address', 'equalto', ansible_switch2)
+          | map(attribute='tor_ports')
+          | first) | default('') }}
+      delegate_to: localhost
+
+    - name: MERGED - TC14 - ASSERT - Verify merged diff preserves both TOR peers
+      ansible.builtin.assert:
+        that:
+          - result.changed == true
+          - result.response[0].RETURN_CODE == 200
+          - "'{{ ansible_tor_int1 }}' in merged_tc14_switch1_diff_tor_ports"
+          - "'{{ ansible_tor_int2 }}' in merged_tc14_switch1_diff_tor_ports"
+          - "'{{ ansible_tor_int1 }}' in merged_tc14_switch2_diff_tor_ports"
+          - "'{{ ansible_tor_int2 }}' in merged_tc14_switch2_diff_tor_ports"
+
+    - name: MERGED - TC14 - QUERY - Wait for merged TOR-pair attachment state
+      cisco.dcnm.dcnm_network:
+        fabric: "{{ test_data_common.fabric }}"
+        state: query
+      register: verify_result
+      until:
+        - "verify_result.response[0].parent.networkStatus is search('DEPLOYED|PENDING')"
+      retries: 30
+      delay: 2
+
+    - name: MERGED - TC14 - Capture updated VPC peer TOR port names
+      ansible.builtin.set_fact:
+        merged_tc14_switch1_port_names: >-
+          {{ (verify_result.response[0].attach
+          | selectattr('ipAddress', 'equalto', ansible_switch1)
+          | map(attribute='portNames')
+          | first) | default('') }}
+        merged_tc14_switch2_port_names: >-
+          {{ (verify_result.response[0].attach
+          | selectattr('ipAddress', 'equalto', ansible_switch2)
+          | map(attribute='portNames')
+          | first) | default('') }}
+        merged_tc14_switch1_entries: >-
+          {{ ((verify_result.response[0].attach
+          | selectattr('ipAddress', 'equalto', ansible_switch1)
+          | map(attribute='portNames')
+          | first) | default('')) | regex_findall('\\S+\\([^)]*\\)') }}
+        merged_tc14_switch2_entries: >-
+          {{ ((verify_result.response[0].attach
+          | selectattr('ipAddress', 'equalto', ansible_switch2)
+          | map(attribute='portNames')
+          | first) | default('')) | regex_findall('\\S+\\([^)]*\\)') }}
+      delegate_to: localhost
+
+    - name: MERGED - TC14 - ASSERT - Verify NDFC preserved both TOR peers and ports
+      ansible.builtin.assert:
+        that:
+          - merged_tc14_switch1_entries | length == 2
+          - merged_tc14_switch2_entries | length == 2
+          - "'{{ ansible_tor_int1 }}' in merged_tc14_switch1_port_names"
+          - "'{{ ansible_tor_int2 }}' in merged_tc14_switch1_port_names"
+          - "'{{ ansible_tor_int1 }}' in merged_tc14_switch2_port_names"
+          - "'{{ ansible_tor_int2 }}' in merged_tc14_switch2_port_names"
+
+    - name: MERGED - TC14 - conf9 - Idempotence
+      cisco.dcnm.dcnm_network: *conf9
+      register: result
+
+    - name: MERGED - TC14 - ASSERT - Check if changed flag is false
+      ansible.builtin.assert:
+        that:
+          - result.changed == false
+          - result.response | length == 0
+  vars:
+    merged_tc14_tor_pair_supported: "{{ ansible_tor_switch2 is defined }}"
+    merged_tc14_tor_switch1: "{{ ansible_tor_switch1 | default('') }}"
+    merged_tc14_tor_switch2: "{{ ansible_tor_switch2 | default('') }}"
+  when: merged_tc14_tor_pair_supported
+  tags: merged
+
+# TC15
+# Scenario 3: single leaf connected to a single TOR switch.
+- name: MERGED - TC15 - DELETED - Clean up any existing network
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ test_data_common.fabric }}"
+    state: deleted
+  tags: merged
+
+- name: MERGED - TC15 - MERGED - Create network with single-leaf TOR attachment
+  cisco.dcnm.dcnm_network: &conf10
+    fabric: "{{ test_data_common.fabric }}"
+    state: merged
+    config:
+      - net_name: ansible-net15
+        vrf_name: Tenant-1
+        net_id: 7007
+        net_template: Default_Network_Universal
+        net_extension_template: Default_Network_Extension_Universal
+        vlan_id: 1502
+        gw_ip_subnet: '192.168.32.1/24'
+        attach:
+          - ip_address: "{{ ansible_switch1 }}"
+            tor_ports:
+              - ip_address: "{{ ansible_tor_switch1 }}"
+                ports: ["{{ ansible_tor_int1 }}"]
+        deploy: false
+  register: result
+  tags: merged
+
+- name: MERGED - TC15 - ASSERT - Check initial single-leaf TOR merge result
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.response[0].RETURN_CODE == 200
+      - result.response[1].RETURN_CODE == 200
+  tags: merged
+
+- name: MERGED - TC15 - QUERY - Wait for initial single-leaf TOR attachment state
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ test_data_common.fabric }}"
+    state: query
+  register: verify_result
+  until:
+    - "verify_result.response[0].parent.networkStatus is search('DEPLOYED|PENDING')"
+  retries: 30
+  delay: 2
+  tags: merged
+
+- name: MERGED - TC15 - Capture initial single-leaf TOR port names
+  ansible.builtin.set_fact:
+    merged_tc15_switch1_port_names: >-
+      {{ (verify_result.response[0].attach
+      | selectattr('ipAddress', 'equalto', ansible_switch1)
+      | map(attribute='portNames')
+      | first) | default('') }}
+    merged_tc15_switch1_entries: >-
+      {{ ((verify_result.response[0].attach
+      | selectattr('ipAddress', 'equalto', ansible_switch1)
+      | map(attribute='portNames')
+      | first) | default('')) | regex_findall('\\S+\\([^)]*\\)') }}
+    merged_tc15_switch2_attach_count: >-
+      {{ verify_result.response[0].attach
+      | selectattr('ipAddress', 'equalto', ansible_switch2)
+      | list | length }}
+  delegate_to: localhost
+  tags: merged
+
+- name: MERGED - TC15 - ASSERT - Verify only the single leaf carries the TOR attachment
+  ansible.builtin.assert:
+    that:
+      - merged_tc15_switch1_entries | length == 1
+      - merged_tc15_switch2_attach_count == 0
+      - "'{{ ansible_tor_int1 }}' in merged_tc15_switch1_port_names"
+  tags: merged
+
+- name: MERGED - TC15 - MERGED - Add second TOR port on the single leaf
+  cisco.dcnm.dcnm_network: &conf11
+    fabric: "{{ test_data_common.fabric }}"
+    state: merged
+    config:
+      - net_name: ansible-net15
+        vrf_name: Tenant-1
+        net_id: 7007
+        net_template: Default_Network_Universal
+        net_extension_template: Default_Network_Extension_Universal
+        vlan_id: 1502
+        gw_ip_subnet: '192.168.32.1/24'
+        attach:
+          - ip_address: "{{ ansible_switch1 }}"
+            tor_ports:
+              - ip_address: "{{ ansible_tor_switch1 }}"
+                ports: ["{{ ansible_tor_int2 }}"]
+        deploy: false
+  register: result
+  tags: merged
+
+- name: MERGED - TC15 - Capture merged single-leaf TOR diff
+  ansible.builtin.set_fact:
+    merged_tc15_switch1_diff_tor_ports: >-
+      {{ (result.diff[0].attach
+      | selectattr('ip_address', 'equalto', ansible_switch1)
+      | map(attribute='tor_ports')
+      | first) | default('') }}
+  delegate_to: localhost
+  tags: merged
+
+- name: MERGED - TC15 - ASSERT - Verify merged diff preserves single-leaf TOR ports
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.response[0].RETURN_CODE == 200
+      - "'{{ ansible_tor_int1 }}' in merged_tc15_switch1_diff_tor_ports"
+      - "'{{ ansible_tor_int2 }}' in merged_tc15_switch1_diff_tor_ports"
+  tags: merged
+
+- name: MERGED - TC15 - QUERY - Wait for merged single-leaf TOR attachment state
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ test_data_common.fabric }}"
+    state: query
+  register: verify_result
+  until:
+    - "verify_result.response[0].parent.networkStatus is search('DEPLOYED|PENDING')"
+  retries: 30
+  delay: 2
+  tags: merged
+
+- name: MERGED - TC15 - Capture updated single-leaf TOR port names
+  ansible.builtin.set_fact:
+    merged_tc15_switch1_port_names: >-
+      {{ (verify_result.response[0].attach
+      | selectattr('ipAddress', 'equalto', ansible_switch1)
+      | map(attribute='portNames')
+      | first) | default('') }}
+    merged_tc15_switch1_entries: >-
+      {{ ((verify_result.response[0].attach
+      | selectattr('ipAddress', 'equalto', ansible_switch1)
+      | map(attribute='portNames')
+      | first) | default('')) | regex_findall('\\S+\\([^)]*\\)') }}
+    merged_tc15_switch2_attach_count: >-
+      {{ verify_result.response[0].attach
+      | selectattr('ipAddress', 'equalto', ansible_switch2)
+      | list | length }}
+  delegate_to: localhost
+  tags: merged
+
+- name: MERGED - TC15 - ASSERT - Verify NDFC preserved both single-leaf TOR ports
+  ansible.builtin.assert:
+    that:
+      - merged_tc15_switch1_entries | length == 1
+      - merged_tc15_switch2_attach_count == 0
+      - "'{{ ansible_tor_int1 }}' in merged_tc15_switch1_port_names"
+      - "'{{ ansible_tor_int2 }}' in merged_tc15_switch1_port_names"
+  tags: merged
+
+- name: MERGED - TC15 - conf11 - Idempotence
+  cisco.dcnm.dcnm_network: *conf11
+  register: result
+  tags: merged
+
+- name: MERGED - TC15 - ASSERT - Check if changed flag is false
   ansible.builtin.assert:
     that:
       - result.changed == false

--- a/tests/unit/modules/dcnm/dcnm_module.py
+++ b/tests/unit/modules/dcnm/dcnm_module.py
@@ -225,15 +225,19 @@ class TestDcnmModule(ModuleTestCase):
                 if '/about/version' in path:
                     if hasattr(self, 'nd_support_version'):
                         return {'response': self.nd_support_version, 'failed': False}
+                if (
+                    'config-deploy' in path
+                    or 'top-down' in path
+                    or '/vrfs' in path
+                    or '/networks' in path
+                ):
+                    return {'response': self.deploy_success_resp, 'failed': False}
                 if '/onemanage/fabrics' in path:
                     if hasattr(self, 'multicluster_fabric_associations'):
                         return {'response': self.multicluster_fabric_associations, 'failed': False}
                 elif '/fabric-associations' in path:
                     if hasattr(self, 'fabric_associations'):
                         return {'response': self.fabric_associations, 'failed': False}
-                elif 'vrfs' in path:
-                    if '/vrfs' in path or 'top-down' in path:
-                        return {'response': self.deploy_success_resp, 'failed': False}
                 return {'failed': True, 'msg': 'Rest Module Mocks not provided'}
 
             # Set the module args if provided for dcnm_network module

--- a/tests/unit/modules/dcnm/fixtures/dcnm_intf_eth_configs.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_intf_eth_configs.json
@@ -202,7 +202,40 @@
 			},
 			"name": "eth1/34",
 			"deploy": "False"
-		}], 
+		}],
+
+		"eth_merged_config_missing_native_vlan" : [
+		{
+			"type": "eth",
+			"switch": [
+				"192.168.1.108"
+			],
+			"profile": {
+				"description": "eth interface  acting as trunk",
+				"bpdu_guard": "True",
+				"sno": "SAL1819SAN8",
+				"mtu": "jumbo",
+				"admin_state": "True",
+				"mode": "trunk",
+				"port_type_fast": "True",
+				"policy": "int_trunk_host_11_1",
+				"allowed_vlans": "none",
+				"native_vlan": 10,
+				"orphan_port": false,
+				"enable_pfc": false,
+				"enable_cdp": true,
+				"enable_monitor": false,
+				"duplex": "auto",
+				"cmds": [
+					"no shutdown"
+				],
+				"speed": "Auto",
+				"ifname": "Ethernet1/30",
+				"fabric": "test_fabric"
+			},
+			"name": "eth1/30",
+			"deploy": "True"
+		}],
 
 		"eth_replaced_config" : [
 		{

--- a/tests/unit/modules/dcnm/fixtures/dcnm_intf_eth_payloads.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_intf_eth_payloads.json
@@ -36,6 +36,42 @@
 			"METHOD": "GET"
 	},
 
+	"eth_merged_trunk_missing_native_vlan_payloads" : 
+	{
+		"MESSAGE": "OK",
+			"REQUEST_PATH": "https://10.122.197.6:443/rest/interface?serialNumber=SAL1819SAN8&ifName=Ethernet1/30",
+			"DATA": [
+			{
+				"policy": "int_trunk_host_11_1",
+				"interfaces": [
+				{
+					"interfaceType": "INTERFACE_ETHERNET",
+					"nvPairs": {
+						"CONF": "no shutdown",
+						"MTU": "jumbo",
+						"PORTTYPE_FAST_ENABLED": "True",
+						"ADMIN_STATE": "True",
+						"INTF_NAME": "Ethernet1/30",
+						"BPDUGUARD_ENABLED": "True",
+						"ALLOWED_VLANS": "none",
+						"SPEED": "auto",
+						"PORT_DUPLEX_MODE": "auto",
+						"DESC": "eth interface  acting as trunk",
+						"ENABLE_ORPHAN_PORT": false,
+						"ENABLE_PFC": false,
+						"CDP_ENABLE": true,
+						"ENABLE_MONITOR": false
+					},
+					"ifName": "Ethernet1/30",
+					"serialNumber": "SAL1819SAN8",
+					"fabricName": "test_fabric"
+				}],
+        "skipResourceCheck": "True"
+			}],
+		"RETURN_CODE": 200,
+			"METHOD": "GET"
+	},
+
 		"eth_merged_access_payloads" : 
 		{
 			"MESSAGE": "OK",

--- a/tests/unit/modules/dcnm/fixtures/dcnm_network.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_network.json
@@ -329,6 +329,96 @@
             "deploy": true
         }
     ],
+    "playbook_tor_vpc_one_sided_config": [
+        {
+            "net_name": "test_network",
+            "vrf_name": "ansible-vrf-int1",
+            "net_id": "9008011",
+            "net_template": "Default_Network_Universal",
+            "net_extension_template": "Default_Network_Extension_Universal",
+            "vlan_id": "202",
+            "gw_ip_subnet": "192.168.30.1/24",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.217",
+                    "ports": [
+                        "Ethernet1/13",
+                        "Ethernet1/14"
+                    ],
+                    "deploy": true
+                },
+                {
+                    "ip_address": "10.10.10.218",
+                    "ports": [
+                        "Ethernet1/13",
+                        "Ethernet1/14"
+                    ],
+                    "deploy": true,
+                    "tor_ports": [
+                        {
+                            "ip_address": "10.10.10.219",
+                            "ports": [
+                                "Ethernet1/12"
+                            ]
+                        },
+                        {
+                            "ip_address": "10.10.10.220",
+                            "ports": [
+                                "Ethernet1/12"
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "deploy": true
+        }
+    ],
+    "playbook_tor_vpc_one_sided_update": [
+        {
+            "net_name": "test_network",
+            "vrf_name": "ansible-vrf-int1",
+            "net_id": "9008011",
+            "net_template": "Default_Network_Universal",
+            "net_extension_template": "Default_Network_Extension_Universal",
+            "vlan_id": "202",
+            "gw_ip_subnet": "192.168.30.1/24",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.217",
+                    "ports": [
+                        "Ethernet1/13",
+                        "Ethernet1/14"
+                    ],
+                    "deploy": true
+                },
+                {
+                    "ip_address": "10.10.10.218",
+                    "ports": [
+                        "Ethernet1/13",
+                        "Ethernet1/14"
+                    ],
+                    "deploy": true,
+                    "tor_ports": [
+                        {
+                            "ip_address": "10.10.10.219",
+                            "ports": [
+                                "Ethernet1/13",
+                                "Ethernet1/14"
+                            ]
+                        },
+                        {
+                            "ip_address": "10.10.10.220",
+                            "ports": [
+                                "Ethernet1/13",
+                                "Ethernet1/14"
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "deploy": true
+        }
+    ],
     "playbook_config_replace": [
         {
             "net_name": "test_network",
@@ -667,6 +757,50 @@
             }
         ]
     },
+    "mock_net_attach_tor_vpc_object": {
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200,
+        "DATA": [
+            {
+                "networkName": "test_network",
+                "lanAttachList": [
+                    {
+                        "networkName": "test_network",
+                        "displayName": "test_network",
+                        "switchName": "n9kv-218",
+                        "switchRole": "leaf",
+                        "fabricName": "test_net",
+                        "lanAttachState": "DEPLOYED",
+                        "isLanAttached": true,
+                        "portNames": "dt-n9k2(Ethernet1/13,Ethernet1/14) dt-n9k6(Ethernet1/12) dt-n9k7(Ethernet1/12)",
+                        "switchSerialNo": "9YO9A29F27U",
+                        "switchDbId": 4191270,
+                        "ipAddress": "10.10.10.218",
+                        "networkId": 9008011,
+                        "vlanId": 202,
+                        "interfaceGroups": null
+                    },
+                    {
+                        "networkName": "test_network",
+                        "displayName": "test_network",
+                        "switchName": "n9kv-217",
+                        "switchRole": "leaf",
+                        "fabricName": "test_net",
+                        "lanAttachState": "DEPLOYED",
+                        "isLanAttached": true,
+                        "portNames": "dt-n9k1(Ethernet1/13,Ethernet1/14) dt-n9k6(Ethernet1/12) dt-n9k7(Ethernet1/12)",
+                        "switchSerialNo": "9NN7E41N16A",
+                        "switchDbId": 4195850,
+                        "ipAddress": "10.10.10.217",
+                        "networkId": 9008011,
+                        "vlanId": 202,
+                        "interfaceGroups": null
+                    }
+                ]
+            }
+        ]
+    },
     "mock_net_attach_object_del_ready": {
         "ERROR": "",
         "RETURN_CODE": 200,
@@ -803,6 +937,54 @@
             "logicalName": "dt-n9k2",
             "serialNumber": "9YO9A29F27U",
             "switchRole": "leaf"
+        },
+        "10.10.10.219": {
+            "ipAddress": "10.10.10.219",
+            "logicalName": "dt-n9k6",
+            "serialNumber": "9YO9A29F28C",
+            "switchRole": "tor"
+        },
+        "10.10.10.220": {
+            "ipAddress": "10.10.10.220",
+            "logicalName": "dt-n9k7",
+            "serialNumber": "9YO9A29F29D",
+            "switchRole": "tor"
+        },
+        "10.10.10.226": {
+            "ipAddress": "10.10.10.226",
+            "logicalName": "dt-n9k3",
+            "serialNumber": "XYZKSJHSMK3",
+            "switchRole": "leaf"
+        },
+        "10.10.10.227": {
+            "ipAddress": "10.10.10.227",
+            "logicalName": "dt-n9k4",
+            "serialNumber": "XYZKSJHSMK4",
+            "switchRole": "border spine"
+        },
+        "10.10.10.228": {
+            "ipAddress": "10.10.10.228",
+            "logicalName": "dt-n9k5",
+            "serialNumber": "XYZKSJHSMK5",
+            "switchRole": "border"
+        }
+    },
+    "net_inv_data_vpc_tor": {
+        "10.10.10.217": {
+            "ipAddress": "10.10.10.217",
+            "logicalName": "dt-n9k1",
+            "serialNumber": "9NN7E41N16A",
+            "switchRole": "leaf",
+            "isVpcConfigured": true,
+            "peerSerialNumber": "9YO9A29F27U"
+        },
+        "10.10.10.218": {
+            "ipAddress": "10.10.10.218",
+            "logicalName": "dt-n9k2",
+            "serialNumber": "9YO9A29F27U",
+            "switchRole": "leaf",
+            "isVpcConfigured": true,
+            "peerSerialNumber": "9NN7E41N16A"
         },
         "10.10.10.219": {
             "ipAddress": "10.10.10.219",

--- a/tests/unit/modules/dcnm/fixtures/dcnm_network.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_network.json
@@ -299,6 +299,36 @@
             "deploy": true
         }
     ],
+    "playbook_tor_only_config_update": [
+        {
+            "net_name": "test_network",
+            "vrf_name": "ansible-vrf-int1",
+            "net_id": "9008011",
+            "net_template": "Default_Network_Universal",
+            "net_extension_template": "Default_Network_Extension_Universal",
+            "vlan_id": "203",
+            "gw_ip_subnet": "192.168.30.1/24",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.218",
+                    "deploy": true
+                },
+                {
+                    "ip_address": "10.10.10.217",
+                    "deploy": true,
+                    "tor_ports": [
+                        {
+                            "ip_address": "10.10.10.220",
+                            "ports": [
+                                "Ethernet1/13"
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "deploy": true
+        }
+    ],
     "playbook_config_replace": [
         {
             "net_name": "test_network",
@@ -582,6 +612,50 @@
                         "lanAttachState": "DEPLOYED",
                         "isLanAttached": true,
                         "portNames": "dt-n9k1(Ethernet1/13,Ethernet1/14) dt-n9k7(Ethernet1/12)",
+                        "switchSerialNo": "9NN7E41N16A",
+                        "switchDbId": 4195850,
+                        "ipAddress": "10.10.10.217",
+                        "networkId": 9008011,
+                        "vlanId": 202,
+                        "interfaceGroups": null
+                    }
+                ]
+            }
+        ]
+    },
+    "mock_net_attach_tor_only_object": {
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200,
+        "DATA": [
+            {
+                "networkName": "test_network",
+                "lanAttachList": [
+                    {
+                        "networkName": "test_network",
+                        "displayName": "test_network",
+                        "switchName": "n9kv-218",
+                        "switchRole": "leaf",
+                        "fabricName": "test_net",
+                        "lanAttachState": "DEPLOYED",
+                        "isLanAttached": true,
+                        "portNames": "",
+                        "switchSerialNo": "9YO9A29F27U",
+                        "switchDbId": 4191270,
+                        "ipAddress": "10.10.10.218",
+                        "networkId": 9008011,
+                        "vlanId": 202,
+                        "interfaceGroups": null
+                    },
+                    {
+                        "networkName": "test_network",
+                        "displayName": "test_network",
+                        "switchName": "n9kv-217",
+                        "switchRole": "leaf",
+                        "fabricName": "test_net",
+                        "lanAttachState": "DEPLOYED",
+                        "isLanAttached": true,
+                        "portNames": "dt-n9k7(Ethernet1/12)",
                         "switchSerialNo": "9NN7E41N16A",
                         "switchDbId": 4195850,
                         "ipAddress": "10.10.10.217",

--- a/tests/unit/modules/dcnm/fixtures/dcnm_network.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_network.json
@@ -805,33 +805,34 @@
         "ERROR": "",
         "RETURN_CODE": 200,
         "MESSAGE": "OK",
-        "DATA": {
-            "networkStatus": "NA",
-            "networkName": "test_network",
-            "switchList": []
-        }
+        "DATA": [
+            {
+                "networkName": "test_network",
+                "lanAttachList": []
+            }
+        ]
     },
     "mock_net_attach_object_del_not_ready": {
         "ERROR": "",
         "RETURN_CODE": 200,
         "MESSAGE": "OK",
-        "DATA": {
-            "networkStatus": "DEPLOYED",
-            "networkName": "test_network",
-            "switchList":
-            [
-                {
-                    "lanAttachedState": "DEPLOYED",
-                    "serialNumber": "9NN7E41N16A"
-                },
-                {
-                    "lanAttachedState": "DEPLOYED",
-                    "serialNumber": "9YO9A29F27U"
-                }
-                
-            ]
-    
-        }
+        "DATA": [
+            {
+                "networkName": "test_network",
+                "lanAttachList": [
+                    {
+                        "networkName": "test_network",
+                        "lanAttachState": "DEPLOYED",
+                        "switchSerialNo": "9NN7E41N16A"
+                    },
+                    {
+                        "networkName": "test_network",
+                        "lanAttachState": "DEPLOYED",
+                        "switchSerialNo": "9YO9A29F27U"
+                    }
+                ]
+            }
+        ]
     },
     "mock_vlan_get": {
         "DATA": "202",
@@ -924,6 +925,17 @@
         "METHOD": "POST",
         "RETURN_CODE": 200,
         "MESSAGE": "OK"
+    },
+    "mock_net_del_ready": {
+        "DATA": [
+            {
+                "networkName": "test_network",
+                "networkStatus": "NA"
+            }
+        ],
+        "MESSAGE": "OK",
+        "METHOD": "GET",
+        "RETURN_CODE": 200
     },
     "net_inv_data": {
         "10.10.10.217": {

--- a/tests/unit/modules/dcnm/fixtures/dcnm_vpc_pair/dcnm_vpc_pair_data.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_vpc_pair/dcnm_vpc_pair_data.json
@@ -934,7 +934,7 @@
         "managable": true,
         "fabricName": "mmudigon-svi",
         "logicalName": "dt-n9k86-174-1",
-        "switchDbID": 777660,
+        "switchDbID": 777680,
         "serialNumber": "SAL1820SDPR",
         "switchRoleEnum": "leaf"
       },
@@ -943,7 +943,7 @@
         "managable": true,
         "fabricName": "mmudigon-svi",
         "logicalName": "dt-n9k86-175-2",
-        "switchDbID": 777620,
+        "switchDbID": 777640,
         "serialNumber": "SAL1819S6K5",
         "switchRoleEnum": "leaf"
       },

--- a/tests/unit/modules/dcnm/fixtures/dcnm_vrf.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_vrf.json
@@ -1269,6 +1269,24 @@
             }
         ]
     },
+    "mock_vrf_object_na": {
+        "ERROR": "",
+        "RETURN_CODE": 200,
+        "MESSAGE": "OK",
+        "DATA": [
+            {
+                "fabric": "standalone_fabric",
+                "serviceVrfTemplate": "None",
+                "source": "None",
+                "vrfExtensionTemplate": "Default_VRF_Extension_Universal",
+                "vrfId": 9008011,
+                "vrfName": "test_vrf_1",
+                "vrfTemplate": "Default_VRF_Universal",
+                "vrfTemplateConfig": "{\"advertiseDefaultRouteFlag\":\"true\",\"vrfVlanId\":\"202\",\"isRPExternal\":\"false\",\"vrfDescription\":\"\",\"L3VniMcastGroup\":\"\",\"maxBgpPaths\":\"1\",\"maxIbgpPaths\":\"2\",\"vrfSegmentId\":\"9008013\",\"ipv6LinkLocalFlag\":\"true\",\"vrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"v6VrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"configureStaticDefaultRouteFlag\":\"true\",\"trmBGWMSiteEnabled\":\"false\",\"tag\":\"12345\",\"rpAddress\":\"\",\"nveId\":\"1\",\"bgpPasswordKeyType\":\"3\",\"bgpPassword\":\"\",\"mtu\":\"9216\",\"multicastGroup\":\"\",\"advertiseHostRouteFlag\":\"false\",\"vrfVlanName\":\"\",\"trmEnabled\":\"false\",\"loopbackNumber\":\"\",\"asn\":\"34343\",\"vrfIntfDescription\":\"\",\"vrfName\":\"test_vrf_1\"}",
+                "vrfStatus": "NA"
+            }
+        ]
+    },
     "mock_msd_parent_vrf_object": {
         "ERROR": "",
         "RETURN_CODE": 200,
@@ -1698,6 +1716,24 @@
                 "serviceVrfTemplate": "None",
                 "source": "None",
                 "vrfStatus": "DEPLOYED",
+                "vrfTemplateConfig": "{\"advertiseDefaultRouteFlag\":\"true\",\"vrfVlanId\":\"202\",\"isRPExternal\":\"false\",\"vrfDescription\":\"\",\"L3VniMcastGroup\":\"\",\"maxBgpPaths\":\"1\",\"maxIbgpPaths\":\"2\",\"vrfSegmentId\":\"9008013\",\"ipv6LinkLocalFlag\":\"true\",\"vrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"v6VrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"configureStaticDefaultRouteFlag\":\"true\",\"trmBGWMSiteEnabled\":\"false\",\"tag\":\"12345\",\"rpAddress\":\"\",\"nveId\":\"1\",\"bgpPasswordKeyType\":\"3\",\"bgpPassword\":\"\",\"mtu\":\"9216\",\"multicastGroup\":\"\",\"advertiseHostRouteFlag\":\"false\",\"vrfVlanName\":\"\",\"trmEnabled\":\"false\",\"loopbackNumber\":\"\",\"asn\":\"34343\",\"vrfIntfDescription\":\"\",\"vrfName\":\"test_vrf_dcnm\"}",
+                "vrfId": "9008013"
+            }
+        ]
+    },
+    "mock_vrf_object_dcnm_only_na": {
+        "ERROR": "",
+        "RETURN_CODE": 200,
+        "MESSAGE": "OK",
+        "DATA": [
+            {
+                "fabric": "standalone_fabric",
+                "vrfName": "test_vrf_dcnm",
+                "vrfTemplate": "Default_VRF_Universal",
+                "vrfExtensionTemplate": "Default_VRF_Extension_Universal",
+                "serviceVrfTemplate": "None",
+                "source": "None",
+                "vrfStatus": "NA",
                 "vrfTemplateConfig": "{\"advertiseDefaultRouteFlag\":\"true\",\"vrfVlanId\":\"202\",\"isRPExternal\":\"false\",\"vrfDescription\":\"\",\"L3VniMcastGroup\":\"\",\"maxBgpPaths\":\"1\",\"maxIbgpPaths\":\"2\",\"vrfSegmentId\":\"9008013\",\"ipv6LinkLocalFlag\":\"true\",\"vrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"v6VrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"configureStaticDefaultRouteFlag\":\"true\",\"trmBGWMSiteEnabled\":\"false\",\"tag\":\"12345\",\"rpAddress\":\"\",\"nveId\":\"1\",\"bgpPasswordKeyType\":\"3\",\"bgpPassword\":\"\",\"mtu\":\"9216\",\"multicastGroup\":\"\",\"advertiseHostRouteFlag\":\"false\",\"vrfVlanName\":\"\",\"trmEnabled\":\"false\",\"loopbackNumber\":\"\",\"asn\":\"34343\",\"vrfIntfDescription\":\"\",\"vrfName\":\"test_vrf_dcnm\"}",
                 "vrfId": "9008013"
             }
@@ -2166,6 +2202,20 @@
         "METHOD": "POST",
         "RETURN_CODE": 200,
         "MESSAGE": "OK"
+    },
+    "delete_failure_resp": {
+        "DATA": {
+            "successList": [],
+            "failureList": [
+                {
+                    "name": "test_vrf_1",
+                    "message": "VRF deletion failed"
+                }
+            ]
+        },
+        "MESSAGE": "Partial failure",
+        "METHOD": "DELETE",
+        "RETURN_CODE": 500
     },
     "vrf_inv_data": {
         "10.10.10.224": {

--- a/tests/unit/modules/dcnm/fixtures/dcnm_vrf.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_vrf.json
@@ -1,1057 +1,1055 @@
 {
-    "mock_ip_sn" : {
-      "10.10.10.224": "XYZKSJHSMK1",
-      "10.10.10.225": "XYZKSJHSMK2",
-      "10.10.10.226": "XYZKSJHSMK3",
-      "10.10.10.227": "XYZKSJHSMK4",
-      "10.10.10.228": "XYZKSJHSMK5"
+    "mock_ip_sn": {
+        "10.10.10.224": "XYZKSJHSMK1",
+        "10.10.10.225": "XYZKSJHSMK2",
+        "10.10.10.226": "XYZKSJHSMK3",
+        "10.10.10.227": "XYZKSJHSMK4",
+        "10.10.10.228": "XYZKSJHSMK5"
     },
-    "mock_ip_fab" : {
+    "mock_ip_fab": {
         "10.10.10.224": "standalone_fabric",
         "10.10.10.225": "standalone_fabric",
         "10.10.10.226": "standalone_fabric",
         "10.10.10.227": "standalone_fabric",
         "10.10.10.228": "standalone_fabric"
     },
-    "mock_sn_fab" : {
+    "mock_sn_fab": {
         "XYZKSJHSMK1": "standalone_fabric",
         "XYZKSJHSMK2": "standalone_fabric",
         "XYZKSJHSMK3": "standalone_fabric",
         "XYZKSJHSMK4": "standalone_fabric",
         "XYZKSJHSMK5": "standalone_fabric"
     },
-    "mock_sn_fab_msd" : {
+    "mock_sn_fab_msd": {
         "XYZKSJHSMK1": "parent_fabric",
         "XYZKSJHSMK2": "parent_fabric"
     },
-    "playbook_config_input_validation" : [
-      {
-        "vrf_template": "Default_VRF_Universal",
-        "vrf_extension_template": "Default_VRF_Extension_Universal",
-        "source": "None",
-        "service_vrf_template": "None",
-        "attach": [
-          {
-            "ip_address": "10.10.10.224",
-            "deploy": true
-          },
-          {
-            "vlan_id": "203",
-            "deploy": true
-          }
-        ],
-        "deploy": true
-      }
-    ],
-    "playbook_config" : [
-      {
-        "vrf_name": "test_vrf_1",
-        "vrf_id": "9008011",
-        "vrf_template": "Default_VRF_Universal",
-        "vrf_extension_template": "Default_VRF_Extension_Universal",
-        "vlan_id": "202",
-        "source": "None",
-        "service_vrf_template": "None",
-        "attach": [
-          {
-            "ip_address": "10.10.10.224",
-            "export_evpn_rt": "5000:100",
-            "import_evpn_rt": "5000:100",
-            "deploy": true
-          },
-          {
-            "ip_address": "10.10.10.225",
-            "export_evpn_rt": "5000:100",
-            "import_evpn_rt": "5000:100",
-            "deploy": true
-          }
-        ],
-        "deploy": true
-      }
-    ],
-    "playbook_no_attach_config" : [
-      {
-        "vrf_name": "test_vrf_1",
-        "vrf_id": "9008011",
-        "vrf_template": "Default_VRF_Universal",
-        "vrf_extension_template": "Default_VRF_Extension_Universal",
-        "vlan_id": "202",
-        "source": "None",
-        "service_vrf_template": "None"
-      }
-    ],
-    "playbook_vrf_lite_config" : [
-      {
-        "vrf_name": "test_vrf_1",
-        "vrf_id": "9008011",
-        "vrf_template": "Default_VRF_Universal",
-        "vrf_extension_template": "Default_VRF_Extension_Universal",
-        "vlan_id": "202",
-        "source": "None",
-        "service_vrf_template": "None",
-        "attach": [
-          {
-            "ip_address": "10.10.10.224",
-            "export_evpn_rt": "5000:100",
-            "import_evpn_rt": "5000:100",
-            "deploy": true
-          },
-          {
-            "ip_address": "10.10.10.227",
-            "export_evpn_rt": "5000:100",
-            "import_evpn_rt": "5000:100",
-              "vrf_lite": [
+    "playbook_config_input_validation": [
+        {
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "source": "None",
+            "service_vrf_template": "None",
+            "attach": [
                 {
-                  "interface": "Ethernet1/16",
-                  "ipv4_addr": "10.33.0.2/30",
-                  "neighbor_ipv4": "10.33.0.1",
-                  "ipv6_addr": "2010::10:34:0:7/64",
-                  "neighbor_ipv6": "2010::10:34:0:3",
-                  "dot1q": "2",
-                  "peer_vrf": "test_vrf_1"
-                }
-              ],
-            "deploy": true
-          }
-        ],
-        "deploy": true
-      }
-    ],
-    "playbook_vrf_merged_lite_redeploy_interface_with_extensions" : [
-        {
-          "vrf_name": "test_vrf_1",
-          "vrf_id": "9008011",
-          "vrf_template": "Default_VRF_Universal",
-          "vrf_extension_template": "Default_VRF_Extension_Universal",
-          "vlan_id": "202",
-          "source": "None",
-          "service_vrf_template": "None",
-          "attach": [
-            {
-              "ip_address": "10.10.10.224",
-              "export_evpn_rt": "5000:100",
-              "import_evpn_rt": "5000:100",
-              "deploy": true
-            },
-            {
-              "ip_address": "10.10.10.227",
-              "export_evpn_rt": "5000:100",
-              "import_evpn_rt": "5000:100",
-                "vrf_lite": [
-                  {
-                    "interface": "Ethernet1/2",
-                    "ipv4_addr": "10.33.0.2/30",
-                    "neighbor_ipv4": "10.33.0.1",
-                    "ipv6_addr": "2010::10:34:0:7/64",
-                    "neighbor_ipv6": "2010::10:34:0:3",
-                    "dot1q": "2",
-                    "peer_vrf": "test_vrf_1"
-                  }
-                ],
-              "deploy": true
-            }
-          ],
-          "deploy": true
-        }
-      ],
-      "playbook_vrf_merged_lite_redeploy_interface_without_extensions" : [
-        {
-          "vrf_name": "test_vrf_1",
-          "vrf_id": "9008011",
-          "vrf_template": "Default_VRF_Universal",
-          "vrf_extension_template": "Default_VRF_Extension_Universal",
-          "vlan_id": "202",
-          "source": "None",
-          "service_vrf_template": "None",
-          "attach": [
-            {
-              "ip_address": "10.10.10.224",
-              "export_evpn_rt": "5000:100",
-              "import_evpn_rt": "5000:100",
-              "deploy": true
-            },
-            {
-              "ip_address": "10.10.10.227",
-              "export_evpn_rt": "5000:100",
-              "import_evpn_rt": "5000:100",
-                "vrf_lite": [
-                  {
-                    "interface": "Ethernet1/16",
-                    "ipv4_addr": "10.33.0.2/30",
-                    "neighbor_ipv4": "10.33.0.1",
-                    "ipv6_addr": "2010::10:34:0:7/64",
-                    "neighbor_ipv6": "2010::10:34:0:3",
-                    "dot1q": "2",
-                    "peer_vrf": "test_vrf_1"
-                  }
-                ],
-              "deploy": true
-            }
-          ],
-          "deploy": true
-        }
-      ],  
-    "playbook_vrf_merged_lite_new_interface_with_extensions" : [
-        {
-          "vrf_name": "test_vrf_1",
-          "vrf_id": "9008011",
-          "vrf_template": "Default_VRF_Universal",
-          "vrf_extension_template": "Default_VRF_Extension_Universal",
-          "vlan_id": "202",
-          "source": "None",
-          "service_vrf_template": "None",
-          "attach": [
-            {
-              "ip_address": "10.10.10.224",
-              "export_evpn_rt": "5000:100",
-              "import_evpn_rt": "5000:100",
-              "deploy": true
-            },
-            {
-              "ip_address": "10.10.10.227",
-              "export_evpn_rt": "5000:100",
-              "import_evpn_rt": "5000:100",
-                "vrf_lite": [
-                  {
-                    "interface": "Ethernet1/2",
-                    "ipv4_addr": "10.33.0.2/30",
-                    "neighbor_ipv4": "10.33.0.1",
-                    "ipv6_addr": "2010::10:34:0:7/64",
-                    "neighbor_ipv6": "2010::10:34:0:3",
-                    "dot1q": "2",
-                    "peer_vrf": "test_vrf_1"
-                  }
-                ],
-              "deploy": true
-            }
-          ],
-          "deploy": true
-        }
-      ],
-    "playbook_vrf_merged_lite_new_interface_without_extensions" : [
-        {
-          "vrf_name": "test_vrf_1",
-          "vrf_id": "9008011",
-          "vrf_template": "Default_VRF_Universal",
-          "vrf_extension_template": "Default_VRF_Extension_Universal",
-          "vlan_id": "202",
-          "source": "None",
-          "service_vrf_template": "None",
-          "attach": [
-            {
-              "ip_address": "10.10.10.224",
-              "export_evpn_rt": "5000:100",
-              "import_evpn_rt": "5000:100",
-              "deploy": true
-            },
-            {
-              "ip_address": "10.10.10.227",
-              "export_evpn_rt": "5000:100",
-              "import_evpn_rt": "5000:100",
-                "vrf_lite": [
-                  {
-                    "interface": "Ethernet1/16",
-                    "ipv4_addr": "10.33.0.2/30",
-                    "neighbor_ipv4": "10.33.0.1",
-                    "ipv6_addr": "2010::10:34:0:7/64",
-                    "neighbor_ipv6": "2010::10:34:0:3",
-                    "dot1q": "2",
-                    "peer_vrf": "test_vrf_1"
-                  }
-                ],
-              "deploy": true
-            }
-          ],
-          "deploy": true
-        }
-      ],
-      "playbook_vrf_lite_override_with_additions_interface_with_extensions" : [
-        {
-          "vrf_name": "test_vrf_1",
-          "vrf_id": "9008011",
-          "vrf_template": "Default_VRF_Universal",
-          "vrf_extension_template": "Default_VRF_Extension_Universal",
-          "vlan_id": "202",
-          "source": "None",
-          "service_vrf_template": "None",
-          "attach": [
-            {
-              "ip_address": "10.10.10.224",
-              "export_evpn_rt": "5000:100",
-              "import_evpn_rt": "5000:100",
-              "deploy": true
-            },
-            {
-              "ip_address": "10.10.10.227",
-              "export_evpn_rt": "5000:100",
-              "import_evpn_rt": "5000:100",
-                "vrf_lite": [
-                  {
-                    "interface": "Ethernet1/2",
-                    "ipv4_addr": "10.33.0.2/30",
-                    "neighbor_ipv4": "10.33.0.1",
-                    "ipv6_addr": "2010::10:34:0:7/64",
-                    "neighbor_ipv6": "2010::10:34:0:3",
-                    "dot1q": "2",
-                    "peer_vrf": "test_vrf_1"
-                  }
-                ],
-              "deploy": true
-            }
-          ],
-          "deploy": true
-        }
-      ],
-      "playbook_vrf_lite_override_with_additions_interface_without_extensions" : [
-        {
-          "vrf_name": "test_vrf_1",
-          "vrf_id": "9008011",
-          "vrf_template": "Default_VRF_Universal",
-          "vrf_extension_template": "Default_VRF_Extension_Universal",
-          "vlan_id": "202",
-          "source": "None",
-          "service_vrf_template": "None",
-          "attach": [
-            {
-              "ip_address": "10.10.10.224",
-              "export_evpn_rt": "5000:100",
-              "import_evpn_rt": "5000:100",
-              "deploy": true
-            },
-            {
-              "ip_address": "10.10.10.227",
-              "export_evpn_rt": "5000:100",
-              "import_evpn_rt": "5000:100",
-                "vrf_lite": [
-                  {
-                    "interface": "Ethernet1/16",
-                    "ipv4_addr": "10.33.0.2/30",
-                    "neighbor_ipv4": "10.33.0.1",
-                    "ipv6_addr": "2010::10:34:0:7/64",
-                    "neighbor_ipv6": "2010::10:34:0:3",
-                    "dot1q": "2",
-                    "peer_vrf": "test_vrf_1"
-                  }
-                ],
-              "deploy": true
-            }
-          ],
-          "deploy": true
-        }
-      ],
-      "playbook_vrf_lite_override_with_deletions_interface_with_extensions" : [
-        {
-          "vrf_name": "test_vrf_1",
-          "vrf_id": "9008011",
-          "vrf_template": "Default_VRF_Universal",
-          "vrf_extension_template": "Default_VRF_Extension_Universal",
-          "vlan_id": "202",
-          "source": "None",
-          "service_vrf_template": "None",
-          "attach": [
-            {
-              "ip_address": "10.10.10.224",
-              "deploy": true
-            },
-            {
-              "ip_address": "10.10.10.228",
-                "vrf_lite": [
-                  {
-                    "interface": "Ethernet1/2",
-                    "ipv4_addr": "10.33.0.11/30",
-                    "neighbor_ipv4": "10.33.0.12",
-                    "ipv6_addr": "2010::10:34:0:1/64",
-                    "neighbor_ipv6": "2010::10:34:0:1",
-                    "dot1q": "21",
-                    "peer_vrf": "test_vrf_1"
-                  }
-                ],
-              "deploy": true
-            }
-          ],
-          "deploy": true
-        }
-      ],
-    "playbook_vrf_lite_override_with_deletions_interface_without_extensions" : [
-        {
-          "vrf_name": "test_vrf_1",
-          "vrf_id": "9008011",
-          "vrf_template": "Default_VRF_Universal",
-          "vrf_extension_template": "Default_VRF_Extension_Universal",
-          "vlan_id": "202",
-          "source": "None",
-          "service_vrf_template": "None",
-          "attach": [
-            {
-              "ip_address": "10.10.10.224",
-              "deploy": true
-            },
-            {
-              "ip_address": "10.10.10.228",
-                "vrf_lite": [
-                  {
-                    "interface": "Ethernet1/17",
-                    "ipv4_addr": "10.33.0.11/30",
-                    "neighbor_ipv4": "10.33.0.12",
-                    "ipv6_addr": "2010::10:34:0:1/64",
-                    "neighbor_ipv6": "2010::10:34:0:1",
-                    "dot1q": "21",
-                    "peer_vrf": "test_vrf_1"
-                  }
-                ],
-              "deploy": true
-            }
-          ],
-          "deploy": true
-        }
-      ],
-      "playbook_vrf_lite_replace_config" : [
-      {
-        "vrf_name": "test_vrf_1",
-        "vrf_id": "9008011",
-        "vrf_template": "Default_VRF_Universal",
-        "vrf_extension_template": "Default_VRF_Extension_Universal",
-        "vlan_id": "202",
-        "source": "None",
-        "service_vrf_template": "None",
-        "attach": [
-          {
-            "ip_address": "10.10.10.224",
-            "deploy": true
-          },
-          {
-            "ip_address": "10.10.10.228",
-              "vrf_lite": [
+                    "ip_address": "10.10.10.224",
+                    "deploy": true
+                },
                 {
-                  "interface": "Ethernet1/17",
-                  "ipv4_addr": "10.33.0.11/30",
-                  "neighbor_ipv4": "10.33.0.12",
-                  "ipv6_addr": "2010::10:34:0:1/64",
-                  "neighbor_ipv6": "2010::10:34:0:1",
-                  "dot1q": "21",
-                  "peer_vrf": "test_vrf_1"
+                    "vlan_id": "203",
+                    "deploy": true
                 }
-              ],
+            ],
             "deploy": true
-          }
-        ],
-        "deploy": true
-      }
-    ],
-    "playbook_vrf_lite_replace_config_interface_with_extension_values" : [
-        {
-          "vrf_name": "test_vrf_1",
-          "vrf_id": "9008011",
-          "vrf_template": "Default_VRF_Universal",
-          "vrf_extension_template": "Default_VRF_Extension_Universal",
-          "vlan_id": "202",
-          "source": "None",
-          "service_vrf_template": "None",
-          "attach": [
-            {
-              "ip_address": "10.10.10.224",
-              "deploy": true
-            },
-            {
-              "ip_address": "10.10.10.228",
-                "vrf_lite": [
-                  {
-                    "interface": "Ethernet1/2",
-                    "ipv4_addr": "10.33.0.11/30",
-                    "neighbor_ipv4": "10.33.0.12",
-                    "ipv6_addr": "2010::10:34:0:1/64",
-                    "neighbor_ipv6": "2010::10:34:0:1",
-                    "dot1q": "21",
-                    "peer_vrf": "test_vrf_1"
-                  }
-                ],
-              "deploy": true
-            }
-          ],
-          "deploy": true
         }
-      ],
-      "playbook_vrf_merged_lite_update_interface_with_extensions" : [
-      {
-        "vrf_name": "test_vrf_1",
-        "vrf_id": "9008011",
-        "vrf_template": "Default_VRF_Universal",
-        "vrf_extension_template": "Default_VRF_Extension_Universal",
-        "vlan_id": "202",
-        "source": "None",
-        "service_vrf_template": "None",
-        "attach": [
-          {
-            "ip_address": "10.10.10.224",
-            "deploy": true
-          },
-          {
-            "ip_address": "10.10.10.228",
-              "vrf_lite": [
-                {
-                  "interface": "Ethernet1/2",
-                  "ipv4_addr": "10.33.0.2/30",
-                  "neighbor_ipv4": "10.33.0.1",
-                  "ipv6_addr": "2010::10:34:0:7/64",
-                  "neighbor_ipv6": "2010::10:34:0:3",
-                  "dot1q": "2",
-                  "peer_vrf": "test_vrf_1"
-                }
-              ],
-            "deploy": true
-          }
-        ],
-        "deploy": true
-      }
     ],
-    "playbook_vrf_merged_lite_update_interface_without_extensions" : [
+    "playbook_config": [
         {
-          "vrf_name": "test_vrf_1",
-          "vrf_id": "9008011",
-          "vrf_template": "Default_VRF_Universal",
-          "vrf_extension_template": "Default_VRF_Extension_Universal",
-          "vlan_id": "202",
-          "source": "None",
-          "service_vrf_template": "None",
-          "attach": [
-            {
-              "ip_address": "10.10.10.224",
-              "deploy": true
-            },
-            {
-              "ip_address": "10.10.10.228",
-                "vrf_lite": [
-                  {
-                    "interface": "Ethernet1/16",
-                    "ipv4_addr": "10.33.0.2/30",
-                    "neighbor_ipv4": "10.33.0.1",
-                    "ipv6_addr": "2010::10:34:0:7/64",
-                    "neighbor_ipv6": "2010::10:34:0:3",
-                    "dot1q": "2",
-                    "peer_vrf": "test_vrf_1"
-                  }
-                ],
-              "deploy": true
-            }
-          ],
-          "deploy": true
-        }
-      ],
-      "playbook_vrf_lite_inv_config" : [
-      {
-        "vrf_name": "test_vrf_1",
-        "vrf_id": "9008011",
-        "vrf_template": "Default_VRF_Universal",
-        "vrf_extension_template": "Default_VRF_Extension_Universal",
-        "vlan_id": "202",
-        "source": "None",
-        "service_vrf_template": "None",
-        "attach": [
-          {
-            "ip_address": "10.10.10.225",
-              "vrf_lite": [
+            "vrf_name": "test_vrf_1",
+            "vrf_id": "9008011",
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "vlan_id": "202",
+            "source": "None",
+            "service_vrf_template": "None",
+            "attach": [
                 {
-                  "interface": "Ethernet1/16",
-                  "ipv4_addr": "10.33.0.2/30",
-                  "neighbor_ipv4": "10.33.0.1",
-                  "ipv6_addr": "2010::10:34:0:7/64",
-                  "neighbor_ipv6": "2010::10:34:0:3",
-                  "dot1q": "2",
-                  "peer_vrf": "test_vrf_1"
+                    "ip_address": "10.10.10.224",
+                    "export_evpn_rt": "5000:100",
+                    "import_evpn_rt": "5000:100",
+                    "deploy": true
+                },
+                {
+                    "ip_address": "10.10.10.225",
+                    "export_evpn_rt": "5000:100",
+                    "import_evpn_rt": "5000:100",
+                    "deploy": true
                 }
-              ],
+            ],
             "deploy": true
-          }
-        ],
-        "deploy": true
-      }
+        }
+    ],
+    "playbook_no_attach_config": [
+        {
+            "vrf_name": "test_vrf_1",
+            "vrf_id": "9008011",
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "vlan_id": "202",
+            "source": "None",
+            "service_vrf_template": "None"
+        }
+    ],
+    "playbook_vrf_lite_config": [
+        {
+            "vrf_name": "test_vrf_1",
+            "vrf_id": "9008011",
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "vlan_id": "202",
+            "source": "None",
+            "service_vrf_template": "None",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.224",
+                    "export_evpn_rt": "5000:100",
+                    "import_evpn_rt": "5000:100",
+                    "deploy": true
+                },
+                {
+                    "ip_address": "10.10.10.227",
+                    "export_evpn_rt": "5000:100",
+                    "import_evpn_rt": "5000:100",
+                    "vrf_lite": [
+                        {
+                            "interface": "Ethernet1/16",
+                            "ipv4_addr": "10.33.0.2/30",
+                            "neighbor_ipv4": "10.33.0.1",
+                            "ipv6_addr": "2010::10:34:0:7/64",
+                            "neighbor_ipv6": "2010::10:34:0:3",
+                            "dot1q": "2",
+                            "peer_vrf": "test_vrf_1"
+                        }
+                    ],
+                    "deploy": true
+                }
+            ],
+            "deploy": true
+        }
+    ],
+    "playbook_vrf_merged_lite_redeploy_interface_with_extensions": [
+        {
+            "vrf_name": "test_vrf_1",
+            "vrf_id": "9008011",
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "vlan_id": "202",
+            "source": "None",
+            "service_vrf_template": "None",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.224",
+                    "export_evpn_rt": "5000:100",
+                    "import_evpn_rt": "5000:100",
+                    "deploy": true
+                },
+                {
+                    "ip_address": "10.10.10.227",
+                    "export_evpn_rt": "5000:100",
+                    "import_evpn_rt": "5000:100",
+                    "vrf_lite": [
+                        {
+                            "interface": "Ethernet1/2",
+                            "ipv4_addr": "10.33.0.2/30",
+                            "neighbor_ipv4": "10.33.0.1",
+                            "ipv6_addr": "2010::10:34:0:7/64",
+                            "neighbor_ipv6": "2010::10:34:0:3",
+                            "dot1q": "2",
+                            "peer_vrf": "test_vrf_1"
+                        }
+                    ],
+                    "deploy": true
+                }
+            ],
+            "deploy": true
+        }
+    ],
+    "playbook_vrf_merged_lite_redeploy_interface_without_extensions": [
+        {
+            "vrf_name": "test_vrf_1",
+            "vrf_id": "9008011",
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "vlan_id": "202",
+            "source": "None",
+            "service_vrf_template": "None",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.224",
+                    "export_evpn_rt": "5000:100",
+                    "import_evpn_rt": "5000:100",
+                    "deploy": true
+                },
+                {
+                    "ip_address": "10.10.10.227",
+                    "export_evpn_rt": "5000:100",
+                    "import_evpn_rt": "5000:100",
+                    "vrf_lite": [
+                        {
+                            "interface": "Ethernet1/16",
+                            "ipv4_addr": "10.33.0.2/30",
+                            "neighbor_ipv4": "10.33.0.1",
+                            "ipv6_addr": "2010::10:34:0:7/64",
+                            "neighbor_ipv6": "2010::10:34:0:3",
+                            "dot1q": "2",
+                            "peer_vrf": "test_vrf_1"
+                        }
+                    ],
+                    "deploy": true
+                }
+            ],
+            "deploy": true
+        }
+    ],
+    "playbook_vrf_merged_lite_new_interface_with_extensions": [
+        {
+            "vrf_name": "test_vrf_1",
+            "vrf_id": "9008011",
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "vlan_id": "202",
+            "source": "None",
+            "service_vrf_template": "None",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.224",
+                    "export_evpn_rt": "5000:100",
+                    "import_evpn_rt": "5000:100",
+                    "deploy": true
+                },
+                {
+                    "ip_address": "10.10.10.227",
+                    "export_evpn_rt": "5000:100",
+                    "import_evpn_rt": "5000:100",
+                    "vrf_lite": [
+                        {
+                            "interface": "Ethernet1/2",
+                            "ipv4_addr": "10.33.0.2/30",
+                            "neighbor_ipv4": "10.33.0.1",
+                            "ipv6_addr": "2010::10:34:0:7/64",
+                            "neighbor_ipv6": "2010::10:34:0:3",
+                            "dot1q": "2",
+                            "peer_vrf": "test_vrf_1"
+                        }
+                    ],
+                    "deploy": true
+                }
+            ],
+            "deploy": true
+        }
+    ],
+    "playbook_vrf_merged_lite_new_interface_without_extensions": [
+        {
+            "vrf_name": "test_vrf_1",
+            "vrf_id": "9008011",
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "vlan_id": "202",
+            "source": "None",
+            "service_vrf_template": "None",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.224",
+                    "export_evpn_rt": "5000:100",
+                    "import_evpn_rt": "5000:100",
+                    "deploy": true
+                },
+                {
+                    "ip_address": "10.10.10.227",
+                    "export_evpn_rt": "5000:100",
+                    "import_evpn_rt": "5000:100",
+                    "vrf_lite": [
+                        {
+                            "interface": "Ethernet1/16",
+                            "ipv4_addr": "10.33.0.2/30",
+                            "neighbor_ipv4": "10.33.0.1",
+                            "ipv6_addr": "2010::10:34:0:7/64",
+                            "neighbor_ipv6": "2010::10:34:0:3",
+                            "dot1q": "2",
+                            "peer_vrf": "test_vrf_1"
+                        }
+                    ],
+                    "deploy": true
+                }
+            ],
+            "deploy": true
+        }
+    ],
+    "playbook_vrf_lite_override_with_additions_interface_with_extensions": [
+        {
+            "vrf_name": "test_vrf_1",
+            "vrf_id": "9008011",
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "vlan_id": "202",
+            "source": "None",
+            "service_vrf_template": "None",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.224",
+                    "export_evpn_rt": "5000:100",
+                    "import_evpn_rt": "5000:100",
+                    "deploy": true
+                },
+                {
+                    "ip_address": "10.10.10.227",
+                    "export_evpn_rt": "5000:100",
+                    "import_evpn_rt": "5000:100",
+                    "vrf_lite": [
+                        {
+                            "interface": "Ethernet1/2",
+                            "ipv4_addr": "10.33.0.2/30",
+                            "neighbor_ipv4": "10.33.0.1",
+                            "ipv6_addr": "2010::10:34:0:7/64",
+                            "neighbor_ipv6": "2010::10:34:0:3",
+                            "dot1q": "2",
+                            "peer_vrf": "test_vrf_1"
+                        }
+                    ],
+                    "deploy": true
+                }
+            ],
+            "deploy": true
+        }
+    ],
+    "playbook_vrf_lite_override_with_additions_interface_without_extensions": [
+        {
+            "vrf_name": "test_vrf_1",
+            "vrf_id": "9008011",
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "vlan_id": "202",
+            "source": "None",
+            "service_vrf_template": "None",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.224",
+                    "export_evpn_rt": "5000:100",
+                    "import_evpn_rt": "5000:100",
+                    "deploy": true
+                },
+                {
+                    "ip_address": "10.10.10.227",
+                    "export_evpn_rt": "5000:100",
+                    "import_evpn_rt": "5000:100",
+                    "vrf_lite": [
+                        {
+                            "interface": "Ethernet1/16",
+                            "ipv4_addr": "10.33.0.2/30",
+                            "neighbor_ipv4": "10.33.0.1",
+                            "ipv6_addr": "2010::10:34:0:7/64",
+                            "neighbor_ipv6": "2010::10:34:0:3",
+                            "dot1q": "2",
+                            "peer_vrf": "test_vrf_1"
+                        }
+                    ],
+                    "deploy": true
+                }
+            ],
+            "deploy": true
+        }
+    ],
+    "playbook_vrf_lite_override_with_deletions_interface_with_extensions": [
+        {
+            "vrf_name": "test_vrf_1",
+            "vrf_id": "9008011",
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "vlan_id": "202",
+            "source": "None",
+            "service_vrf_template": "None",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.224",
+                    "deploy": true
+                },
+                {
+                    "ip_address": "10.10.10.228",
+                    "vrf_lite": [
+                        {
+                            "interface": "Ethernet1/2",
+                            "ipv4_addr": "10.33.0.11/30",
+                            "neighbor_ipv4": "10.33.0.12",
+                            "ipv6_addr": "2010::10:34:0:1/64",
+                            "neighbor_ipv6": "2010::10:34:0:1",
+                            "dot1q": "21",
+                            "peer_vrf": "test_vrf_1"
+                        }
+                    ],
+                    "deploy": true
+                }
+            ],
+            "deploy": true
+        }
+    ],
+    "playbook_vrf_lite_override_with_deletions_interface_without_extensions": [
+        {
+            "vrf_name": "test_vrf_1",
+            "vrf_id": "9008011",
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "vlan_id": "202",
+            "source": "None",
+            "service_vrf_template": "None",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.224",
+                    "deploy": true
+                },
+                {
+                    "ip_address": "10.10.10.228",
+                    "vrf_lite": [
+                        {
+                            "interface": "Ethernet1/17",
+                            "ipv4_addr": "10.33.0.11/30",
+                            "neighbor_ipv4": "10.33.0.12",
+                            "ipv6_addr": "2010::10:34:0:1/64",
+                            "neighbor_ipv6": "2010::10:34:0:1",
+                            "dot1q": "21",
+                            "peer_vrf": "test_vrf_1"
+                        }
+                    ],
+                    "deploy": true
+                }
+            ],
+            "deploy": true
+        }
+    ],
+    "playbook_vrf_lite_replace_config": [
+        {
+            "vrf_name": "test_vrf_1",
+            "vrf_id": "9008011",
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "vlan_id": "202",
+            "source": "None",
+            "service_vrf_template": "None",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.224",
+                    "deploy": true
+                },
+                {
+                    "ip_address": "10.10.10.228",
+                    "vrf_lite": [
+                        {
+                            "interface": "Ethernet1/17",
+                            "ipv4_addr": "10.33.0.11/30",
+                            "neighbor_ipv4": "10.33.0.12",
+                            "ipv6_addr": "2010::10:34:0:1/64",
+                            "neighbor_ipv6": "2010::10:34:0:1",
+                            "dot1q": "21",
+                            "peer_vrf": "test_vrf_1"
+                        }
+                    ],
+                    "deploy": true
+                }
+            ],
+            "deploy": true
+        }
+    ],
+    "playbook_vrf_lite_replace_config_interface_with_extension_values": [
+        {
+            "vrf_name": "test_vrf_1",
+            "vrf_id": "9008011",
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "vlan_id": "202",
+            "source": "None",
+            "service_vrf_template": "None",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.224",
+                    "deploy": true
+                },
+                {
+                    "ip_address": "10.10.10.228",
+                    "vrf_lite": [
+                        {
+                            "interface": "Ethernet1/2",
+                            "ipv4_addr": "10.33.0.11/30",
+                            "neighbor_ipv4": "10.33.0.12",
+                            "ipv6_addr": "2010::10:34:0:1/64",
+                            "neighbor_ipv6": "2010::10:34:0:1",
+                            "dot1q": "21",
+                            "peer_vrf": "test_vrf_1"
+                        }
+                    ],
+                    "deploy": true
+                }
+            ],
+            "deploy": true
+        }
+    ],
+    "playbook_vrf_merged_lite_update_interface_with_extensions": [
+        {
+            "vrf_name": "test_vrf_1",
+            "vrf_id": "9008011",
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "vlan_id": "202",
+            "source": "None",
+            "service_vrf_template": "None",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.224",
+                    "deploy": true
+                },
+                {
+                    "ip_address": "10.10.10.228",
+                    "vrf_lite": [
+                        {
+                            "interface": "Ethernet1/2",
+                            "ipv4_addr": "10.33.0.2/30",
+                            "neighbor_ipv4": "10.33.0.1",
+                            "ipv6_addr": "2010::10:34:0:7/64",
+                            "neighbor_ipv6": "2010::10:34:0:3",
+                            "dot1q": "2",
+                            "peer_vrf": "test_vrf_1"
+                        }
+                    ],
+                    "deploy": true
+                }
+            ],
+            "deploy": true
+        }
+    ],
+    "playbook_vrf_merged_lite_update_interface_without_extensions": [
+        {
+            "vrf_name": "test_vrf_1",
+            "vrf_id": "9008011",
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "vlan_id": "202",
+            "source": "None",
+            "service_vrf_template": "None",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.224",
+                    "deploy": true
+                },
+                {
+                    "ip_address": "10.10.10.228",
+                    "vrf_lite": [
+                        {
+                            "interface": "Ethernet1/16",
+                            "ipv4_addr": "10.33.0.2/30",
+                            "neighbor_ipv4": "10.33.0.1",
+                            "ipv6_addr": "2010::10:34:0:7/64",
+                            "neighbor_ipv6": "2010::10:34:0:3",
+                            "dot1q": "2",
+                            "peer_vrf": "test_vrf_1"
+                        }
+                    ],
+                    "deploy": true
+                }
+            ],
+            "deploy": true
+        }
+    ],
+    "playbook_vrf_lite_inv_config": [
+        {
+            "vrf_name": "test_vrf_1",
+            "vrf_id": "9008011",
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "vlan_id": "202",
+            "source": "None",
+            "service_vrf_template": "None",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.225",
+                    "vrf_lite": [
+                        {
+                            "interface": "Ethernet1/16",
+                            "ipv4_addr": "10.33.0.2/30",
+                            "neighbor_ipv4": "10.33.0.1",
+                            "ipv6_addr": "2010::10:34:0:7/64",
+                            "neighbor_ipv6": "2010::10:34:0:3",
+                            "dot1q": "2",
+                            "peer_vrf": "test_vrf_1"
+                        }
+                    ],
+                    "deploy": true
+                }
+            ],
+            "deploy": true
+        }
     ],
     "playbook_config_update": [
-      {
-        "vrf_name": "test_vrf_1",
-        "vrf_id": "9008011",
-        "vrf_template": "Default_VRF_Universal",
-        "vrf_extension_template": "Default_VRF_Extension_Universal",
-        "vlan_id": "203",
-        "source": "None",
-        "service_vrf_template": "None",
-        "attach": [
-          {
-            "ip_address": "10.10.10.226",
-            "deploy": true
-          },
-          {
-            "ip_address": "10.10.10.225",
-            "deploy": true
-          }
-        ],
-        "deploy": true
-      }
-    ],
-  "playbook_config_update_vlan": [
-    {
-      "vrf_name": "test_vrf_1",
-      "vrf_id": "9008011",
-      "vrf_template": "Default_VRF_Universal",
-      "vrf_extension_template": "Default_VRF_Extension_Universal",
-      "vlan_id": "303",
-      "source": "None",
-      "service_vrf_template": "None",
-      "attach": [
         {
-          "ip_address": "10.10.10.225",
-          "deploy": true
-        },
-        {
-          "ip_address": "10.10.10.226",
-          "deploy": true
-        }
-      ],
-      "deploy": true
-    }
-  ],
-  "playbook_vrf_lite_update_vlan_config_interface_with_extensions" : [
-      {
-        "vrf_name": "test_vrf_1",
-        "vrf_id": "9008011",
-        "vrf_template": "Default_VRF_Universal",
-        "vrf_extension_template": "Default_VRF_Extension_Universal",
-        "vlan_id": "402",
-        "source": "None",
-        "service_vrf_template": "None",
-        "attach": [
-          {
-            "ip_address": "10.10.10.224",
-            "deploy": true
-          },
-          {
-            "ip_address": "10.10.10.228",
-              "vrf_lite": [
+            "vrf_name": "test_vrf_1",
+            "vrf_id": "9008011",
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "vlan_id": "203",
+            "source": "None",
+            "service_vrf_template": "None",
+            "attach": [
                 {
-                  "interface": "Ethernet1/2",
-                  "ipv4_addr": "10.33.0.2/30",
-                  "neighbor_ipv4": "10.33.0.1",
-                  "ipv6_addr": "2010::10:34:0:7/64",
-                  "neighbor_ipv6": "2010::10:34:0:3",
-                  "dot1q": "2",
-                  "peer_vrf": "test_vrf_1"
+                    "ip_address": "10.10.10.226",
+                    "deploy": true
+                },
+                {
+                    "ip_address": "10.10.10.225",
+                    "deploy": true
                 }
-              ],
+            ],
             "deploy": true
-          }
-        ],
-        "deploy": true
-      }
+        }
     ],
-    "playbook_vrf_lite_update_vlan_config_interface_without_extensions" : [
+    "playbook_config_update_vlan": [
         {
-          "vrf_name": "test_vrf_1",
-          "vrf_id": "9008011",
-          "vrf_template": "Default_VRF_Universal",
-          "vrf_extension_template": "Default_VRF_Extension_Universal",
-          "vlan_id": "402",
-          "source": "None",
-          "service_vrf_template": "None",
-          "attach": [
-            {
-              "ip_address": "10.10.10.224",
-              "deploy": true
-            },
-            {
-              "ip_address": "10.10.10.228",
-                "vrf_lite": [
-                  {
-                    "interface": "Ethernet1/16",
-                    "ipv4_addr": "10.33.0.2/30",
-                    "neighbor_ipv4": "10.33.0.1",
-                    "ipv6_addr": "2010::10:34:0:7/64",
-                    "neighbor_ipv6": "2010::10:34:0:3",
-                    "dot1q": "2",
-                    "peer_vrf": "test_vrf_1"
-                  }
-                ],
-              "deploy": true
-            }
-          ],
-          "deploy": true
+            "vrf_name": "test_vrf_1",
+            "vrf_id": "9008011",
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "vlan_id": "303",
+            "source": "None",
+            "service_vrf_template": "None",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.225",
+                    "deploy": true
+                },
+                {
+                    "ip_address": "10.10.10.226",
+                    "deploy": true
+                }
+            ],
+            "deploy": true
         }
-      ],
-      "playbook_config_override": [
-    {
-      "vrf_name": "test_vrf_2",
-      "vrf_id": "9008012",
-      "vrf_template": "Default_VRF_Universal",
-      "vrf_extension_template": "Default_VRF_Extension_Universal",
-      "vlan_id": "303",
-      "source": "None",
-      "service_vrf_template": "None",
-      "attach": [
+    ],
+    "playbook_vrf_lite_update_vlan_config_interface_with_extensions": [
         {
-          "ip_address": "10.10.10.225",
-          "deploy": true
-        },
-        {
-          "ip_address": "10.10.10.226",
-          "deploy": true
+            "vrf_name": "test_vrf_1",
+            "vrf_id": "9008011",
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "vlan_id": "402",
+            "source": "None",
+            "service_vrf_template": "None",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.224",
+                    "deploy": true
+                },
+                {
+                    "ip_address": "10.10.10.228",
+                    "vrf_lite": [
+                        {
+                            "interface": "Ethernet1/2",
+                            "ipv4_addr": "10.33.0.2/30",
+                            "neighbor_ipv4": "10.33.0.1",
+                            "ipv6_addr": "2010::10:34:0:7/64",
+                            "neighbor_ipv6": "2010::10:34:0:3",
+                            "dot1q": "2",
+                            "peer_vrf": "test_vrf_1"
+                        }
+                    ],
+                    "deploy": true
+                }
+            ],
+            "deploy": true
         }
-      ],
-      "deploy": true
-    }
-  ],
-  "playbook_config_incorrect_vrfid": [
-    {
-      "vrf_name": "test_vrf_1",
-      "vrf_id": "9008012",
-      "vrf_template": "Default_VRF_Universal",
-      "vrf_extension_template": "Default_VRF_Extension_Universal",
-      "source": "None",
-      "service_vrf_template": "None",
-      "attach": [
+    ],
+    "playbook_vrf_lite_update_vlan_config_interface_without_extensions": [
         {
-          "ip_address": "10.10.10.224",
-          "vlan_id": "202",
-          "deploy": true
-        },
-        {
-          "ip_address": "10.10.10.225",
-          "vlan_id": "203",
-          "deploy": true
+            "vrf_name": "test_vrf_1",
+            "vrf_id": "9008011",
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "vlan_id": "402",
+            "source": "None",
+            "service_vrf_template": "None",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.224",
+                    "deploy": true
+                },
+                {
+                    "ip_address": "10.10.10.228",
+                    "vrf_lite": [
+                        {
+                            "interface": "Ethernet1/16",
+                            "ipv4_addr": "10.33.0.2/30",
+                            "neighbor_ipv4": "10.33.0.1",
+                            "ipv6_addr": "2010::10:34:0:7/64",
+                            "neighbor_ipv6": "2010::10:34:0:3",
+                            "dot1q": "2",
+                            "peer_vrf": "test_vrf_1"
+                        }
+                    ],
+                    "deploy": true
+                }
+            ],
+            "deploy": true
         }
-      ],
-      "deploy": true
-    }
-  ],
-  "playbook_config_replace": [
-    {
-      "vrf_name": "test_vrf_1",
-      "vrf_id": "9008011",
-      "vrf_template": "Default_VRF_Universal",
-      "vrf_extension_template": "Default_VRF_Extension_Universal",
-      "vlan_id": "203",
-      "source": "None",
-      "service_vrf_template": "None",
-      "attach": [
+    ],
+    "playbook_config_override": [
         {
-          "ip_address": "10.10.10.225",
-          "deploy": true
-        },
-        {
-          "ip_address": "10.10.10.226",
-          "deploy": true
+            "vrf_name": "test_vrf_2",
+            "vrf_id": "9008012",
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "vlan_id": "303",
+            "source": "None",
+            "service_vrf_template": "None",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.225",
+                    "deploy": true
+                },
+                {
+                    "ip_address": "10.10.10.226",
+                    "deploy": true
+                }
+            ],
+            "deploy": true
         }
-      ],
-      "deploy": true
-    }
-  ],
-  "playbook_config_replace_no_atch": [
-    {
-      "vrf_name": "test_vrf_1",
-      "vrf_id": "9008011",
-      "vrf_template": "Default_VRF_Universal",
-      "vrf_extension_template": "Default_VRF_Extension_Universal",
-      "source": "None",
-      "service_vrf_template": "None"
-    }
-  ],
-  "playbook_msd_config" : [
-    {
-      "vrf_name": "test_vrf_1",
-      "vrf_id": "9008011",
-      "vrf_template": "Default_VRF_Universal",
-      "vrf_extension_template": "Default_VRF_Extension_Universal",
-      "vlan_id": "2000",
-      "source": "None",
-      "service_vrf_template": "None",
-      "attach": [
+    ],
+    "playbook_config_incorrect_vrfid": [
         {
-          "ip_address": "10.10.10.224"
+            "vrf_name": "test_vrf_1",
+            "vrf_id": "9008012",
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "source": "None",
+            "service_vrf_template": "None",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.224",
+                    "vlan_id": "202",
+                    "deploy": true
+                },
+                {
+                    "ip_address": "10.10.10.225",
+                    "vlan_id": "203",
+                    "deploy": true
+                }
+            ],
+            "deploy": true
         }
-      ],
-      "child_fabric_config": [
+    ],
+    "playbook_config_replace": [
         {
-          "adv_host_routes": false,
-          "adv_default_routes": false,
-          "l3vni_wo_vlan": false,
-          "fabric": "child_fabric"
+            "vrf_name": "test_vrf_1",
+            "vrf_id": "9008011",
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "vlan_id": "203",
+            "source": "None",
+            "service_vrf_template": "None",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.225",
+                    "deploy": true
+                },
+                {
+                    "ip_address": "10.10.10.226",
+                    "deploy": true
+                }
+            ],
+            "deploy": true
         }
-      ],
-      "deploy": true
-    }
-  ],
-  "playbook_msd_replace_config" : [
-    {
-      "vrf_name": "test_vrf_1",
-      "vrf_id": "9008011",
-      "vrf_template": "Default_VRF_Universal",
-      "vrf_extension_template": "Default_VRF_Extension_Universal",
-      "vrf_int_mtu": 1500,
-      "attach": [
+    ],
+    "playbook_config_replace_no_atch": [
         {
-          "ip_address": "10.10.10.224"
+            "vrf_name": "test_vrf_1",
+            "vrf_id": "9008011",
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "source": "None",
+            "service_vrf_template": "None"
         }
-      ],
-      "child_fabric_config": [
+    ],
+    "playbook_msd_config": [
         {
-          "fabric": "child_fabric",
-          "static_default_route": false,
-          "l3vni_wo_vlan": true
+            "vrf_name": "test_vrf_1",
+            "vrf_id": "9008011",
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "vlan_id": "2000",
+            "source": "None",
+            "service_vrf_template": "None",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.224"
+                }
+            ],
+            "child_fabric_config": [
+                {
+                    "adv_host_routes": false,
+                    "adv_default_routes": false,
+                    "l3vni_wo_vlan": false,
+                    "fabric": "child_fabric"
+                }
+            ],
+            "deploy": true
         }
-      ],
-      "deploy": true
-    }
-  ],
-  "playbook_msd_config_no_child" : [
-    {
-      "vrf_name": "test_vrf_1",
-      "vrf_id": "9008011",
-      "vrf_template": "Default_VRF_Universal",
-      "vrf_extension_template": "Default_VRF_Extension_Universal",
-      "vlan_id": "2000",
-      "source": "None",
-      "service_vrf_template": "None",
-      "attach": [
+    ],
+    "playbook_msd_replace_config": [
         {
-          "ip_address": "10.10.10.224"
+            "vrf_name": "test_vrf_1",
+            "vrf_id": "9008011",
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "vrf_int_mtu": 1500,
+            "attach": [
+                {
+                    "ip_address": "10.10.10.224"
+                }
+            ],
+            "child_fabric_config": [
+                {
+                    "fabric": "child_fabric",
+                    "static_default_route": false,
+                    "l3vni_wo_vlan": true
+                }
+            ],
+            "deploy": true
         }
-      ],
-      "deploy": true
-    }
-  ],
-  "playbook_msd_config_misconfig_1" : [
-    {
-      "vrf_name": "test_vrf_1",
-      "vrf_id": "9008011",
-      "vrf_template": "Default_VRF_Universal",
-      "vrf_extension_template": "Default_VRF_Extension_Universal",
-      "vlan_id": "2000",
-      "source": "None",
-      "service_vrf_template": "None",
-      "attach": [
+    ],
+    "playbook_msd_config_no_child": [
         {
-          "ip_address": "10.10.10.224"
+            "vrf_name": "test_vrf_1",
+            "vrf_id": "9008011",
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "vlan_id": "2000",
+            "source": "None",
+            "service_vrf_template": "None",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.224"
+                }
+            ],
+            "deploy": true
         }
-      ],
-      "child_fabric_config": [
+    ],
+    "playbook_msd_config_misconfig_1": [
         {
-          "fabric_name": "k_fab",
-          "static_default_route": true,
-          "l3vni_wo_vlan": true
+            "vrf_name": "test_vrf_1",
+            "vrf_id": "9008011",
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "vlan_id": "2000",
+            "source": "None",
+            "service_vrf_template": "None",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.224"
+                }
+            ],
+            "child_fabric_config": [
+                {
+                    "fabric_name": "k_fab",
+                    "static_default_route": true,
+                    "l3vni_wo_vlan": true
+                }
+            ],
+            "deploy": true
         }
-      ],
-      "deploy": true
-    }
-  ],
-  "playbook_msd_config_misconfig_2" : [
-    {
-      "vrf_name": "test_vrf_1",
-      "vrf_id": "9008011",
-      "vrf_template": "Default_VRF_Universal",
-      "vrf_extension_template": "Default_VRF_Extension_Universal",
-      "vlan_id": "2000",
-      "source": "None",
-      "service_vrf_template": "None",
-      "attach": [
+    ],
+    "playbook_msd_config_misconfig_2": [
         {
-          "ip_address": "10.10.10.224"
+            "vrf_name": "test_vrf_1",
+            "vrf_id": "9008011",
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "vlan_id": "2000",
+            "source": "None",
+            "service_vrf_template": "None",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.224"
+                }
+            ],
+            "child_fabric_config": [
+                {
+                    "fabric": "k_fab",
+                    "static_default_route": true,
+                    "l3vni_wo_vlan": true
+                }
+            ],
+            "deploy": true
         }
-      ],
-      "child_fabric_config": [
+    ],
+    "playbook_msd_config_misconfig_3": [
         {
-          "fabric": "k_fab",
-          "static_default_route": true,
-          "l3vni_wo_vlan": true
+            "vrf_name": "test_vrf_1",
+            "vrf_id": "9008011",
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "vlan_id": "2000",
+            "source": "None",
+            "service_vrf_template": "None",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.224"
+                }
+            ],
+            "child_fabric_config": [],
+            "deploy": true
         }
-      ],
-      "deploy": true
-    }
-  ],
-  "playbook_msd_config_misconfig_3" : [
-    {
-      "vrf_name": "test_vrf_1",
-      "vrf_id": "9008011",
-      "vrf_template": "Default_VRF_Universal",
-      "vrf_extension_template": "Default_VRF_Extension_Universal",
-      "vlan_id": "2000",
-      "source": "None",
-      "service_vrf_template": "None",
-      "attach": [
+    ],
+    "playbook_msd_delete_config": [
         {
-          "ip_address": "10.10.10.224"
+            "vrf_name": "test_vrf_1",
+            "vrf_id": "9008011",
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "vlan_id": "2000",
+            "source": "None",
+            "service_vrf_template": "None",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.224"
+                }
+            ],
+            "deploy": true
         }
-      ],
-      "child_fabric_config": [
-      ],
-      "deploy": true
-    }
-  ],
-  "playbook_msd_delete_config" : [
-    {
-      "vrf_name": "test_vrf_1",
-      "vrf_id": "9008011",
-      "vrf_template": "Default_VRF_Universal",
-      "vrf_extension_template": "Default_VRF_Extension_Universal",
-      "vlan_id": "2000",
-      "source": "None",
-      "service_vrf_template": "None",
-      "attach": [
+    ],
+    "playbook_msd_override_config": [
         {
-          "ip_address": "10.10.10.224"
+            "vrf_name": "test_vrf_2",
+            "vrf_id": "9008012",
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "vlan_id": "2001",
+            "source": "None",
+            "service_vrf_template": "None",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.224",
+                    "deploy": true
+                }
+            ],
+            "child_fabric_config": [
+                {
+                    "fabric": "child_fabric",
+                    "adv_host_routes": false,
+                    "adv_default_routes": false,
+                    "l3vni_wo_vlan": false
+                }
+            ],
+            "deploy": true
         }
-      ],
-      "deploy": true
-    }
-  ],
-  "playbook_msd_override_config": [
-    {
-      "vrf_name": "test_vrf_2",
-      "vrf_id": "9008012",
-      "vrf_template": "Default_VRF_Universal",
-      "vrf_extension_template": "Default_VRF_Extension_Universal",
-      "vlan_id": "2001",
-      "source": "None",
-      "service_vrf_template": "None",
-      "attach": [
+    ],
+    "playbook_msd_query_config": [
         {
-          "ip_address": "10.10.10.224",
-          "deploy": true
+            "vrf_name": "test_vrf_1",
+            "vrf_id": "9008011",
+            "vlan_id": "2000",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.224"
+                }
+            ],
+            "child_fabric_config": [
+                {
+                    "adv_host_routes": true,
+                    "adv_default_routes": true,
+                    "l3vni_wo_vlan": false,
+                    "fabric": "child_fabric"
+                }
+            ],
+            "deploy": true
         }
-      ],
-      "child_fabric_config": [
+    ],
+    "playbook_msd_child_config": [
         {
-          "fabric": "child_fabric",
-          "adv_host_routes": false,
-          "adv_default_routes": false,
-          "l3vni_wo_vlan": false
+            "vrf_name": "test_vrf_1",
+            "adv_host_routes": true,
+            "adv_default_routes": true,
+            "l3vni_wo_vlan": false
         }
-      ],
-      "deploy": true
-    }
-  ],
-  "playbook_msd_query_config" : [
-    {
-      "vrf_name": "test_vrf_1",
-      "vrf_id": "9008011",
-      "vlan_id": "2000",
-      "attach": [
+    ],
+    "playbook_mcfg_config": [
         {
-          "ip_address": "10.10.10.224"
+            "vrf_name": "test_vrf_1",
+            "vrf_id": "9008011",
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "vlan_id": "2000",
+            "source": "None",
+            "service_vrf_template": "None",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.224"
+                }
+            ],
+            "child_fabric_config": [
+                {
+                    "adv_host_routes": true,
+                    "adv_default_routes": true,
+                    "l3vni_wo_vlan": false,
+                    "fabric": "child_fabric"
+                }
+            ],
+            "deploy": true
         }
-      ],
-      "child_fabric_config": [
+    ],
+    "playbook_mcfg_replace_config": [
         {
-          "adv_host_routes": true,
-          "adv_default_routes": true,
-          "l3vni_wo_vlan": false,
-          "fabric": "child_fabric"
+            "vrf_name": "test_vrf_1",
+            "vrf_id": "9008011",
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "vrf_int_mtu": 1500,
+            "attach": [
+                {
+                    "ip_address": "10.10.10.224"
+                }
+            ],
+            "child_fabric_config": [
+                {
+                    "fabric": "child_fabric",
+                    "static_default_route": true,
+                    "l3vni_wo_vlan": true
+                }
+            ],
+            "deploy": true
         }
-      ],
-      "deploy": true
-    }
-  ],
-  "playbook_msd_child_config" : [
-    {
-      "vrf_name": "test_vrf_1",
-      "adv_host_routes": true,
-      "adv_default_routes": true,
-      "l3vni_wo_vlan": false
-    }
-  ],
-  "playbook_mcfg_config" : [
-    {
-      "vrf_name": "test_vrf_1",
-      "vrf_id": "9008011",
-      "vrf_template": "Default_VRF_Universal",
-      "vrf_extension_template": "Default_VRF_Extension_Universal",
-      "vlan_id": "2000",
-      "source": "None",
-      "service_vrf_template": "None",
-      "attach": [
+    ],
+    "playbook_mcfg_delete_config": [
         {
-          "ip_address": "10.10.10.224"
+            "vrf_name": "test_vrf_1",
+            "vrf_id": "9008011",
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "vlan_id": "2000",
+            "source": "None",
+            "service_vrf_template": "None",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.224"
+                }
+            ],
+            "deploy": true
         }
-      ],
-      "child_fabric_config": [
+    ],
+    "playbook_mcfg_override_config": [
         {
-          "adv_host_routes": true,
-          "adv_default_routes": true,
-          "l3vni_wo_vlan": false,
-          "fabric": "child_fabric"
+            "vrf_name": "test_vrf_2",
+            "vrf_id": "9008012",
+            "vrf_template": "Default_VRF_Universal",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "vlan_id": "2001",
+            "source": "None",
+            "service_vrf_template": "None",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.224",
+                    "deploy": true
+                }
+            ],
+            "child_fabric_config": [
+                {
+                    "fabric": "child_fabric",
+                    "adv_host_routes": true,
+                    "adv_default_routes": true,
+                    "l3vni_wo_vlan": false
+                }
+            ],
+            "deploy": true
         }
-      ],
-      "deploy": true
-    }
-  ],
-  "playbook_mcfg_replace_config" : [
-    {
-      "vrf_name": "test_vrf_1",
-      "vrf_id": "9008011",
-      "vrf_template": "Default_VRF_Universal",
-      "vrf_extension_template": "Default_VRF_Extension_Universal",
-      "vrf_int_mtu": 1500,
-      "attach": [
-        {
-          "ip_address": "10.10.10.224"
-        }
-      ],
-      "child_fabric_config": [
-        {
-          "fabric": "child_fabric",
-          "static_default_route": true,
-          "l3vni_wo_vlan": true
-        }
-      ],
-      "deploy": true
-    }
-  ],
-  "playbook_mcfg_delete_config" : [
-    {
-      "vrf_name": "test_vrf_1",
-      "vrf_id": "9008011",
-      "vrf_template": "Default_VRF_Universal",
-      "vrf_extension_template": "Default_VRF_Extension_Universal",
-      "vlan_id": "2000",
-      "source": "None",
-      "service_vrf_template": "None",
-      "attach": [
-        {
-          "ip_address": "10.10.10.224"
-        }
-      ],
-      "deploy": true
-    }
-  ],
-  "playbook_mcfg_override_config": [
-    {
-      "vrf_name": "test_vrf_2",
-      "vrf_id": "9008012",
-      "vrf_template": "Default_VRF_Universal",
-      "vrf_extension_template": "Default_VRF_Extension_Universal",
-      "vlan_id": "2001",
-      "source": "None",
-      "service_vrf_template": "None",
-      "attach": [
-        {
-          "ip_address": "10.10.10.224",
-          "deploy": true
-        }
-      ],
-      "child_fabric_config": [
-        {
-          "fabric": "child_fabric",
-          "adv_host_routes": true,
-          "adv_default_routes": true,
-          "l3vni_wo_vlan": false
-        }
-      ],
-      "deploy": true
-    }
-  ],
-  "nd_version": {
-    "RETURN_CODE":200,
-    "METHOD":"GET",
-    "MESSAGE":"OK",
-    "DATA":
-        {
+    ],
+    "nd_version": {
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "MESSAGE": "OK",
+        "DATA": {
             "version": "12.2.1.321",
             "mode": "",
             "isMediaController": false,
@@ -1061,13 +1059,12 @@
             "uuid": "",
             "is_upgrade_inprogress": false
         }
-  },
-  "nd_version_11": {
-    "RETURN_CODE":200,
-    "METHOD":"GET",
-    "MESSAGE":"OK",
-    "DATA":
-        {
+    },
+    "nd_version_11": {
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "MESSAGE": "OK",
+        "DATA": {
             "version": "11.1",
             "mode": "",
             "isMediaController": false,
@@ -1077,1132 +1074,1132 @@
             "uuid": "",
             "is_upgrade_inprogress": false
         }
-  },
-  "mock_fabric_associations": {
-    "DATA": [
-      {
-        "fabricId": 38,
-        "fabricName": "parent_fabric",
-        "fabricParent": "None",
-        "fabricState": "msd",
-        "fabricTechnology": "VXLANFabric",
-        "fabricType": "MSD"
-      },
-      {
-        "fabricId": 40,
-        "fabricName": "child_fabric",
-        "fabricParent": "parent_fabric",
-        "fabricState": "member",
-        "fabricTechnology": "VXLANFabric",
-        "fabricType": "Switch_Fabric"
-      },
-      {
-        "fabricId": 11,
-        "fabricName": "standalone_fabric",
-        "fabricParent": "None",
-        "fabricState": "standalone",
-        "fabricTechnology": "VXLANFabric",
-        "fabricType": "Switch_Fabric"
-      }
-    ],
-    "MESSAGE": "OK",
-    "METHOD": "GET",
-    "REQUEST_PATH": "https://mock.ndfc/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/msd/fabric-associations",
-    "RETURN_CODE": 200
-  },
-  "mock_vrf_get_object": {
-    "RETURN_CODE": 200,
-    "MESSAGE": "OK",
-    "DATA":[
-      {
-        "fabric": "child_fabric",
-        "vrfName": "test_vrf_1",
-        "enforce": null,
-        "defaultSGTag": null,
-        "vrfTemplate": "Default_VRF_Universal",
-        "vrfExtensionTemplate": "Default_VRF_Extension_Universal",
-        "vrfTemplateConfig": "{\"routeTargetExportEvpn\":\"\",\"routeTargetImport\":\"\",\"vrfVlanId\":\"2000\",\"vrfDescription\":\"\",\"disableRtAuto\":\"false\",\"v6VrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"maxBgpPaths\":\"1\",\"maxIbgpPaths\":\"2\",\"vrfSegmentId\":\"50000\",\"routeTargetExport\":\"\",\"ipv6LinkLocalFlag\":\"true\",\"mtu\":\"9216\",\"vrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"vrfVlanName\":\"\",\"tag\":\"12345\",\"nveId\":\"1\",\"vrfIntfDescription\":\"\",\"routeTargetImportEvpn\":\"\",\"vrfName\":\"test_vrf_1\"}",
-        "tenantName": null,
-        "id": 19899,
-        "vrfId": 9008011,
-        "serviceVrfTemplate": null,
-        "source": null,
-        "vrfStatus": "DEPLOYED",
-        "hierarchicalKey": "child_fabric"
-      },
-      {
-        "fabric": "child_fabric",
-        "vrfName": "test_vrf_2",
-        "enforce": null,
-        "defaultSGTag": null,
-        "vrfTemplate": "Default_VRF_Universal",
-        "vrfExtensionTemplate": "Default_VRF_Extension_Universal",
-        "vrfTemplateConfig": "{\"routeTargetExportEvpn\":\"\",\"routeTargetImport\":\"\",\"vrfVlanId\":\"2001\",\"vrfDescription\":\"\",\"disableRtAuto\":\"false\",\"v6VrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"maxBgpPaths\":\"1\",\"maxIbgpPaths\":\"2\",\"vrfSegmentId\":\"50000\",\"routeTargetExport\":\"\",\"ipv6LinkLocalFlag\":\"true\",\"mtu\":\"9216\",\"vrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"vrfVlanName\":\"\",\"tag\":\"12345\",\"nveId\":\"1\",\"vrfIntfDescription\":\"\",\"routeTargetImportEvpn\":\"\",\"vrfName\":\"test_vrf_2\"}",
-        "tenantName": null,
-        "id": 19899,
-        "vrfId": 9008012,
-        "serviceVrfTemplate": null,
-        "source": null,
-        "vrfStatus": "DEPLOYED",
-        "hierarchicalKey": "child_fabric"
-      }
-    ]
-  },
-  "mock_vrf_attach_object_del_not_ready": {
-    "ERROR": "",
-    "RETURN_CODE": 200,
-    "MESSAGE": "OK",
-    "DATA": [
-      {
-        "vrfName": "test_vrf_1",
-        "lanAttachList": [
-          {
-            "lanAttachState": "DEPLOYED",
-            "isLanAttached": false
-          },
-          {
-            "lanAttachState": "DEPLOYED",
-            "isLanAttached": false
-          }
-        ]
-      }
-    ]
-  },
-  "mock_msd_vrf_attach_object_del_not_ready": {
-    "ERROR": "",
-    "RETURN_CODE": 200,
-    "MESSAGE": "OK",
-    "DATA": [
-      {
-        "vrfName": "test_vrf_1",
-        "lanAttachList": [
-          {
-            "vrfName": "test_vrf_1",
-            "switchName": "n9kv_leaf1",
-            "lanAttachState": "DEPLOYED",
-            "isLanAttached": true,
-            "switchSerialNo": "XYZKSJHSMK1",
-            "switchRole": "leaf",
-            "fabricName": "child_fabric",
-            "ipAddress": "10.10.10.224",
-            "vlanId": "2000",
-            "vrfId": "9008011"
-          }
-        ]
-      }
-    ]
-  },
-  "mock_vrf_attach_object_del_oos": {
-    "ERROR": "",
-    "RETURN_CODE": 200,
-    "MESSAGE": "OK",
-    "DATA": [
-      {
-        "vrfName": "test_vrf_1",
-        "lanAttachList": [
-          {
-            "lanAttachState": "OUT-OF-SYNC"
-          },
-          {
-            "lanAttachState": "OUT-OF-SYNC"
-          }
-        ]
-      }
-    ]
-  },
-  "mock_vrf_attach_object_del_ready": {
-    "ERROR": "",
-    "RETURN_CODE": 200,
-    "MESSAGE": "OK",
-    "DATA": [
-      {
-        "vrfName": "test_vrf_1",
-        "lanAttachList": [
-          {
-            "lanAttachState": "NA",
-            "isLanAttached": false
-          },
-          {
-            "lanAttachState": "NA",
-            "isLanAttached": false
-          }
-        ]
-      }
-    ]
-  },
-  "mock_msd_vrf_attach_object_del_ready": {
-    "ERROR": "",
-    "RETURN_CODE": 200,
-    "MESSAGE": "OK",
-    "DATA": [
-      {
-        "vrfName": "test_vrf_1",
-        "lanAttachList": [
-          {
-            "vrfName": "test_vrf_1",
-            "switchName": "n9kv_leaf1",
-            "lanAttachState": "NA",
-            "isLanAttached": false,
-            "switchSerialNo": "XYZKSJHSMK1",
-            "switchRole": "leaf",
-            "fabricName": "child_fabric",
-            "ipAddress": "10.10.10.224",
-            "vlanId": "2000",
-            "vrfId": "9008011"
-          }
-        ]
-      }
-    ]
-  },
-  "mock_vrf_object": {
-    "ERROR": "",
-    "RETURN_CODE": 200,
-    "MESSAGE":"OK",
-    "DATA": [
-      {
-        "fabric": "standalone_fabric",
-        "serviceVrfTemplate": "None",
-        "source": "None",
-        "vrfExtensionTemplate": "Default_VRF_Extension_Universal",
-        "vrfId": 9008011,
-        "vrfName": "test_vrf_1",
-        "vrfTemplate": "Default_VRF_Universal",
-        "vrfTemplateConfig": "{\"advertiseDefaultRouteFlag\":\"true\",\"vrfVlanId\":\"202\",\"isRPExternal\":\"false\",\"vrfDescription\":\"\",\"L3VniMcastGroup\":\"\",\"maxBgpPaths\":\"1\",\"maxIbgpPaths\":\"2\",\"vrfSegmentId\":\"9008013\",\"ipv6LinkLocalFlag\":\"true\",\"vrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"v6VrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"configureStaticDefaultRouteFlag\":\"true\",\"trmBGWMSiteEnabled\":\"false\",\"tag\":\"12345\",\"rpAddress\":\"\",\"nveId\":\"1\",\"bgpPasswordKeyType\":\"3\",\"bgpPassword\":\"\",\"mtu\":\"9216\",\"multicastGroup\":\"\",\"advertiseHostRouteFlag\":\"false\",\"vrfVlanName\":\"\",\"trmEnabled\":\"false\",\"loopbackNumber\":\"\",\"asn\":\"34343\",\"vrfIntfDescription\":\"\",\"vrfName\":\"test_vrf_1\"}",
-        "vrfStatus": "DEPLOYED"
-      }
-    ]
-  },
-  "mock_msd_parent_vrf_object": {
-    "ERROR": "",
-    "RETURN_CODE": 200,
-    "MESSAGE":"OK",
-    "DATA": [
-      {
-        "fabric": "parent_fabric",
-        "serviceVrfTemplate": "None",
-        "source": "None",
-        "vrfExtensionTemplate": "Default_VRF_Extension_Universal",
-        "vrfId": 9008011,
-        "vrfName": "test_vrf_1",
-        "vrfTemplate": "Default_VRF_Universal",
-        "vrfTemplateConfig": "{\"advertiseDefaultRouteFlag\":\"true\",\"vrfVlanId\":\"2000\",\"isRPExternal\":\"false\",\"vrfDescription\":\"\",\"L3VniMcastGroup\":\"\",\"maxBgpPaths\":\"1\",\"maxIbgpPaths\":\"2\",\"vrfSegmentId\":\"9008013\",\"ipv6LinkLocalFlag\":\"true\",\"vrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"v6VrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"configureStaticDefaultRouteFlag\":\"true\",\"trmBGWMSiteEnabled\":\"false\",\"tag\":\"12345\",\"rpAddress\":\"\",\"nveId\":\"1\",\"bgpPasswordKeyType\":\"3\",\"bgpPassword\":\"\",\"mtu\":\"9216\",\"multicastGroup\":\"\",\"advertiseHostRouteFlag\":\"false\",\"vrfVlanName\":\"\",\"trmEnabled\":\"false\",\"loopbackNumber\":\"\",\"asn\":\"34343\",\"vrfIntfDescription\":\"\",\"vrfName\":\"test_vrf_1\"}",
-        "vrfStatus": "DEPLOYED"
-      }
-    ]
-  },
-  "mock_msd_vrf_object": {
-    "ERROR": "",
-    "RETURN_CODE": 200,
-    "MESSAGE":"OK",
-    "DATA": [
-      {
-        "fabric": "child_fabric",
-        "serviceVrfTemplate": "None",
-        "source": "None",
-        "vrfExtensionTemplate": "Default_VRF_Extension_Universal",
-        "vrfId": 9008011,
-        "vrfName": "test_vrf_1",
-        "vrfTemplate": "Default_VRF_Universal",
-        "vrfTemplateConfig": "{\"advertiseDefaultRouteFlag\":\"true\",\"vrfVlanId\":\"2000\",\"isRPExternal\":\"false\",\"vrfDescription\":\"\",\"L3VniMcastGroup\":\"\",\"maxBgpPaths\":\"1\",\"maxIbgpPaths\":\"2\",\"vrfSegmentId\":\"9008013\",\"ipv6LinkLocalFlag\":\"true\",\"vrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"v6VrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"configureStaticDefaultRouteFlag\":\"true\",\"trmBGWMSiteEnabled\":\"false\",\"tag\":\"12345\",\"rpAddress\":\"\",\"nveId\":\"1\",\"bgpPasswordKeyType\":\"3\",\"bgpPassword\":\"\",\"mtu\":\"9216\",\"multicastGroup\":\"\",\"advertiseHostRouteFlag\":\"false\",\"vrfVlanName\":\"\",\"trmEnabled\":\"false\",\"loopbackNumber\":\"\",\"asn\":\"34343\",\"vrfIntfDescription\":\"\",\"vrfName\":\"test_vrf_1\"}",
-        "vrfStatus": "DEPLOYED"
-      }
-    ]
-  },
-  "mock_msd_vrf_object_2": {
-    "ERROR": "",
-    "RETURN_CODE": 200,
-    "MESSAGE":"OK",
-    "DATA": [
-      {
-        "fabric": "child_fabric",
-        "serviceVrfTemplate": "None",
-        "source": "None",
-        "vrfExtensionTemplate": "Default_VRF_Extension_Universal",
-        "vrfId": 9008012,
-        "vrfName": "test_vrf_2",
-        "vrfTemplate": "Default_VRF_Universal",
-        "vrfTemplateConfig": "{\"advertiseDefaultRouteFlag\":\"true\",\"vrfVlanId\":\"2001\",\"isRPExternal\":\"false\",\"vrfDescription\":\"\",\"L3VniMcastGroup\":\"\",\"maxBgpPaths\":\"1\",\"maxIbgpPaths\":\"2\",\"vrfSegmentId\":\"9008013\",\"ipv6LinkLocalFlag\":\"true\",\"vrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"v6VrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"configureStaticDefaultRouteFlag\":\"true\",\"trmBGWMSiteEnabled\":\"false\",\"tag\":\"12345\",\"rpAddress\":\"\",\"nveId\":\"1\",\"bgpPasswordKeyType\":\"3\",\"bgpPassword\":\"\",\"mtu\":\"9216\",\"multicastGroup\":\"\",\"advertiseHostRouteFlag\":\"false\",\"vrfVlanName\":\"\",\"trmEnabled\":\"false\",\"loopbackNumber\":\"\",\"asn\":\"34343\",\"vrfIntfDescription\":\"\",\"vrfName\":\"test_vrf_2\"}",
-        "vrfStatus": "DEPLOYED"
-      }
-    ]
-  },
-  "mock_vrf_attach_object" : {
-    "MESSAGE": "OK",
-    "METHOD": "POST",
-    "RETURN_CODE": 200,
-    "DATA": [
-      {
-        "vrfName": "test_vrf_1",
-        "lanAttachList": [
-          {
-            "vrfName": "test_vrf_1",
-            "switchName": "n9kv_leaf1",
-            "lanAttachState": "DEPLOYED",
-            "instanceValues": "{\"loopbackId\":\"\",\"loopbackIpAddress\":\"\",\"loopbackIpV6Address\":\"\",\"switchRouteTargetImportEvpn\":\"5000:100\",\"switchRouteTargetExportEvpn\":\"5000:100\"}",
-            "isLanAttached": true,
-            "switchSerialNo": "XYZKSJHSMK1",
-            "switchRole": "leaf",
-            "fabricName": "test-fabric",
-            "ipAddress": "10.10.10.224",
-            "vlanId": "202",
-            "vrfId": "9008011"
-          },
-          {
-            "vrfName": "test_vrf_1",
-            "switchName": "n9kv_leaf2",
-            "lanAttachState": "DEPLOYED",
-            "instanceValues": "{\"loopbackId\":\"\",\"loopbackIpAddress\":\"\",\"loopbackIpV6Address\":\"\",\"switchRouteTargetImportEvpn\":\"5000:100\",\"switchRouteTargetExportEvpn\":\"5000:100\"}",
-            "isLanAttached": true,
-            "switchSerialNo": "XYZKSJHSMK2",
-            "switchRole": "leaf",
-            "fabricName": "test-fabric",
-            "ipAddress": "10.10.10.225",
-            "vlanId": "202",
-            "vrfId": "9008011"
-          }
-        ]
-      }
-    ]
-  },
-  "mock_msd_vrf_attach_object" : {
-    "MESSAGE": "OK",
-    "METHOD": "POST",
-    "RETURN_CODE": 200,
-    "DATA": [
-      {
-        "vrfName": "test_vrf_1",
-        "lanAttachList": [
-          {
-            "vrfName": "test_vrf_1",
-            "switchName": "n9kv_leaf1",
-            "lanAttachState": "DEPLOYED",
-            "instanceValues": "{\"loopbackId\":\"\",\"loopbackIpAddress\":\"\",\"loopbackIpV6Address\":\"\",\"switchRouteTargetImportEvpn\":\"\",\"switchRouteTargetExportEvpn\":\"\"}",
-            "isLanAttached": true,
-            "switchSerialNo": "XYZKSJHSMK1",
-            "switchRole": "leaf",
-            "fabricName": "test-fabric",
-            "ipAddress": "10.10.10.224",
-            "vlanId": "2000",
-            "vrfId": "9008011"
-          }
-        ]
-      }
-    ]
-  },
-  "mock_msd_vrf_child_attach_object" : {
-    "MESSAGE": "OK",
-    "METHOD": "POST",
-    "RETURN_CODE": 200,
-    "DATA": [
-      {
-        "vrfName": "test_vrf_1",
-        "lanAttachList": [
-          {
-            "vrfName": "test_vrf_1",
-            "switchName": "n9kv_leaf1",
-            "lanAttachState": "DEPLOYED",
-            "instanceValues": "{\"loopbackId\":\"\",\"loopbackIpAddress\":\"\",\"loopbackIpV6Address\":\"\",\"switchRouteTargetImportEvpn\":\"\",\"switchRouteTargetExportEvpn\":\"\"}",
-            "isLanAttached": true,
-            "switchSerialNo": "XYZKSJHSMK1",
-            "switchRole": "leaf",
-            "fabricName": "child_fabric",
-            "ipAddress": "10.10.10.224",
-            "vlanId": "2000",
-            "vrfId": "9008011"
-          }
-        ]
-      }
-    ]
-  },
-  "mock_msd_vrf_child_attach_object_2" : {
-    "MESSAGE": "OK",
-    "METHOD": "POST",
-    "RETURN_CODE": 200,
-    "DATA": [
-      {
-        "vrfName": "test_vrf_2",
-        "lanAttachList": [
-          {
-            "vrfName": "test_vrf_2",
-            "switchName": "n9kv_leaf1",
-            "lanAttachState": "DEPLOYED",
-            "instanceValues": "{\"loopbackId\":\"\",\"loopbackIpAddress\":\"\",\"loopbackIpV6Address\":\"\",\"switchRouteTargetImportEvpn\":\"\",\"switchRouteTargetExportEvpn\":\"\"}",
-            "isLanAttached": true,
-            "switchSerialNo": "XYZKSJHSMK1",
-            "switchRole": "leaf",
-            "fabricName": "child_fabric",
-            "ipAddress": "10.10.10.224",
-            "vlanId": "2001",
-            "vrfId": "9008012"
-          }
-        ]
-      }
-    ]
-  },
-  "mock_msd_vrf_get_attach_object_replaced_parent" : {
-    "METHOD": "GET",
-    "RETURN_CODE": 200,
-    "DATA": [
-      {
-        "vrfName": "test_vrf_1",
-        "lanAttachList": [
-          {
-            "vrfName": "test_vrf_1",
-            "switchName": "n9kv_leaf1",
-            "lanAttachState": "DEPLOYED",
-            "instanceValues": "{\"loopbackId\":\"\",\"loopbackIpAddress\":\"\",\"loopbackIpV6Address\":\"\",\"switchRouteTargetImportEvpn\":\"\",\"switchRouteTargetExportEvpn\":\"\"}",
-            "isLanAttached": true,
-            "switchSerialNo": "XYZKSJHSMK1",
-            "switchRole": "leaf",
-            "fabricName": "test-fabric",
-            "ipAddress": "10.10.10.224",
-            "vlanId": "2000",
-            "vrfId": "9008011"
-          }
-        ]
-      }
-    ]
-  },
-   "mock_vrf_attach_object_query" : {
-    "MESSAGE": "OK",
-    "METHOD": "POST",
-    "RETURN_CODE": 200,
-    "DATA": [
-      {
-        "vrfName": "test_vrf_1",
-        "lanAttachList": [
-          {
-            "vrfName": "test_vrf_1",
-            "switchName": "n9kv_leaf1",
-            "lanAttachState": "DEPLOYED",
-            "isLanAttached": true,
-            "switchSerialNo": "XYZKSJHSMK1",
-            "switchRole": "leaf",
-            "fabricName": "test-fabric",
-            "ipAddress": "10.10.10.224",
-            "vlanId": "202",
-            "vrfId": "9008011"
-          },
-          {
-            "vrfName": "test_vrf_1",
-            "switchName": "n9kv_leaf2",
-            "lanAttachState": "DEPLOYED",
-            "isLanAttached": true,
-            "switchSerialNo": "XYZKSJHSMK2",
-            "switchRole": "leaf",
-            "fabricName": "test-fabric",
-            "ipAddress": "10.10.10.225",
-            "vlanId": "202",
-            "vrfId": "9008011"
-          }
-        ]
-      }
-    ]
-  },
-  "mock_msd_vrf_parent_attach_object_query" : {
-    "MESSAGE": "OK",
-    "METHOD": "POST",
-    "RETURN_CODE": 200,
-    "DATA": [
-      {
-        "vrfName": "test_vrf_1",
-        "lanAttachList": [
-          {
-            "vrfName": "test_vrf_1",
-            "switchName": "n9kv_leaf1",
-            "lanAttachState": "DEPLOYED",
-            "isLanAttached": true,
-            "switchSerialNo": "XYZKSJHSMK1",
-            "switchRole": "leaf",
-            "fabricName": "parent_fabric",
-            "ipAddress": "10.10.10.224",
-            "vlanId": "2000",
-            "vrfId": "9008011"
-          }
-        ]
-      }
-    ]
-  },
-  "mock_msd_vrf_child_attach_object_query" : {
-    "MESSAGE": "OK",
-    "METHOD": "POST",
-    "RETURN_CODE": 200,
-    "DATA": [
-      {
-        "vrfName": "test_vrf_1",
-        "lanAttachList": [
-          {
-            "vrfName": "test_vrf_1",
-            "switchName": "n9kv_leaf1",
-            "lanAttachState": "DEPLOYED",
-            "isLanAttached": true,
-            "switchSerialNo": "XYZKSJHSMK1",
-            "switchRole": "leaf",
-            "fabricName": "child_fabric",
-            "ipAddress": "10.10.10.224",
-            "vlanId": "2000",
-            "vrfId": "9008011"
-          }
-        ]
-      }
-    ]
-  },
-  "mock_vrf_attach_object2" : {
-    "MESSAGE": "OK",
-    "METHOD": "POST",
-    "RETURN_CODE": 200,
-    "DATA": [
-      {
-        "vrfName": "test_vrf_1",
-        "lanAttachList": [
-          {
-            "vrfName": "test_vrf_1",
-            "switchName": "n9kv_leaf1",
-            "lanAttachState": "DEPLOYED",
-            "isLanAttached": true,
-            "switchSerialNo": "XYZKSJHSMK1",
-            "switchRole": "leaf",
-            "fabricName": "test-fabric",
-            "ipAddress": "10.10.10.224",
-            "vlanId": "202",
-            "vrfId": "9008011"
-          },
-          {
-            "vrfName": "test_vrf_1",
-            "switchName": "n9kv_leaf4",
-            "lanAttachState": "DEPLOYED",
-            "isLanAttached": true,
-            "switchSerialNo": "XYZKSJHSMK4",
-            "switchRole": "border",
-            "fabricName": "test-fabric",
-            "ipAddress": "10.10.10.227",
-            "vlanId": "202",
-            "vrfId": "9008011"
-          }
-        ]
-      }
-    ]
-  },
-  "mock_vrf_attach_object2_query" : {
-    "MESSAGE": "OK",
-    "METHOD": "POST",
-    "RETURN_CODE": 200,
-    "DATA": [
-      {
-        "vrfName": "test_vrf_1",
-        "lanAttachList": [
-          {
-            "vrfName": "test_vrf_1",
-            "switchName": "n9kv_leaf1",
-            "lanAttachState": "DEPLOYED",
-            "isLanAttached": true,
-            "switchSerialNo": "XYZKSJHSMK1",
-            "switchRole": "leaf",
-            "fabricName": "test-fabric",
-            "ipAddress": "10.10.10.224",
-            "vlanId": "202",
-            "vrfId": "9008011"
-          },
-          {
-            "vrfName": "test_vrf_1",
-            "switchName": "n9kv_leaf4",
-            "lanAttachState": "DEPLOYED",
-            "isLanAttached": true,
-            "switchSerialNo": "XYZKSJHSMK4",
-            "switchRole": "border",
-            "fabricName": "test-fabric",
-            "ipAddress": "10.10.10.227",
-            "vlanId": "202",
-            "vrfId": "9008011"
-          }
-        ]
-      }
-    ]
-  },
-  "mock_vrf_attach_lite_object" : {
-    "MESSAGE": "OK",
-    "METHOD": "POST",
-    "RETURN_CODE": 200,
-    "DATA": [
-      {
-        "vrfName": "test_vrf_1",
-        "lanAttachList": [
-          {
-            "deployment": true,
-            "extensionValues": "",
-            "fabric": "standalone_fabric",
-            "freeformConfig": "",
-            "instanceValues": "",
-            "serialNumber": "XYZKSJHSMK1",
-            "vlan": 202,
-            "vrfName": "test_vrf_1",
-            "vrf_lite": []
-          },
-          {
-            "deployment": true,
-            "extensionValues": "{\"VRF_LITE_CONN\":\"{\\\"VRF_LITE_CONN\\\":[{\\\"IF_NAME\\\":\\\"Ethernet1/16\\\",\\\"DOT1Q_ID\\\":\\\"2\\\",\\\"IP_MASK\\\":\\\"10.33.0.2/30\\\",\\\"NEIGHBOR_IP\\\":\\\"10.33.0.1\\\",\\\"NEIGHBOR_ASN\\\":\\\"65535\\\",\\\"IPV6_MASK\\\":\\\"2010::10:34:0:7/64\\\",\\\"IPV6_NEIGHBOR\\\":\\\"2010::10:34:0:3\\\",\\\"AUTO_VRF_LITE_FLAG\\\":\\\"false\\\",\\\"PEER_VRF_NAME\\\":\\\"ansible-vrf-int1\\\",\\\"VRF_LITE_JYTHON_TEMPLATE\\\":\\\"Ext_VRF_Lite_Jython\\\"}]}\",\"MULTISITE_CONN\":\"{\\\"MULTISITE_CONN\\\":[]}\"}",
-            "fabric": "standalone_fabric",
-            "freeformConfig": "",
-            "instanceValues": "{\"loopbackId\":\"\",\"loopbackIpAddress\":\"\",\"loopbackIpV6Address\":\"\",\"switchRouteTargetImportEvpn\":\"5000:100\",\"switchRouteTargetExportEvpn\":\"5000:100\"}",
-            "serialNumber": "XYZKSJHSMK4",
-            "vlan": 202,
-            "vrfName": "test_vrf_1"
-          }
-        ]
-      }
-    ]
-  },
-  "mock_vrf_attach_object_pending": {
-    "MESSAGE": "OK",
-    "METHOD": "POST",
-    "RETURN_CODE": 200,
-    "DATA": [
-      {
-        "vrfName": "test_vrf_1",
-        "lanAttachList": [
-          {
-            "vrfName": "test_vrf_1",
-            "switchName": "n9kv_leaf1",
-            "lanAttachState": "PENDING",
-            "isLanAttached": true,
-            "switchSerialNo": "XYZKSJHSMK1",
-            "switchRole": "leaf",
-            "fabricName": "test-fabric",
-            "ipAddress": "10.10.10.224",
-            "vlanId": "202",
-            "vrfId": "9008011"
-          },
-          {
-            "vrfName": "test_vrf_1",
-            "switchName": "n9kv_leaf2",
-            "lanAttachState": "PENDING",
-            "isLanAttached": true,
-            "switchSerialNo": "XYZKSJHSMK2",
-            "switchRole": "leaf",
-            "fabricName": "test-fabric",
-            "ipAddress": "10.10.10.225",
-            "vlanId": "202",
-            "vrfId": "9008011"
-          }
-        ]
-      }
-    ]
-  },
-  "mock_vrf_object_dcnm_only": {
-    "ERROR": "",
-    "RETURN_CODE": 200,
-    "MESSAGE": "OK",
-    "DATA": [
-      {
-        "fabric": "standalone_fabric",
-        "vrfName": "test_vrf_dcnm",
-        "vrfTemplate": "Default_VRF_Universal",
-        "vrfExtensionTemplate": "Default_VRF_Extension_Universal",
-        "serviceVrfTemplate": "None",
-        "source": "None",
-        "vrfStatus": "DEPLOYED",
-        "vrfTemplateConfig": "{\"advertiseDefaultRouteFlag\":\"true\",\"vrfVlanId\":\"202\",\"isRPExternal\":\"false\",\"vrfDescription\":\"\",\"L3VniMcastGroup\":\"\",\"maxBgpPaths\":\"1\",\"maxIbgpPaths\":\"2\",\"vrfSegmentId\":\"9008013\",\"ipv6LinkLocalFlag\":\"true\",\"vrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"v6VrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"configureStaticDefaultRouteFlag\":\"true\",\"trmBGWMSiteEnabled\":\"false\",\"tag\":\"12345\",\"rpAddress\":\"\",\"nveId\":\"1\",\"bgpPasswordKeyType\":\"3\",\"bgpPassword\":\"\",\"mtu\":\"9216\",\"multicastGroup\":\"\",\"advertiseHostRouteFlag\":\"false\",\"vrfVlanName\":\"\",\"trmEnabled\":\"false\",\"loopbackNumber\":\"\",\"asn\":\"34343\",\"vrfIntfDescription\":\"\",\"vrfName\":\"test_vrf_dcnm\"}",
-        "vrfId": "9008013"
-      }
-    ]
-  },
-  "mock_net_from_vrf_empty": {
-    "ERROR": "",
-    "RETURN_CODE": 200,
-    "MESSAGE": "OK",
-    "DATA": []
-  },
-  "mock_vrf_attach_object_dcnm_only": {
-    "MESSAGE": "OK",
-    "METHOD": "POST",
-    "RETURN_CODE": 200,
-    "DATA": [
-      {
-        "vrfName": "test_vrf_dcnm",
-        "lanAttachList": [
-          {
-            "vrfName": "test_vrf_dcnm",
-            "switchName": "n9kv_leaf1",
-            "lanAttachState": "DEPLOYED",
-            "isLanAttached": true,
-            "switchSerialNo": "XYZKSJHSMK1",
-            "switchRole": "leaf",
-            "fabricName": "test-fabric",
-            "ipAddress": "10.10.10.224",
-            "vlanId": "402",
-            "vrfId": "9008013"
-          },
-          {
-            "vrfName": "test_vrf_dcnm",
-            "switchName": "n9kv_leaf2",
-            "lanAttachState": "DEPLOYED",
-            "isLanAttached": true,
-            "switchSerialNo": "XYZKSJHSMK2",
-            "switchRole": "leaf",
-            "fabricName": "test-fabric",
-            "ipAddress": "10.10.10.225",
-            "vlanId": "403",
-            "vrfId": "9008013"
-          }
-        ]
-      }
-    ]
-  },
-  "mock_vrf_attach_get_ext_object_dcnm_att1_only": {
-    "MESSAGE": "OK",
-    "METHOD": "POST",
-    "RETURN_CODE": 200,
-    "DATA": [
-      {
-        "switchDetailsList": [
+    },
+    "mock_fabric_associations": {
+        "DATA": [
             {
-                "errorMessage": null,
-                "extensionPrototypeValues": [],
-                "extensionValues": "",
-                "freeformConfig": "",
-                "instanceValues": "{\"loopbackId\":\"10\",\"loopbackIpAddress\":\"11.1.1.1\",\"loopbackIpV6Address\":\"\",\"switchRouteTargetImportEvpn\":\"5000:100\",\"switchRouteTargetExportEvpn\":\"5000:100\"}",
-                "islanAttached": true,
-                "lanAttachedState": "DEPLOYED",
-                "peerSerialNumber": null,
-                "role": "leaf",
-                "serialNumber": "XYZKSJHSMK1",
-                "switchName": "n9kv_leaf1",
-                "vlan": "402",
-                "vlanModifiable": true
+                "fabricId": 38,
+                "fabricName": "parent_fabric",
+                "fabricParent": "None",
+                "fabricState": "msd",
+                "fabricTechnology": "VXLANFabric",
+                "fabricType": "MSD"
+            },
+            {
+                "fabricId": 40,
+                "fabricName": "child_fabric",
+                "fabricParent": "parent_fabric",
+                "fabricState": "member",
+                "fabricTechnology": "VXLANFabric",
+                "fabricType": "Switch_Fabric"
+            },
+            {
+                "fabricId": 11,
+                "fabricName": "standalone_fabric",
+                "fabricParent": "None",
+                "fabricState": "standalone",
+                "fabricTechnology": "VXLANFabric",
+                "fabricType": "Switch_Fabric"
             }
         ],
-        "templateName": "Default_VRF_Universal",
-        "vrfName": "test_vrf_dcnm"
-      }
-    ]
-  },
-  "mock_vrf_attach_get_ext_object_dcnm_att2_only": {
-    "MESSAGE": "OK",
-    "METHOD": "POST",
-    "RETURN_CODE": 200,
-    "DATA": [
-      {
-        "switchDetailsList": [
+        "MESSAGE": "OK",
+        "METHOD": "GET",
+        "REQUEST_PATH": "https://mock.ndfc/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/msd/fabric-associations",
+        "RETURN_CODE": 200
+    },
+    "mock_vrf_get_object": {
+        "RETURN_CODE": 200,
+        "MESSAGE": "OK",
+        "DATA": [
             {
-                "errorMessage": null,
-                "extensionPrototypeValues": [],
-                "extensionValues": "",
-                "freeformConfig": "",
-                "instanceValues": "{\"loopbackId\":\"10\",\"loopbackIpAddress\":\"11.1.1.1\",\"loopbackIpV6Address\":\"\",\"switchRouteTargetImportEvpn\":\"5000:100\",\"switchRouteTargetExportEvpn\":\"5000:100\"}",
-                "islanAttached": true,
-                "lanAttachedState": "DEPLOYED",
-                "peerSerialNumber": null,
-                "role": "leaf",
-                "serialNumber": "XYZKSJHSMK2",
-                "switchName": "n9kv_leaf2",
-                "vlan": "403",
-                "vlanModifiable": true
+                "fabric": "child_fabric",
+                "vrfName": "test_vrf_1",
+                "enforce": null,
+                "defaultSGTag": null,
+                "vrfTemplate": "Default_VRF_Universal",
+                "vrfExtensionTemplate": "Default_VRF_Extension_Universal",
+                "vrfTemplateConfig": "{\"routeTargetExportEvpn\":\"\",\"routeTargetImport\":\"\",\"vrfVlanId\":\"2000\",\"vrfDescription\":\"\",\"disableRtAuto\":\"false\",\"v6VrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"maxBgpPaths\":\"1\",\"maxIbgpPaths\":\"2\",\"vrfSegmentId\":\"50000\",\"routeTargetExport\":\"\",\"ipv6LinkLocalFlag\":\"true\",\"mtu\":\"9216\",\"vrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"vrfVlanName\":\"\",\"tag\":\"12345\",\"nveId\":\"1\",\"vrfIntfDescription\":\"\",\"routeTargetImportEvpn\":\"\",\"vrfName\":\"test_vrf_1\"}",
+                "tenantName": null,
+                "id": 19899,
+                "vrfId": 9008011,
+                "serviceVrfTemplate": null,
+                "source": null,
+                "vrfStatus": "DEPLOYED",
+                "hierarchicalKey": "child_fabric"
+            },
+            {
+                "fabric": "child_fabric",
+                "vrfName": "test_vrf_2",
+                "enforce": null,
+                "defaultSGTag": null,
+                "vrfTemplate": "Default_VRF_Universal",
+                "vrfExtensionTemplate": "Default_VRF_Extension_Universal",
+                "vrfTemplateConfig": "{\"routeTargetExportEvpn\":\"\",\"routeTargetImport\":\"\",\"vrfVlanId\":\"2001\",\"vrfDescription\":\"\",\"disableRtAuto\":\"false\",\"v6VrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"maxBgpPaths\":\"1\",\"maxIbgpPaths\":\"2\",\"vrfSegmentId\":\"50000\",\"routeTargetExport\":\"\",\"ipv6LinkLocalFlag\":\"true\",\"mtu\":\"9216\",\"vrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"vrfVlanName\":\"\",\"tag\":\"12345\",\"nveId\":\"1\",\"vrfIntfDescription\":\"\",\"routeTargetImportEvpn\":\"\",\"vrfName\":\"test_vrf_2\"}",
+                "tenantName": null,
+                "id": 19899,
+                "vrfId": 9008012,
+                "serviceVrfTemplate": null,
+                "source": null,
+                "vrfStatus": "DEPLOYED",
+                "hierarchicalKey": "child_fabric"
             }
-        ],
-        "templateName": "Default_VRF_Universal",
-        "vrfName": "test_vrf_dcnm"
-      }
-    ]
-  },
-  "mock_vrf_attach_get_ext_object_merge_att1_only": {
-    "MESSAGE": "OK",
-    "METHOD": "POST",
-    "RETURN_CODE": 200,
-    "DATA": [
-      {
-        "switchDetailsList": [
+        ]
+    },
+    "mock_vrf_attach_object_del_not_ready": {
+        "ERROR": "",
+        "RETURN_CODE": 200,
+        "MESSAGE": "OK",
+        "DATA": [
             {
-                "errorMessage": null,
-                "extensionPrototypeValues": [],
-                "extensionValues": "",
-                "freeformConfig": "",
-                "instanceValues": "",
-                "islanAttached": true,
-                "lanAttachedState": "DEPLOYED",
-                "peerSerialNumber": null,
-                "role": "leaf",
-                "serialNumber": "XYZKSJHSMK1",
-                "switchName": "n9kv_leaf1",
-                "vlan": "202",
-                "vlanModifiable": true
-            }
-        ],
-        "templateName": "Default_VRF_Universal",
-        "vrfName": "test_vrf_1"
-      }
-    ]
-  },
-  "mock_vrf_attach_get_ext_object_merge_att2_only": {
-    "MESSAGE": "OK",
-    "METHOD": "POST",
-    "RETURN_CODE": 200,
-    "DATA": [
-      {
-        "switchDetailsList": [
-            {
-                "errorMessage": null,
-                "extensionPrototypeValues": [],
-                "extensionValues": "",
-                "freeformConfig": "",
-                "instanceValues": "",
-                "islanAttached": true,
-                "lanAttachedState": "DEPLOYED",
-                "peerSerialNumber": null,
-                "role": "leaf",
-                "serialNumber": "XYZKSJHSMK2",
-                "switchName": "n9kv_leaf2",
-                "vlan": "202",
-                "vlanModifiable": true
-            }
-        ],
-        "templateName": "Default_VRF_Universal",
-        "vrfName": "test_vrf_1"
-      }
-    ]
-  },
-  "mock_msd_vrf_attach_get_ext_object_merge_att1_only": {
-    "MESSAGE": "OK",
-    "METHOD": "POST",
-    "RETURN_CODE": 200,
-    "DATA": [
-      {
-        "switchDetailsList": [
-            {
-                "errorMessage": null,
-                "extensionPrototypeValues": [],
-                "extensionValues": "",
-                "freeformConfig": "",
-                "instanceValues": "",
-                "islanAttached": true,
-                "lanAttachedState": "DEPLOYED",
-                "peerSerialNumber": null,
-                "role": "leaf",
-                "serialNumber": "XYZKSJHSMK1",
-                "switchName": "n9kv_leaf1",
-                "vlan": "2000",
-                "vlanModifiable": true
-            }
-        ],
-        "templateName": "Default_VRF_Universal",
-        "vrfName": "test_vrf_1"
-      }
-    ]
-  },
-
-  "mock_vrf_attach_get_ext_object_ov_att1_only": {
-    "MESSAGE": "OK",
-    "METHOD": "POST",
-    "RETURN_CODE": 200,
-    "DATA": [
-      {
-        "switchDetailsList": [
-            {
-                "errorMessage": null,
-                "extensionPrototypeValues": [],
-                "extensionValues": "",
-                "freeformConfig": "",
-                "instanceValues": "",
-                "islanAttached": true,
-                "lanAttachedState": "DEPLOYED",
-                "peerSerialNumber": null,
-                "role": "leaf",
-                "serialNumber": "XYZKSJHSMK1",
-                "switchName": "n9kv_leaf1",
-                "vlan": "303",
-                "vlanModifiable": true
-            }
-        ],
-        "templateName": "Default_VRF_Universal",
-        "vrfName": "test_vrf_1"
-      }
-    ]
-  },
-  "mock_vrf_attach_get_ext_object_ov_att2_only": {
-    "MESSAGE": "OK",
-    "METHOD": "POST",
-    "RETURN_CODE": 200,
-    "DATA": [
-      {
-        "switchDetailsList": [
-            {
-                "errorMessage": null,
-                "extensionPrototypeValues": [],
-                "extensionValues": "",
-                "freeformConfig": "",
-                "instanceValues": "",
-                "islanAttached": true,
-                "lanAttachedState": "DEPLOYED",
-                "peerSerialNumber": null,
-                "role": "leaf",
-                "serialNumber": "XYZKSJHSMK2",
-                "switchName": "n9kv_leaf2",
-                "vlan": "303",
-                "vlanModifiable": true
-            }
-        ],
-        "templateName": "Default_VRF_Universal",
-        "vrfName": "test_vrf_1"
-      }
-    ]
-  },
-
-  "mock_vrf_attach_get_ext_object_merge_att3_only": {
-    "MESSAGE": "OK",
-    "METHOD": "POST",
-    "RETURN_CODE": 200,
-    "DATA": [
-      {
-        "switchDetailsList": [
-            {
-                "errorMessage": null,
-                "extensionPrototypeValues": [],
-                "extensionValues": "",
-                "freeformConfig": "",
-                "instanceValues": "",
-                "islanAttached": true,
-                "lanAttachedState": "DEPLOYED",
-                "peerSerialNumber": null,
-                "role": "leaf",
-                "serialNumber": "XYZKSJHSMK1",
-                "switchName": "n9kv_leaf1",
-                "vlan": "202",
-                "vlanModifiable": true
-            }
-        ],
-        "templateName": "Default_VRF_Universal",
-        "vrfName": "test_vrf_1"
-      }
-    ]
-  },
-  "mock_vrf_attach_get_ext_object_merge_att4_only": {
-    "MESSAGE": "OK",
-    "METHOD": "POST",
-    "RETURN_CODE": 200,
-    "DATA": [
-      {
-        "switchDetailsList": [
-            {
-                "errorMessage": null,
-                "extensionPrototypeValues": [
+                "vrfName": "test_vrf_1",
+                "lanAttachList": [
                     {
-                        "destInterfaceName": "Ethernet1/16",
-                        "destSwitchName": "dt-n9k2-1",
-                        "extensionType": "VRF_LITE",
-                        "extensionValues": "{\"PEER_VRF_NAME\": \"\", \"NEIGHBOR_IP\": \"10.33.0.1\", \"VRF_LITE_JYTHON_TEMPLATE\": \"Ext_VRF_Lite_Jython\", \"enableBorderExtension\": \"VRF_LITE\", \"AUTO_VRF_LITE_FLAG\": \"false\", \"IP_MASK\": \"10.33.0.2/30\", \"MTU\": \"9216\", \"NEIGHBOR_ASN\": \"65535\", \"IF_NAME\": \"Ethernet1/16\", \"IPV6_NEIGHBOR\": \"\", \"IPV6_MASK\": \"\", \"DOT1Q_ID\": \"3\", \"asn\": \"65535\"}",
-                        "interfaceName": "Ethernet1/16"
+                        "lanAttachState": "DEPLOYED",
+                        "isLanAttached": false
+                    },
+                    {
+                        "lanAttachState": "DEPLOYED",
+                        "isLanAttached": false
+                    }
+                ]
+            }
+        ]
+    },
+    "mock_msd_vrf_attach_object_del_not_ready": {
+        "ERROR": "",
+        "RETURN_CODE": 200,
+        "MESSAGE": "OK",
+        "DATA": [
+            {
+                "vrfName": "test_vrf_1",
+                "lanAttachList": [
+                    {
+                        "vrfName": "test_vrf_1",
+                        "switchName": "n9kv_leaf1",
+                        "lanAttachState": "DEPLOYED",
+                        "isLanAttached": true,
+                        "switchSerialNo": "XYZKSJHSMK1",
+                        "switchRole": "leaf",
+                        "fabricName": "child_fabric",
+                        "ipAddress": "10.10.10.224",
+                        "vlanId": "2000",
+                        "vrfId": "9008011"
+                    }
+                ]
+            }
+        ]
+    },
+    "mock_vrf_attach_object_del_oos": {
+        "ERROR": "",
+        "RETURN_CODE": 200,
+        "MESSAGE": "OK",
+        "DATA": [
+            {
+                "vrfName": "test_vrf_1",
+                "lanAttachList": [
+                    {
+                        "lanAttachState": "OUT-OF-SYNC"
+                    },
+                    {
+                        "lanAttachState": "OUT-OF-SYNC"
+                    }
+                ]
+            }
+        ]
+    },
+    "mock_vrf_attach_object_del_ready": {
+        "ERROR": "",
+        "RETURN_CODE": 200,
+        "MESSAGE": "OK",
+        "DATA": [
+            {
+                "vrfName": "test_vrf_1",
+                "lanAttachList": [
+                    {
+                        "lanAttachState": "NA",
+                        "isLanAttached": false
+                    },
+                    {
+                        "lanAttachState": "NA",
+                        "isLanAttached": false
+                    }
+                ]
+            }
+        ]
+    },
+    "mock_msd_vrf_attach_object_del_ready": {
+        "ERROR": "",
+        "RETURN_CODE": 200,
+        "MESSAGE": "OK",
+        "DATA": [
+            {
+                "vrfName": "test_vrf_1",
+                "lanAttachList": [
+                    {
+                        "vrfName": "test_vrf_1",
+                        "switchName": "n9kv_leaf1",
+                        "lanAttachState": "NA",
+                        "isLanAttached": false,
+                        "switchSerialNo": "XYZKSJHSMK1",
+                        "switchRole": "leaf",
+                        "fabricName": "child_fabric",
+                        "ipAddress": "10.10.10.224",
+                        "vlanId": "2000",
+                        "vrfId": "9008011"
+                    }
+                ]
+            }
+        ]
+    },
+    "mock_vrf_object": {
+        "ERROR": "",
+        "RETURN_CODE": 200,
+        "MESSAGE": "OK",
+        "DATA": [
+            {
+                "fabric": "standalone_fabric",
+                "serviceVrfTemplate": "None",
+                "source": "None",
+                "vrfExtensionTemplate": "Default_VRF_Extension_Universal",
+                "vrfId": 9008011,
+                "vrfName": "test_vrf_1",
+                "vrfTemplate": "Default_VRF_Universal",
+                "vrfTemplateConfig": "{\"advertiseDefaultRouteFlag\":\"true\",\"vrfVlanId\":\"202\",\"isRPExternal\":\"false\",\"vrfDescription\":\"\",\"L3VniMcastGroup\":\"\",\"maxBgpPaths\":\"1\",\"maxIbgpPaths\":\"2\",\"vrfSegmentId\":\"9008013\",\"ipv6LinkLocalFlag\":\"true\",\"vrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"v6VrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"configureStaticDefaultRouteFlag\":\"true\",\"trmBGWMSiteEnabled\":\"false\",\"tag\":\"12345\",\"rpAddress\":\"\",\"nveId\":\"1\",\"bgpPasswordKeyType\":\"3\",\"bgpPassword\":\"\",\"mtu\":\"9216\",\"multicastGroup\":\"\",\"advertiseHostRouteFlag\":\"false\",\"vrfVlanName\":\"\",\"trmEnabled\":\"false\",\"loopbackNumber\":\"\",\"asn\":\"34343\",\"vrfIntfDescription\":\"\",\"vrfName\":\"test_vrf_1\"}",
+                "vrfStatus": "DEPLOYED"
+            }
+        ]
+    },
+    "mock_msd_parent_vrf_object": {
+        "ERROR": "",
+        "RETURN_CODE": 200,
+        "MESSAGE": "OK",
+        "DATA": [
+            {
+                "fabric": "parent_fabric",
+                "serviceVrfTemplate": "None",
+                "source": "None",
+                "vrfExtensionTemplate": "Default_VRF_Extension_Universal",
+                "vrfId": 9008011,
+                "vrfName": "test_vrf_1",
+                "vrfTemplate": "Default_VRF_Universal",
+                "vrfTemplateConfig": "{\"advertiseDefaultRouteFlag\":\"true\",\"vrfVlanId\":\"2000\",\"isRPExternal\":\"false\",\"vrfDescription\":\"\",\"L3VniMcastGroup\":\"\",\"maxBgpPaths\":\"1\",\"maxIbgpPaths\":\"2\",\"vrfSegmentId\":\"9008013\",\"ipv6LinkLocalFlag\":\"true\",\"vrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"v6VrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"configureStaticDefaultRouteFlag\":\"true\",\"trmBGWMSiteEnabled\":\"false\",\"tag\":\"12345\",\"rpAddress\":\"\",\"nveId\":\"1\",\"bgpPasswordKeyType\":\"3\",\"bgpPassword\":\"\",\"mtu\":\"9216\",\"multicastGroup\":\"\",\"advertiseHostRouteFlag\":\"false\",\"vrfVlanName\":\"\",\"trmEnabled\":\"false\",\"loopbackNumber\":\"\",\"asn\":\"34343\",\"vrfIntfDescription\":\"\",\"vrfName\":\"test_vrf_1\"}",
+                "vrfStatus": "DEPLOYED"
+            }
+        ]
+    },
+    "mock_msd_vrf_object": {
+        "ERROR": "",
+        "RETURN_CODE": 200,
+        "MESSAGE": "OK",
+        "DATA": [
+            {
+                "fabric": "child_fabric",
+                "serviceVrfTemplate": "None",
+                "source": "None",
+                "vrfExtensionTemplate": "Default_VRF_Extension_Universal",
+                "vrfId": 9008011,
+                "vrfName": "test_vrf_1",
+                "vrfTemplate": "Default_VRF_Universal",
+                "vrfTemplateConfig": "{\"advertiseDefaultRouteFlag\":\"true\",\"vrfVlanId\":\"2000\",\"isRPExternal\":\"false\",\"vrfDescription\":\"\",\"L3VniMcastGroup\":\"\",\"maxBgpPaths\":\"1\",\"maxIbgpPaths\":\"2\",\"vrfSegmentId\":\"9008013\",\"ipv6LinkLocalFlag\":\"true\",\"vrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"v6VrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"configureStaticDefaultRouteFlag\":\"true\",\"trmBGWMSiteEnabled\":\"false\",\"tag\":\"12345\",\"rpAddress\":\"\",\"nveId\":\"1\",\"bgpPasswordKeyType\":\"3\",\"bgpPassword\":\"\",\"mtu\":\"9216\",\"multicastGroup\":\"\",\"advertiseHostRouteFlag\":\"false\",\"vrfVlanName\":\"\",\"trmEnabled\":\"false\",\"loopbackNumber\":\"\",\"asn\":\"34343\",\"vrfIntfDescription\":\"\",\"vrfName\":\"test_vrf_1\"}",
+                "vrfStatus": "DEPLOYED"
+            }
+        ]
+    },
+    "mock_msd_vrf_object_2": {
+        "ERROR": "",
+        "RETURN_CODE": 200,
+        "MESSAGE": "OK",
+        "DATA": [
+            {
+                "fabric": "child_fabric",
+                "serviceVrfTemplate": "None",
+                "source": "None",
+                "vrfExtensionTemplate": "Default_VRF_Extension_Universal",
+                "vrfId": 9008012,
+                "vrfName": "test_vrf_2",
+                "vrfTemplate": "Default_VRF_Universal",
+                "vrfTemplateConfig": "{\"advertiseDefaultRouteFlag\":\"true\",\"vrfVlanId\":\"2001\",\"isRPExternal\":\"false\",\"vrfDescription\":\"\",\"L3VniMcastGroup\":\"\",\"maxBgpPaths\":\"1\",\"maxIbgpPaths\":\"2\",\"vrfSegmentId\":\"9008013\",\"ipv6LinkLocalFlag\":\"true\",\"vrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"v6VrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"configureStaticDefaultRouteFlag\":\"true\",\"trmBGWMSiteEnabled\":\"false\",\"tag\":\"12345\",\"rpAddress\":\"\",\"nveId\":\"1\",\"bgpPasswordKeyType\":\"3\",\"bgpPassword\":\"\",\"mtu\":\"9216\",\"multicastGroup\":\"\",\"advertiseHostRouteFlag\":\"false\",\"vrfVlanName\":\"\",\"trmEnabled\":\"false\",\"loopbackNumber\":\"\",\"asn\":\"34343\",\"vrfIntfDescription\":\"\",\"vrfName\":\"test_vrf_2\"}",
+                "vrfStatus": "DEPLOYED"
+            }
+        ]
+    },
+    "mock_vrf_attach_object": {
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200,
+        "DATA": [
+            {
+                "vrfName": "test_vrf_1",
+                "lanAttachList": [
+                    {
+                        "vrfName": "test_vrf_1",
+                        "switchName": "n9kv_leaf1",
+                        "lanAttachState": "DEPLOYED",
+                        "instanceValues": "{\"loopbackId\":\"\",\"loopbackIpAddress\":\"\",\"loopbackIpV6Address\":\"\",\"switchRouteTargetImportEvpn\":\"5000:100\",\"switchRouteTargetExportEvpn\":\"5000:100\"}",
+                        "isLanAttached": true,
+                        "switchSerialNo": "XYZKSJHSMK1",
+                        "switchRole": "leaf",
+                        "fabricName": "test-fabric",
+                        "ipAddress": "10.10.10.224",
+                        "vlanId": "202",
+                        "vrfId": "9008011"
+                    },
+                    {
+                        "vrfName": "test_vrf_1",
+                        "switchName": "n9kv_leaf2",
+                        "lanAttachState": "DEPLOYED",
+                        "instanceValues": "{\"loopbackId\":\"\",\"loopbackIpAddress\":\"\",\"loopbackIpV6Address\":\"\",\"switchRouteTargetImportEvpn\":\"5000:100\",\"switchRouteTargetExportEvpn\":\"5000:100\"}",
+                        "isLanAttached": true,
+                        "switchSerialNo": "XYZKSJHSMK2",
+                        "switchRole": "leaf",
+                        "fabricName": "test-fabric",
+                        "ipAddress": "10.10.10.225",
+                        "vlanId": "202",
+                        "vrfId": "9008011"
+                    }
+                ]
+            }
+        ]
+    },
+    "mock_msd_vrf_attach_object": {
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200,
+        "DATA": [
+            {
+                "vrfName": "test_vrf_1",
+                "lanAttachList": [
+                    {
+                        "vrfName": "test_vrf_1",
+                        "switchName": "n9kv_leaf1",
+                        "lanAttachState": "DEPLOYED",
+                        "instanceValues": "{\"loopbackId\":\"\",\"loopbackIpAddress\":\"\",\"loopbackIpV6Address\":\"\",\"switchRouteTargetImportEvpn\":\"\",\"switchRouteTargetExportEvpn\":\"\"}",
+                        "isLanAttached": true,
+                        "switchSerialNo": "XYZKSJHSMK1",
+                        "switchRole": "leaf",
+                        "fabricName": "test-fabric",
+                        "ipAddress": "10.10.10.224",
+                        "vlanId": "2000",
+                        "vrfId": "9008011"
+                    }
+                ]
+            }
+        ]
+    },
+    "mock_msd_vrf_child_attach_object": {
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200,
+        "DATA": [
+            {
+                "vrfName": "test_vrf_1",
+                "lanAttachList": [
+                    {
+                        "vrfName": "test_vrf_1",
+                        "switchName": "n9kv_leaf1",
+                        "lanAttachState": "DEPLOYED",
+                        "instanceValues": "{\"loopbackId\":\"\",\"loopbackIpAddress\":\"\",\"loopbackIpV6Address\":\"\",\"switchRouteTargetImportEvpn\":\"\",\"switchRouteTargetExportEvpn\":\"\"}",
+                        "isLanAttached": true,
+                        "switchSerialNo": "XYZKSJHSMK1",
+                        "switchRole": "leaf",
+                        "fabricName": "child_fabric",
+                        "ipAddress": "10.10.10.224",
+                        "vlanId": "2000",
+                        "vrfId": "9008011"
+                    }
+                ]
+            }
+        ]
+    },
+    "mock_msd_vrf_child_attach_object_2": {
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200,
+        "DATA": [
+            {
+                "vrfName": "test_vrf_2",
+                "lanAttachList": [
+                    {
+                        "vrfName": "test_vrf_2",
+                        "switchName": "n9kv_leaf1",
+                        "lanAttachState": "DEPLOYED",
+                        "instanceValues": "{\"loopbackId\":\"\",\"loopbackIpAddress\":\"\",\"loopbackIpV6Address\":\"\",\"switchRouteTargetImportEvpn\":\"\",\"switchRouteTargetExportEvpn\":\"\"}",
+                        "isLanAttached": true,
+                        "switchSerialNo": "XYZKSJHSMK1",
+                        "switchRole": "leaf",
+                        "fabricName": "child_fabric",
+                        "ipAddress": "10.10.10.224",
+                        "vlanId": "2001",
+                        "vrfId": "9008012"
+                    }
+                ]
+            }
+        ]
+    },
+    "mock_msd_vrf_get_attach_object_replaced_parent": {
+        "METHOD": "GET",
+        "RETURN_CODE": 200,
+        "DATA": [
+            {
+                "vrfName": "test_vrf_1",
+                "lanAttachList": [
+                    {
+                        "vrfName": "test_vrf_1",
+                        "switchName": "n9kv_leaf1",
+                        "lanAttachState": "DEPLOYED",
+                        "instanceValues": "{\"loopbackId\":\"\",\"loopbackIpAddress\":\"\",\"loopbackIpV6Address\":\"\",\"switchRouteTargetImportEvpn\":\"\",\"switchRouteTargetExportEvpn\":\"\"}",
+                        "isLanAttached": true,
+                        "switchSerialNo": "XYZKSJHSMK1",
+                        "switchRole": "leaf",
+                        "fabricName": "test-fabric",
+                        "ipAddress": "10.10.10.224",
+                        "vlanId": "2000",
+                        "vrfId": "9008011"
+                    }
+                ]
+            }
+        ]
+    },
+    "mock_vrf_attach_object_query": {
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200,
+        "DATA": [
+            {
+                "vrfName": "test_vrf_1",
+                "lanAttachList": [
+                    {
+                        "vrfName": "test_vrf_1",
+                        "switchName": "n9kv_leaf1",
+                        "lanAttachState": "DEPLOYED",
+                        "isLanAttached": true,
+                        "switchSerialNo": "XYZKSJHSMK1",
+                        "switchRole": "leaf",
+                        "fabricName": "test-fabric",
+                        "ipAddress": "10.10.10.224",
+                        "vlanId": "202",
+                        "vrfId": "9008011"
+                    },
+                    {
+                        "vrfName": "test_vrf_1",
+                        "switchName": "n9kv_leaf2",
+                        "lanAttachState": "DEPLOYED",
+                        "isLanAttached": true,
+                        "switchSerialNo": "XYZKSJHSMK2",
+                        "switchRole": "leaf",
+                        "fabricName": "test-fabric",
+                        "ipAddress": "10.10.10.225",
+                        "vlanId": "202",
+                        "vrfId": "9008011"
+                    }
+                ]
+            }
+        ]
+    },
+    "mock_msd_vrf_parent_attach_object_query": {
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200,
+        "DATA": [
+            {
+                "vrfName": "test_vrf_1",
+                "lanAttachList": [
+                    {
+                        "vrfName": "test_vrf_1",
+                        "switchName": "n9kv_leaf1",
+                        "lanAttachState": "DEPLOYED",
+                        "isLanAttached": true,
+                        "switchSerialNo": "XYZKSJHSMK1",
+                        "switchRole": "leaf",
+                        "fabricName": "parent_fabric",
+                        "ipAddress": "10.10.10.224",
+                        "vlanId": "2000",
+                        "vrfId": "9008011"
+                    }
+                ]
+            }
+        ]
+    },
+    "mock_msd_vrf_child_attach_object_query": {
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200,
+        "DATA": [
+            {
+                "vrfName": "test_vrf_1",
+                "lanAttachList": [
+                    {
+                        "vrfName": "test_vrf_1",
+                        "switchName": "n9kv_leaf1",
+                        "lanAttachState": "DEPLOYED",
+                        "isLanAttached": true,
+                        "switchSerialNo": "XYZKSJHSMK1",
+                        "switchRole": "leaf",
+                        "fabricName": "child_fabric",
+                        "ipAddress": "10.10.10.224",
+                        "vlanId": "2000",
+                        "vrfId": "9008011"
+                    }
+                ]
+            }
+        ]
+    },
+    "mock_vrf_attach_object2": {
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200,
+        "DATA": [
+            {
+                "vrfName": "test_vrf_1",
+                "lanAttachList": [
+                    {
+                        "vrfName": "test_vrf_1",
+                        "switchName": "n9kv_leaf1",
+                        "lanAttachState": "DEPLOYED",
+                        "isLanAttached": true,
+                        "switchSerialNo": "XYZKSJHSMK1",
+                        "switchRole": "leaf",
+                        "fabricName": "test-fabric",
+                        "ipAddress": "10.10.10.224",
+                        "vlanId": "202",
+                        "vrfId": "9008011"
+                    },
+                    {
+                        "vrfName": "test_vrf_1",
+                        "switchName": "n9kv_leaf4",
+                        "lanAttachState": "DEPLOYED",
+                        "isLanAttached": true,
+                        "switchSerialNo": "XYZKSJHSMK4",
+                        "switchRole": "border",
+                        "fabricName": "test-fabric",
+                        "ipAddress": "10.10.10.227",
+                        "vlanId": "202",
+                        "vrfId": "9008011"
+                    }
+                ]
+            }
+        ]
+    },
+    "mock_vrf_attach_object2_query": {
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200,
+        "DATA": [
+            {
+                "vrfName": "test_vrf_1",
+                "lanAttachList": [
+                    {
+                        "vrfName": "test_vrf_1",
+                        "switchName": "n9kv_leaf1",
+                        "lanAttachState": "DEPLOYED",
+                        "isLanAttached": true,
+                        "switchSerialNo": "XYZKSJHSMK1",
+                        "switchRole": "leaf",
+                        "fabricName": "test-fabric",
+                        "ipAddress": "10.10.10.224",
+                        "vlanId": "202",
+                        "vrfId": "9008011"
+                    },
+                    {
+                        "vrfName": "test_vrf_1",
+                        "switchName": "n9kv_leaf4",
+                        "lanAttachState": "DEPLOYED",
+                        "isLanAttached": true,
+                        "switchSerialNo": "XYZKSJHSMK4",
+                        "switchRole": "border",
+                        "fabricName": "test-fabric",
+                        "ipAddress": "10.10.10.227",
+                        "vlanId": "202",
+                        "vrfId": "9008011"
+                    }
+                ]
+            }
+        ]
+    },
+    "mock_vrf_attach_lite_object": {
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200,
+        "DATA": [
+            {
+                "vrfName": "test_vrf_1",
+                "lanAttachList": [
+                    {
+                        "deployment": true,
+                        "extensionValues": "",
+                        "fabric": "standalone_fabric",
+                        "freeformConfig": "",
+                        "instanceValues": "",
+                        "serialNumber": "XYZKSJHSMK1",
+                        "vlan": 202,
+                        "vrfName": "test_vrf_1",
+                        "vrf_lite": []
+                    },
+                    {
+                        "deployment": true,
+                        "extensionValues": "{\"VRF_LITE_CONN\":\"{\\\"VRF_LITE_CONN\\\":[{\\\"IF_NAME\\\":\\\"Ethernet1/16\\\",\\\"DOT1Q_ID\\\":\\\"2\\\",\\\"IP_MASK\\\":\\\"10.33.0.2/30\\\",\\\"NEIGHBOR_IP\\\":\\\"10.33.0.1\\\",\\\"NEIGHBOR_ASN\\\":\\\"65535\\\",\\\"IPV6_MASK\\\":\\\"2010::10:34:0:7/64\\\",\\\"IPV6_NEIGHBOR\\\":\\\"2010::10:34:0:3\\\",\\\"AUTO_VRF_LITE_FLAG\\\":\\\"false\\\",\\\"PEER_VRF_NAME\\\":\\\"ansible-vrf-int1\\\",\\\"VRF_LITE_JYTHON_TEMPLATE\\\":\\\"Ext_VRF_Lite_Jython\\\"}]}\",\"MULTISITE_CONN\":\"{\\\"MULTISITE_CONN\\\":[]}\"}",
+                        "fabric": "standalone_fabric",
+                        "freeformConfig": "",
+                        "instanceValues": "{\"loopbackId\":\"\",\"loopbackIpAddress\":\"\",\"loopbackIpV6Address\":\"\",\"switchRouteTargetImportEvpn\":\"5000:100\",\"switchRouteTargetExportEvpn\":\"5000:100\"}",
+                        "serialNumber": "XYZKSJHSMK4",
+                        "vlan": 202,
+                        "vrfName": "test_vrf_1"
+                    }
+                ]
+            }
+        ]
+    },
+    "mock_vrf_attach_object_pending": {
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200,
+        "DATA": [
+            {
+                "vrfName": "test_vrf_1",
+                "lanAttachList": [
+                    {
+                        "vrfName": "test_vrf_1",
+                        "switchName": "n9kv_leaf1",
+                        "lanAttachState": "PENDING",
+                        "isLanAttached": true,
+                        "switchSerialNo": "XYZKSJHSMK1",
+                        "switchRole": "leaf",
+                        "fabricName": "test-fabric",
+                        "ipAddress": "10.10.10.224",
+                        "vlanId": "202",
+                        "vrfId": "9008011"
+                    },
+                    {
+                        "vrfName": "test_vrf_1",
+                        "switchName": "n9kv_leaf2",
+                        "lanAttachState": "PENDING",
+                        "isLanAttached": true,
+                        "switchSerialNo": "XYZKSJHSMK2",
+                        "switchRole": "leaf",
+                        "fabricName": "test-fabric",
+                        "ipAddress": "10.10.10.225",
+                        "vlanId": "202",
+                        "vrfId": "9008011"
+                    }
+                ]
+            }
+        ]
+    },
+    "mock_vrf_object_dcnm_only": {
+        "ERROR": "",
+        "RETURN_CODE": 200,
+        "MESSAGE": "OK",
+        "DATA": [
+            {
+                "fabric": "standalone_fabric",
+                "vrfName": "test_vrf_dcnm",
+                "vrfTemplate": "Default_VRF_Universal",
+                "vrfExtensionTemplate": "Default_VRF_Extension_Universal",
+                "serviceVrfTemplate": "None",
+                "source": "None",
+                "vrfStatus": "DEPLOYED",
+                "vrfTemplateConfig": "{\"advertiseDefaultRouteFlag\":\"true\",\"vrfVlanId\":\"202\",\"isRPExternal\":\"false\",\"vrfDescription\":\"\",\"L3VniMcastGroup\":\"\",\"maxBgpPaths\":\"1\",\"maxIbgpPaths\":\"2\",\"vrfSegmentId\":\"9008013\",\"ipv6LinkLocalFlag\":\"true\",\"vrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"v6VrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"configureStaticDefaultRouteFlag\":\"true\",\"trmBGWMSiteEnabled\":\"false\",\"tag\":\"12345\",\"rpAddress\":\"\",\"nveId\":\"1\",\"bgpPasswordKeyType\":\"3\",\"bgpPassword\":\"\",\"mtu\":\"9216\",\"multicastGroup\":\"\",\"advertiseHostRouteFlag\":\"false\",\"vrfVlanName\":\"\",\"trmEnabled\":\"false\",\"loopbackNumber\":\"\",\"asn\":\"34343\",\"vrfIntfDescription\":\"\",\"vrfName\":\"test_vrf_dcnm\"}",
+                "vrfId": "9008013"
+            }
+        ]
+    },
+    "mock_net_from_vrf_empty": {
+        "ERROR": "",
+        "RETURN_CODE": 200,
+        "MESSAGE": "OK",
+        "DATA": []
+    },
+    "mock_vrf_attach_object_dcnm_only": {
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200,
+        "DATA": [
+            {
+                "vrfName": "test_vrf_dcnm",
+                "lanAttachList": [
+                    {
+                        "vrfName": "test_vrf_dcnm",
+                        "switchName": "n9kv_leaf1",
+                        "lanAttachState": "DEPLOYED",
+                        "isLanAttached": true,
+                        "switchSerialNo": "XYZKSJHSMK1",
+                        "switchRole": "leaf",
+                        "fabricName": "test-fabric",
+                        "ipAddress": "10.10.10.224",
+                        "vlanId": "402",
+                        "vrfId": "9008013"
+                    },
+                    {
+                        "vrfName": "test_vrf_dcnm",
+                        "switchName": "n9kv_leaf2",
+                        "lanAttachState": "DEPLOYED",
+                        "isLanAttached": true,
+                        "switchSerialNo": "XYZKSJHSMK2",
+                        "switchRole": "leaf",
+                        "fabricName": "test-fabric",
+                        "ipAddress": "10.10.10.225",
+                        "vlanId": "403",
+                        "vrfId": "9008013"
+                    }
+                ]
+            }
+        ]
+    },
+    "mock_vrf_attach_get_ext_object_dcnm_att1_only": {
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200,
+        "DATA": [
+            {
+                "switchDetailsList": [
+                    {
+                        "errorMessage": null,
+                        "extensionPrototypeValues": [],
+                        "extensionValues": "",
+                        "freeformConfig": "",
+                        "instanceValues": "{\"loopbackId\":\"10\",\"loopbackIpAddress\":\"11.1.1.1\",\"loopbackIpV6Address\":\"\",\"switchRouteTargetImportEvpn\":\"5000:100\",\"switchRouteTargetExportEvpn\":\"5000:100\"}",
+                        "islanAttached": true,
+                        "lanAttachedState": "DEPLOYED",
+                        "peerSerialNumber": null,
+                        "role": "leaf",
+                        "serialNumber": "XYZKSJHSMK1",
+                        "switchName": "n9kv_leaf1",
+                        "vlan": "402",
+                        "vlanModifiable": true
                     }
                 ],
-                "extensionValues": "{\"VRF_LITE_CONN\":\"{\\\"VRF_LITE_CONN\\\":[{\\\"IF_NAME\\\":\\\"Ethernet1/16\\\",\\\"DOT1Q_ID\\\":\\\"2\\\",\\\"IP_MASK\\\":\\\"10.33.0.2/30\\\",\\\"NEIGHBOR_IP\\\":\\\"10.33.0.1\\\",\\\"NEIGHBOR_ASN\\\":\\\"65535\\\",\\\"IPV6_MASK\\\":\\\"2010::10:34:0:7/64\\\",\\\"IPV6_NEIGHBOR\\\":\\\"2010::10:34:0:3\\\",\\\"AUTO_VRF_LITE_FLAG\\\":\\\"false\\\",\\\"PEER_VRF_NAME\\\":\\\"test_vrf_1\\\",\\\"VRF_LITE_JYTHON_TEMPLATE\\\":\\\"Ext_VRF_Lite_Jython\\\"}]}\",\"MULTISITE_CONN\":\"{\\\"MULTISITE_CONN\\\":[]}\"}",
-                "freeformConfig": "",
-                "instanceValues": "{\"loopbackId\":\"\",\"loopbackIpAddress\":\"\",\"loopbackIpV6Address\":\"\"}",
-                "islanAttached": true,
-                "lanAttachedState": "DEPLOYED",
-                "peerSerialNumber": null,
-                "role": "border",
-                "serialNumber": "XYZKSJHSMK4",
-                "switchName": "n9kv_leaf4",
-                "vlan": 202,
-                "vlanModifiable": true
+                "templateName": "Default_VRF_Universal",
+                "vrfName": "test_vrf_dcnm"
             }
-        ],
-        "templateName": "Default_VRF_Extension_Universal",
-        "vrfName": "test_vrf_1"
-      }
-    ]
-  },
-  "mock_vrf_msd_attach_get_ext_object_dcnm_att1_only": {
-    "MESSAGE": "OK",
-    "METHOD": "POST",
-    "RETURN_CODE": 200,
-    "DATA": [
-      {
-        "switchDetailsList": [
+        ]
+    },
+    "mock_vrf_attach_get_ext_object_dcnm_att2_only": {
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200,
+        "DATA": [
             {
-                "errorMessage": null,
-                "extensionPrototypeValues": [],
-                "extensionValues": "",
-                "freeformConfig": "",
-                "instanceValues": "{\"loopbackId\":\"\",\"loopbackIpAddress\":\"\",\"loopbackIpV6Address\":\"\",\"switchRouteTargetImportEvpn\":\"\",\"switchRouteTargetExportEvpn\":\"\"}",
-                "islanAttached": true,
-                "lanAttachedState": "DEPLOYED",
-                "peerSerialNumber": null,
-                "role": "leaf",
-                "serialNumber": "XYZKSJHSMK1",
-                "switchName": "n9kv_leaf1",
-                "vlan": "2000",
-                "vlanModifiable": true
+                "switchDetailsList": [
+                    {
+                        "errorMessage": null,
+                        "extensionPrototypeValues": [],
+                        "extensionValues": "",
+                        "freeformConfig": "",
+                        "instanceValues": "{\"loopbackId\":\"10\",\"loopbackIpAddress\":\"11.1.1.1\",\"loopbackIpV6Address\":\"\",\"switchRouteTargetImportEvpn\":\"5000:100\",\"switchRouteTargetExportEvpn\":\"5000:100\"}",
+                        "islanAttached": true,
+                        "lanAttachedState": "DEPLOYED",
+                        "peerSerialNumber": null,
+                        "role": "leaf",
+                        "serialNumber": "XYZKSJHSMK2",
+                        "switchName": "n9kv_leaf2",
+                        "vlan": "403",
+                        "vlanModifiable": true
+                    }
+                ],
+                "templateName": "Default_VRF_Universal",
+                "vrfName": "test_vrf_dcnm"
             }
-        ],
-        "templateName": "Default_VRF_Universal",
-        "vrfName": "test_vrf_dcnm"
-      }
-    ]
-  },
-  "mock_vrf_msd_attach_get_ext_object_ov_att1_only": {
-    "MESSAGE": "OK",
-    "METHOD": "POST",
-    "RETURN_CODE": 200,
-    "DATA": [
-      {
-        "switchDetailsList": [
+        ]
+    },
+    "mock_vrf_attach_get_ext_object_merge_att1_only": {
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200,
+        "DATA": [
             {
-                "errorMessage": null,
-                "extensionPrototypeValues": [],
-                "extensionValues": "",
-                "freeformConfig": "",
-                "instanceValues": "",
-                "islanAttached": true,
-                "lanAttachedState": "DEPLOYED",
-                "peerSerialNumber": null,
-                "role": "leaf",
-                "serialNumber": "XYZKSJHSMK1",
-                "switchName": "n9kv_leaf1",
-                "vlan": "2001",
-                "vlanModifiable": true
+                "switchDetailsList": [
+                    {
+                        "errorMessage": null,
+                        "extensionPrototypeValues": [],
+                        "extensionValues": "",
+                        "freeformConfig": "",
+                        "instanceValues": "",
+                        "islanAttached": true,
+                        "lanAttachedState": "DEPLOYED",
+                        "peerSerialNumber": null,
+                        "role": "leaf",
+                        "serialNumber": "XYZKSJHSMK1",
+                        "switchName": "n9kv_leaf1",
+                        "vlan": "202",
+                        "vlanModifiable": true
+                    }
+                ],
+                "templateName": "Default_VRF_Universal",
+                "vrfName": "test_vrf_1"
             }
-        ],
-        "templateName": "Default_VRF_Universal",
-        "vrfName": "test_vrf_1"
-      }
-    ]
-  },
-  "attach_success_resp": {
-    "DATA": {
-      "test-vrf-1--XYZKSJHSMK1(leaf1)": "SUCCESS",
-      "test-vrf-1--XYZKSJHSMK2(leaf2)": "SUCCESS"
+        ]
     },
-    "MESSAGE": "OK",
-    "METHOD": "POST",
-    "RETURN_CODE": 200
-  },
-  "msd_attach_success_resp": {
-    "DATA": {
-      "test-vrf-1--XYZKSJHSMK1(leaf1)": "SUCCESS"
+    "mock_vrf_attach_get_ext_object_merge_att2_only": {
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200,
+        "DATA": [
+            {
+                "switchDetailsList": [
+                    {
+                        "errorMessage": null,
+                        "extensionPrototypeValues": [],
+                        "extensionValues": "",
+                        "freeformConfig": "",
+                        "instanceValues": "",
+                        "islanAttached": true,
+                        "lanAttachedState": "DEPLOYED",
+                        "peerSerialNumber": null,
+                        "role": "leaf",
+                        "serialNumber": "XYZKSJHSMK2",
+                        "switchName": "n9kv_leaf2",
+                        "vlan": "202",
+                        "vlanModifiable": true
+                    }
+                ],
+                "templateName": "Default_VRF_Universal",
+                "vrfName": "test_vrf_1"
+            }
+        ]
     },
-    "MESSAGE": "OK",
-    "METHOD": "POST",
-    "RETURN_CODE": 200
-  },
-  "msd_attach_success_resp_2": {
-    "DATA": {
-      "test-vrf-2--XYZKSJHSMK1(leaf1)": "SUCCESS"
+    "mock_msd_vrf_attach_get_ext_object_merge_att1_only": {
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200,
+        "DATA": [
+            {
+                "switchDetailsList": [
+                    {
+                        "errorMessage": null,
+                        "extensionPrototypeValues": [],
+                        "extensionValues": "",
+                        "freeformConfig": "",
+                        "instanceValues": "",
+                        "islanAttached": true,
+                        "lanAttachedState": "DEPLOYED",
+                        "peerSerialNumber": null,
+                        "role": "leaf",
+                        "serialNumber": "XYZKSJHSMK1",
+                        "switchName": "n9kv_leaf1",
+                        "vlan": "2000",
+                        "vlanModifiable": true
+                    }
+                ],
+                "templateName": "Default_VRF_Universal",
+                "vrfName": "test_vrf_1"
+            }
+        ]
     },
-    "MESSAGE": "OK",
-    "METHOD": "POST",
-    "RETURN_CODE": 200
-  },
-  "attach_success_resp2": {
-    "DATA": {
-      "test-vrf-2--XYZKSJHSMK2(leaf2)": "SUCCESS",
-      "test-vrf-2--XYZKSJHSMK3(leaf3)": "SUCCESS"
+    "mock_vrf_attach_get_ext_object_ov_att1_only": {
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200,
+        "DATA": [
+            {
+                "switchDetailsList": [
+                    {
+                        "errorMessage": null,
+                        "extensionPrototypeValues": [],
+                        "extensionValues": "",
+                        "freeformConfig": "",
+                        "instanceValues": "",
+                        "islanAttached": true,
+                        "lanAttachedState": "DEPLOYED",
+                        "peerSerialNumber": null,
+                        "role": "leaf",
+                        "serialNumber": "XYZKSJHSMK1",
+                        "switchName": "n9kv_leaf1",
+                        "vlan": "303",
+                        "vlanModifiable": true
+                    }
+                ],
+                "templateName": "Default_VRF_Universal",
+                "vrfName": "test_vrf_1"
+            }
+        ]
     },
-    "MESSAGE": "OK",
-    "METHOD": "POST",
-    "RETURN_CODE": 200
-  },
-  "attach_success_resp3": {
-    "DATA": {
-      "test-vrf-1--XYZKSJHSMK2(leaf1)": "SUCCESS",
-      "test-vrf-1--XYZKSJHSMK3(leaf4)": "SUCCESS"
+    "mock_vrf_attach_get_ext_object_ov_att2_only": {
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200,
+        "DATA": [
+            {
+                "switchDetailsList": [
+                    {
+                        "errorMessage": null,
+                        "extensionPrototypeValues": [],
+                        "extensionValues": "",
+                        "freeformConfig": "",
+                        "instanceValues": "",
+                        "islanAttached": true,
+                        "lanAttachedState": "DEPLOYED",
+                        "peerSerialNumber": null,
+                        "role": "leaf",
+                        "serialNumber": "XYZKSJHSMK2",
+                        "switchName": "n9kv_leaf2",
+                        "vlan": "303",
+                        "vlanModifiable": true
+                    }
+                ],
+                "templateName": "Default_VRF_Universal",
+                "vrfName": "test_vrf_1"
+            }
+        ]
     },
-    "MESSAGE": "OK",
-    "METHOD": "POST",
-    "RETURN_CODE": 200
-  },
-  "deploy_success_resp": {
-    "DATA": {"status": ""},
-    "MESSAGE": "OK",
-    "METHOD": "POST",
-    "RETURN_CODE": 200
-  },
-  "blank_data": {
-    "MESSAGE": "OK",
-    "METHOD": "POST",
-    "RETURN_CODE": 200
-  },
-  "mock_vrf_id_response": {
-    "MESSAGE": "OK",
-    "METHOD": "GET",
-    "RETURN_CODE": 200,
-    "DATA": {
-      "l3vni": 9008011
-    }
-  },
-  "update_data": {
-    "MESSAGE": "OK",
-    "METHOD": "PUT",
-    "RETURN_CODE": 200
-  },
-  "get_have_failure": {
-    "DATA": "Invalid JSON response: Invalid Fabric: demo-fabric-123",
-    "ERROR": "Not Found",
-    "METHOD": "GET",
-    "RETURN_CODE": 404,
-    "MESSAGE": "OK"
-  },
-  "error1": {
-    "DATA": "None",
-    "ERROR": "There is an error",
-    "METHOD": "POST",
-    "RETURN_CODE": 400,
-    "MESSAGE": "OK"
-  },
-  "error2": {
-    "DATA": {
-      "test-vrf-1--XYZKSJHSMK1(leaf1)": "Entered VRF VLAN ID 203 is in use already",
-      "test-vrf-1--XYZKSJHSMK2(leaf2)": "SUCCESS"
+    "mock_vrf_attach_get_ext_object_merge_att3_only": {
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200,
+        "DATA": [
+            {
+                "switchDetailsList": [
+                    {
+                        "errorMessage": null,
+                        "extensionPrototypeValues": [],
+                        "extensionValues": "",
+                        "freeformConfig": "",
+                        "instanceValues": "",
+                        "islanAttached": true,
+                        "lanAttachedState": "DEPLOYED",
+                        "peerSerialNumber": null,
+                        "role": "leaf",
+                        "serialNumber": "XYZKSJHSMK1",
+                        "switchName": "n9kv_leaf1",
+                        "vlan": "202",
+                        "vlanModifiable": true
+                    }
+                ],
+                "templateName": "Default_VRF_Universal",
+                "vrfName": "test_vrf_1"
+            }
+        ]
     },
-    "ERROR": "",
-    "METHOD": "POST",
-    "RETURN_CODE": 200,
-    "MESSAGE": "OK"
-  },
-  "error3": {
-    "DATA": "No switches PENDING for deployment",
-    "ERROR": "",
-    "METHOD": "POST",
-    "RETURN_CODE": 200,
-    "MESSAGE": "OK"
-  },
-  "delete_success_resp": {
-    "ERROR": "",
-    "METHOD": "POST",
-    "RETURN_CODE": 200,
-    "MESSAGE": "OK"
-  },
-  "vrf_inv_data": {
-    "10.10.10.224":{
-      "ipAddress": "10.10.10.224",
-      "logicalName": "dt-n9k1",
-      "serialNumber": "XYZKSJHSMK1",
-      "switchRole": "leaf"
+    "mock_vrf_attach_get_ext_object_merge_att4_only": {
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200,
+        "DATA": [
+            {
+                "switchDetailsList": [
+                    {
+                        "errorMessage": null,
+                        "extensionPrototypeValues": [
+                            {
+                                "destInterfaceName": "Ethernet1/16",
+                                "destSwitchName": "dt-n9k2-1",
+                                "extensionType": "VRF_LITE",
+                                "extensionValues": "{\"PEER_VRF_NAME\": \"\", \"NEIGHBOR_IP\": \"10.33.0.1\", \"VRF_LITE_JYTHON_TEMPLATE\": \"Ext_VRF_Lite_Jython\", \"enableBorderExtension\": \"VRF_LITE\", \"AUTO_VRF_LITE_FLAG\": \"false\", \"IP_MASK\": \"10.33.0.2/30\", \"MTU\": \"9216\", \"NEIGHBOR_ASN\": \"65535\", \"IF_NAME\": \"Ethernet1/16\", \"IPV6_NEIGHBOR\": \"\", \"IPV6_MASK\": \"\", \"DOT1Q_ID\": \"3\", \"asn\": \"65535\"}",
+                                "interfaceName": "Ethernet1/16"
+                            }
+                        ],
+                        "extensionValues": "{\"VRF_LITE_CONN\":\"{\\\"VRF_LITE_CONN\\\":[{\\\"IF_NAME\\\":\\\"Ethernet1/16\\\",\\\"DOT1Q_ID\\\":\\\"2\\\",\\\"IP_MASK\\\":\\\"10.33.0.2/30\\\",\\\"NEIGHBOR_IP\\\":\\\"10.33.0.1\\\",\\\"NEIGHBOR_ASN\\\":\\\"65535\\\",\\\"IPV6_MASK\\\":\\\"2010::10:34:0:7/64\\\",\\\"IPV6_NEIGHBOR\\\":\\\"2010::10:34:0:3\\\",\\\"AUTO_VRF_LITE_FLAG\\\":\\\"false\\\",\\\"PEER_VRF_NAME\\\":\\\"test_vrf_1\\\",\\\"VRF_LITE_JYTHON_TEMPLATE\\\":\\\"Ext_VRF_Lite_Jython\\\"}]}\",\"MULTISITE_CONN\":\"{\\\"MULTISITE_CONN\\\":[]}\"}",
+                        "freeformConfig": "",
+                        "instanceValues": "{\"loopbackId\":\"\",\"loopbackIpAddress\":\"\",\"loopbackIpV6Address\":\"\"}",
+                        "islanAttached": true,
+                        "lanAttachedState": "DEPLOYED",
+                        "peerSerialNumber": null,
+                        "role": "border",
+                        "serialNumber": "XYZKSJHSMK4",
+                        "switchName": "n9kv_leaf4",
+                        "vlan": 202,
+                        "vlanModifiable": true
+                    }
+                ],
+                "templateName": "Default_VRF_Extension_Universal",
+                "vrfName": "test_vrf_1"
+            }
+        ]
     },
-    "10.10.10.225":{
-      "ipAddress": "10.10.10.225",
-      "logicalName": "dt-n9k2",
-      "serialNumber": "XYZKSJHSMK2",
-      "switchRole": "leaf"
+    "mock_vrf_msd_attach_get_ext_object_dcnm_att1_only": {
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200,
+        "DATA": [
+            {
+                "switchDetailsList": [
+                    {
+                        "errorMessage": null,
+                        "extensionPrototypeValues": [],
+                        "extensionValues": "",
+                        "freeformConfig": "",
+                        "instanceValues": "{\"loopbackId\":\"\",\"loopbackIpAddress\":\"\",\"loopbackIpV6Address\":\"\",\"switchRouteTargetImportEvpn\":\"\",\"switchRouteTargetExportEvpn\":\"\"}",
+                        "islanAttached": true,
+                        "lanAttachedState": "DEPLOYED",
+                        "peerSerialNumber": null,
+                        "role": "leaf",
+                        "serialNumber": "XYZKSJHSMK1",
+                        "switchName": "n9kv_leaf1",
+                        "vlan": "2000",
+                        "vlanModifiable": true
+                    }
+                ],
+                "templateName": "Default_VRF_Universal",
+                "vrfName": "test_vrf_dcnm"
+            }
+        ]
     },
-    "10.10.10.226":{
-      "ipAddress": "10.10.10.226",
-      "logicalName": "dt-n9k3",
-      "serialNumber": "XYZKSJHSMK3",
-      "switchRole": "leaf"
+    "mock_vrf_msd_attach_get_ext_object_ov_att1_only": {
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200,
+        "DATA": [
+            {
+                "switchDetailsList": [
+                    {
+                        "errorMessage": null,
+                        "extensionPrototypeValues": [],
+                        "extensionValues": "",
+                        "freeformConfig": "",
+                        "instanceValues": "",
+                        "islanAttached": true,
+                        "lanAttachedState": "DEPLOYED",
+                        "peerSerialNumber": null,
+                        "role": "leaf",
+                        "serialNumber": "XYZKSJHSMK1",
+                        "switchName": "n9kv_leaf1",
+                        "vlan": "2001",
+                        "vlanModifiable": true
+                    }
+                ],
+                "templateName": "Default_VRF_Universal",
+                "vrfName": "test_vrf_1"
+            }
+        ]
     },
-    "10.10.10.227":{
-      "ipAddress": "10.10.10.227",
-      "logicalName": "dt-n9k4",
-      "serialNumber": "XYZKSJHSMK4",
-      "switchRole": "border spine"
+    "attach_success_resp": {
+        "DATA": {
+            "test-vrf-1--XYZKSJHSMK1(leaf1)": "SUCCESS",
+            "test-vrf-1--XYZKSJHSMK2(leaf2)": "SUCCESS"
+        },
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200
     },
-    "10.10.10.228":{
-      "ipAddress": "10.10.10.228",
-      "logicalName": "dt-n9k5",
-      "serialNumber": "XYZKSJHSMK5",
-      "switchRole": "border"
-    }
-  },
-  "fabric_details_mfd": {
+    "msd_attach_success_resp": {
+        "DATA": {
+            "test-vrf-1--XYZKSJHSMK1(leaf1)": "SUCCESS"
+        },
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200
+    },
+    "msd_attach_success_resp_2": {
+        "DATA": {
+            "test-vrf-2--XYZKSJHSMK1(leaf1)": "SUCCESS"
+        },
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200
+    },
+    "attach_success_resp2": {
+        "DATA": {
+            "test-vrf-2--XYZKSJHSMK2(leaf2)": "SUCCESS",
+            "test-vrf-2--XYZKSJHSMK3(leaf3)": "SUCCESS"
+        },
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200
+    },
+    "attach_success_resp3": {
+        "DATA": {
+            "test-vrf-1--XYZKSJHSMK2(leaf1)": "SUCCESS",
+            "test-vrf-1--XYZKSJHSMK3(leaf4)": "SUCCESS"
+        },
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200
+    },
+    "deploy_success_resp": {
+        "DATA": {
+            "status": ""
+        },
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200
+    },
+    "blank_data": {
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200
+    },
+    "mock_vrf_id_response": {
+        "MESSAGE": "OK",
+        "METHOD": "GET",
+        "RETURN_CODE": 200,
+        "DATA": {
+            "l3vni": 9008011
+        }
+    },
+    "update_data": {
+        "MESSAGE": "OK",
+        "METHOD": "PUT",
+        "RETURN_CODE": 200
+    },
+    "get_have_failure": {
+        "DATA": "Invalid JSON response: Invalid Fabric: demo-fabric-123",
+        "ERROR": "Not Found",
+        "METHOD": "GET",
+        "RETURN_CODE": 404,
+        "MESSAGE": "OK"
+    },
+    "error1": {
+        "DATA": "None",
+        "ERROR": "There is an error",
+        "METHOD": "POST",
+        "RETURN_CODE": 400,
+        "MESSAGE": "OK"
+    },
+    "error2": {
+        "DATA": {
+            "test-vrf-1--XYZKSJHSMK1(leaf1)": "Entered VRF VLAN ID 203 is in use already",
+            "test-vrf-1--XYZKSJHSMK2(leaf2)": "SUCCESS"
+        },
+        "ERROR": "",
+        "METHOD": "POST",
+        "RETURN_CODE": 200,
+        "MESSAGE": "OK"
+    },
+    "error3": {
+        "DATA": "No switches PENDING for deployment",
+        "ERROR": "",
+        "METHOD": "POST",
+        "RETURN_CODE": 200,
+        "MESSAGE": "OK"
+    },
+    "delete_success_resp": {
+        "ERROR": "",
+        "METHOD": "POST",
+        "RETURN_CODE": 200,
+        "MESSAGE": "OK"
+    },
+    "vrf_inv_data": {
+        "10.10.10.224": {
+            "ipAddress": "10.10.10.224",
+            "logicalName": "dt-n9k1",
+            "serialNumber": "XYZKSJHSMK1",
+            "switchRole": "leaf"
+        },
+        "10.10.10.225": {
+            "ipAddress": "10.10.10.225",
+            "logicalName": "dt-n9k2",
+            "serialNumber": "XYZKSJHSMK2",
+            "switchRole": "leaf"
+        },
+        "10.10.10.226": {
+            "ipAddress": "10.10.10.226",
+            "logicalName": "dt-n9k3",
+            "serialNumber": "XYZKSJHSMK3",
+            "switchRole": "leaf"
+        },
+        "10.10.10.227": {
+            "ipAddress": "10.10.10.227",
+            "logicalName": "dt-n9k4",
+            "serialNumber": "XYZKSJHSMK4",
+            "switchRole": "border spine"
+        },
+        "10.10.10.228": {
+            "ipAddress": "10.10.10.228",
+            "logicalName": "dt-n9k5",
+            "serialNumber": "XYZKSJHSMK5",
+            "switchRole": "border"
+        }
+    },
+    "fabric_details_mfd": {
         "id": 4,
         "fabricId": "standalone_fabric_mfd",
         "fabricName": "MSD",
@@ -2290,1065 +2287,1159 @@
         "networkExtensionTemplate": "Default_Network_Extension_Universal",
         "createdOn": 1737248524471,
         "modifiedOn": 1737248525048
-  },
-  "fabric_details_vxlan": {
-    "id": 5,
-    "fabricId": "FABRIC-5",
-    "fabricName": "VXLAN",
-    "fabricType": "Switch_Fabric",
-    "fabricTypeFriendly": "Switch Fabric",
-    "fabricTechnology": "VXLANFabric",
-    "templateFabricType": "Data Center VXLAN EVPN",
-    "fabricTechnologyFriendly": "VXLAN EVPN",
-    "provisionMode": "DCNMTopDown",
-    "deviceType": "n9k",
-    "replicationMode": "Multicast",
-    "operStatus": "WARNING",
-    "asn": "65001",
-    "siteId": "65001",
-    "templateName": "Easy_Fabric",
-    "nvPairs": {
-        "MSO_SITE_ID": "",
-        "PHANTOM_RP_LB_ID1": "",
-        "PHANTOM_RP_LB_ID2": "",
-        "PHANTOM_RP_LB_ID3": "",
-        "IBGP_PEER_TEMPLATE": "",
-        "PHANTOM_RP_LB_ID4": "",
-        "abstract_ospf": "base_ospf",
-        "L3_PARTITION_ID_RANGE": "50000-59000",
-        "FEATURE_PTP": "false",
-        "DHCP_START_INTERNAL": "",
-        "SSPINE_COUNT": "0",
-        "ENABLE_SGT": "false",
-        "ENABLE_MACSEC_PREV": "false",
-        "NXC_DEST_VRF": "management",
-        "ADVERTISE_PIP_BGP": "false",
-        "FABRIC_VPC_QOS_POLICY_NAME": "spine_qos_for_fabric_vpc_peering",
-        "BFD_PIM_ENABLE": "false",
-        "DHCP_END": "",
-        "FABRIC_VPC_DOMAIN_ID": "",
-        "SEED_SWITCH_CORE_INTERFACES": "",
-        "UNDERLAY_IS_V6": "false",
-        "ALLOW_NXC_PREV": "true",
-        "FABRIC_MTU_PREV": "9216",
-        "BFD_ISIS_ENABLE": "false",
-        "HD_TIME": "180",
-        "AUTO_UNIQUE_VRF_LITE_IP_PREFIX": "false",
-        "LOOPBACK1_IPV6_RANGE": "",
-        "OSPF_AUTH_ENABLE": "false",
-        "ROUTER_ID_RANGE": "",
-        "MSO_CONNECTIVITY_DEPLOYED": "",
-        "ENABLE_MACSEC": "false",
-        "DEAFULT_QUEUING_POLICY_OTHER": "queuing_policy_default_other",
-        "UNNUM_DHCP_START_INTERNAL": "",
-        "MACSEC_REPORT_TIMER": "",
-        "PFC_WATCH_INT_PREV": "",
-        "PREMSO_PARENT_FABRIC": "",
-        "MPLS_ISIS_AREA_NUM": "0001",
-        "UNNUM_DHCP_END_INTERNAL": "",
-        "PTP_DOMAIN_ID": "",
-        "USE_LINK_LOCAL": "false",
-        "AUTO_SYMMETRIC_VRF_LITE": "false",
-        "BGP_AS_PREV": "65001",
-        "ENABLE_PBR": "false",
-        "DCI_SUBNET_TARGET_MASK": "30",
-        "ENABLE_TRMv6": "false",
-        "VPC_PEER_LINK_PO": "500",
-        "ISIS_AUTH_ENABLE": "false",
-        "PER_VRF_LOOPBACK_AUTO_PROVISION": "false",
-        "REPLICATION_MODE": "Multicast",
-        "ENABLE_DCI_MACSEC_PREV": "false",
-        "SITE_ID_POLICY_ID": "",
-        "SGT_NAME_PREFIX": "",
-        "ANYCAST_RP_IP_RANGE": "10.254.254.0/24",
-        "VPC_ENABLE_IPv6_ND_SYNC": "true",
-        "abstract_isis_interface": "isis_interface",
-        "TCAM_ALLOCATION": "true",
-        "ENABLE_RT_INTF_STATS": "false",
-        "SERVICE_NETWORK_VLAN_RANGE": "3000-3199",
-        "MACSEC_ALGORITHM": "",
-        "ISIS_LEVEL": "level-2",
-        "SUBNET_TARGET_MASK": "30",
-        "abstract_anycast_rp": "anycast_rp",
-        "AUTO_SYMMETRIC_DEFAULT_VRF": "false",
-        "ENABLE_NETFLOW": "false",
-        "DEAFULT_QUEUING_POLICY_R_SERIES": "queuing_policy_default_r_series",
-        "PER_VRF_LOOPBACK_IP_RANGE_V6": "",
-        "temp_vpc_peer_link": "int_vpc_peer_link_po",
-        "BROWNFIELD_NETWORK_NAME_FORMAT": "Auto_Net_VNI$$VNI$$_VLAN$$VLAN_ID$$",
-        "ENABLE_FABRIC_VPC_DOMAIN_ID": "false",
-        "IBGP_PEER_TEMPLATE_LEAF": "",
-        "DCI_SUBNET_RANGE": "10.33.0.0/16",
-        "MGMT_GW_INTERNAL": "",
-        "ENABLE_NXAPI": "true",
-        "VRF_LITE_AUTOCONFIG": "Manual",
-        "GRFIELD_DEBUG_FLAG": "Disable",
-        "VRF_VLAN_RANGE": "2000-2299",
-        "ISIS_AUTH_KEYCHAIN_NAME": "",
-        "OBJECT_TRACKING_NUMBER_RANGE": "100-299",
-        "SSPINE_ADD_DEL_DEBUG_FLAG": "Disable",
-        "abstract_bgp_neighbor": "evpn_bgp_rr_neighbor",
-        "OSPF_AUTH_KEY_ID": "",
-        "PIM_HELLO_AUTH_ENABLE": "false",
-        "abstract_feature_leaf": "base_feature_leaf_upg",
-        "BFD_AUTH_ENABLE": "false",
-        "INTF_STAT_LOAD_INTERVAL": "",
-        "BGP_LB_ID": "0",
-        "LOOPBACK1_IP_RANGE": "10.3.0.0/22",
-        "AGG_ACC_VPC_PO_ID_RANGE": "",
-        "EXTRA_CONF_TOR": "",
-        "AAA_SERVER_CONF": "",
-        "VPC_PEER_KEEP_ALIVE_OPTION": "management",
-        "AUTO_VRFLITE_IFC_DEFAULT_VRF": "false",
-        "enableRealTimeBackup": "",
-        "DCI_MACSEC_KEY_STRING": "",
-        "ENABLE_AI_ML_QOS_POLICY": "false",
-        "V6_SUBNET_TARGET_MASK": "126",
-        "STRICT_CC_MODE": "false",
-        "BROWNFIELD_SKIP_OVERLAY_NETWORK_ATTACHMENTS": "false",
-        "VPC_PEER_LINK_VLAN": "3600",
-        "abstract_trunk_host": "int_trunk_host",
-        "NXAPI_HTTP_PORT": "80",
-        "MST_INSTANCE_RANGE": "",
-        "BGP_AUTH_ENABLE": "false",
-        "PM_ENABLE_PREV": "false",
-        "NXC_PROXY_PORT": "8080",
-        "ENABLE_AGG_ACC_ID_RANGE": "false",
-        "RP_MODE": "asm",
-        "enableScheduledBackup": "",
-        "abstract_ospf_interface": "ospf_interface_11_1",
-        "BFD_OSPF_ENABLE": "false",
-        "MACSEC_FALLBACK_ALGORITHM": "",
-        "UNNUM_DHCP_END": "",
-        "LOOPBACK0_IP_RANGE": "10.2.0.0/22",
-        "ENABLE_AAA": "false",
-        "DEPLOYMENT_FREEZE": "false",
-        "L2_HOST_INTF_MTU_PREV": "9216",
-        "SGT_RECALC_STATUS": "empty",
-        "NETFLOW_MONITOR_LIST": "",
-        "ENABLE_AGENT": "false",
-        "NTP_SERVER_IP_LIST": "",
-        "MACSEC_FALLBACK_KEY_STRING": "",
-        "OVERLAY_MODE": "cli",
-        "PER_VRF_LOOPBACK_AUTO_PROVISION_PREV": "false",
-        "FF": "Easy_Fabric",
-        "STP_ROOT_OPTION": "unmanaged",
-        "FABRIC_TYPE": "Switch_Fabric",
-        "ISIS_OVERLOAD_ENABLE": "false",
-        "NETFLOW_RECORD_LIST": "",
-        "SPINE_COUNT": "0",
-        "PER_VRF_LOOPBACK_AUTO_PROVISION_V6": "false",
-        "abstract_extra_config_bootstrap": "extra_config_bootstrap_11_1",
-        "L3VNI_IPv6_MCAST_GROUP": "",
-        "MPLS_LOOPBACK_IP_RANGE": "",
-        "LINK_STATE_ROUTING_TAG_PREV": "UNDERLAY",
-        "DHCP_ENABLE": "false",
-        "BFD_AUTH_KEY_ID": "",
-        "ALLOW_L3VNI_NO_VLAN": "true",
-        "MSO_SITE_GROUP_NAME": "",
-        "MGMT_PREFIX_INTERNAL": "",
-        "DHCP_IPV6_ENABLE_INTERNAL": "",
-        "BGP_AUTH_KEY_TYPE": "3",
-        "SITE_ID": "65001",
-        "temp_anycast_gateway": "anycast_gateway",
-        "BRFIELD_DEBUG_FLAG": "Disable",
-        "BGP_AS": "65001",
-        "BOOTSTRAP_MULTISUBNET": "#Scope_Start_IP, Scope_End_IP, Scope_Default_Gateway, Scope_Subnet_Prefix",
-        "ISIS_P2P_ENABLE": "false",
-        "ENABLE_NGOAM": "true",
-        "CDP_ENABLE": "false",
-        "PTP_LB_ID": "",
-        "DHCP_IPV6_ENABLE": "",
-        "MACSEC_KEY_STRING": "",
-        "TOPDOWN_CONFIG_RM_TRACKING": "notstarted",
-        "ENABLE_L3VNI_NO_VLAN": "false",
-        "KME_SERVER_PORT": "",
-        "OSPF_AUTH_KEY": "",
-        "QKD_PROFILE_NAME": "",
-        "ENABLE_FABRIC_VPC_DOMAIN_ID_PREV": "false",
-        "MVPN_VRI_ID_RANGE": "",
-        "ENABLE_DCI_MACSEC": "false",
-        "EXTRA_CONF_LEAF": "",
-        "ENABLE_AI_ML_QOS_POLICY_FLAP": "false",
-        "vrf_extension_template": "Default_VRF_Extension_Universal",
-        "DHCP_START": "",
-        "ENABLE_TRM": "false",
-        "ENABLE_PVLAN_PREV": "false",
-        "FEATURE_PTP_INTERNAL": "false",
-        "SGT_PREPROV_RECALC_STATUS": "empty",
-        "ENABLE_NXAPI_HTTP": "true",
-        "abstract_isis": "base_isis_level2",
-        "MPLS_LB_ID": "",
-        "FABRIC_VPC_DOMAIN_ID_PREV": "",
-        "ROUTE_MAP_SEQUENCE_NUMBER_RANGE": "1-65534",
-        "NETWORK_VLAN_RANGE": "2300-2999",
-        "STATIC_UNDERLAY_IP_ALLOC": "false",
-        "MGMT_V6PREFIX_INTERNAL": "",
-        "MPLS_HANDOFF": "false",
-        "STP_BRIDGE_PRIORITY": "",
-        "scheduledTime": "",
-        "ANYCAST_LB_ID": "",
-        "MACSEC_CIPHER_SUITE": "",
-        "STP_VLAN_RANGE": "",
-        "MSO_CONTROLER_ID": "",
-        "POWER_REDUNDANCY_MODE": "ps-redundant",
-        "BFD_ENABLE": "false",
-        "abstract_extra_config_leaf": "extra_config_leaf",
-        "ANYCAST_GW_MAC": "2020.0000.00aa",
-        "abstract_dhcp": "base_dhcp",
-        "default_pvlan_sec_network": "",
-        "EXTRA_CONF_SPINE": "",
-        "NTP_SERVER_VRF": "",
-        "SPINE_SWITCH_CORE_INTERFACES": "",
-        "ENABLE_VRI_ID_REALLOC": "false",
-        "LINK_STATE_ROUTING_TAG": "UNDERLAY",
-        "ISIS_OVERLOAD_ELAPSE_TIME": "",
-        "DCI_MACSEC_ALGORITHM": "",
-        "RP_LB_ID": "254",
-        "AI_ML_QOS_POLICY": "AI_Fabric_QOS_400G",
-        "PTP_VLAN_ID": "",
-        "BOOTSTRAP_CONF": "",
-        "PER_VRF_LOOPBACK_AUTO_PROVISION_V6_PREV": "false",
-        "LINK_STATE_ROUTING": "ospf",
-        "ISIS_AUTH_KEY": "",
-        "network_extension_template": "Default_Network_Extension_Universal",
-        "DNS_SERVER_IP_LIST": "",
-        "DOMAIN_NAME_INTERNAL": "",
-        "ENABLE_EVPN": "true",
-        "abstract_multicast": "base_multicast_11_1",
-        "VPC_DELAY_RESTORE_TIME": "60",
-        "BFD_AUTH_KEY": "",
-        "IPv6_MULTICAST_GROUP_SUBNET": "",
-        "AGENT_INTF": "eth0",
-        "FABRIC_MTU": "9216",
-        "QKD_PROFILE_NAME_PREV": "",
-        "L3VNI_MCAST_GROUP": "",
-        "UNNUM_BOOTSTRAP_LB_ID": "",
-        "HOST_INTF_ADMIN_STATE": "true",
-        "VPC_DOMAIN_ID_RANGE": "1-1000",
-        "ALLOW_L3VNI_NO_VLAN_PREV": "true",
-        "BFD_IBGP_ENABLE": "false",
-        "SGT_PREPROVISION": "false",
-        "DCI_MACSEC_FALLBACK_KEY_STRING": "",
-        "AUTO_UNIQUE_VRF_LITE_IP_PREFIX_PREV": "false",
-        "IPv6_ANYCAST_RP_IP_RANGE_INTERNAL": "",
-        "DCI_MACSEC_FALLBACK_ALGORITHM": "",
-        "VPC_AUTO_RECOVERY_TIME": "360",
-        "DNS_SERVER_VRF": "",
-        "UPGRADE_FROM_VERSION": "",
-        "ISIS_AREA_NUM": "0001",
-        "BANNER": "",
-        "NXC_SRC_INTF": "",
-        "SGT_ID_RANGE": "",
-        "ENABLE_QKD": "false",
-        "PER_VRF_LOOPBACK_IP_RANGE": "",
-        "SGT_PREPROVISION_PREV": "false",
-        "SYSLOG_SEV": "",
-        "abstract_loopback_interface": "int_fabric_loopback_11_1",
-        "SYSLOG_SERVER_VRF": "",
-        "EXTRA_CONF_INTRA_LINKS": "",
-        "SNMP_SERVER_HOST_TRAP": "true",
-        "abstract_extra_config_spine": "extra_config_spine",
-        "PIM_HELLO_AUTH_KEY": "",
-        "KME_SERVER_IP": "",
-        "temp_vpc_domain_mgmt": "vpc_domain_mgmt",
-        "V6_SUBNET_RANGE": "",
-        "SUBINTERFACE_RANGE": "2-511",
-        "abstract_routed_host": "int_routed_host",
-        "BGP_AUTH_KEY": "",
-        "INBAND_DHCP_SERVERS": "",
-        "ENABLE_PVLAN": "false",
-        "MPLS_ISIS_AREA_NUM_PREV": "",
-        "default_network": "Default_Network_Universal",
-        "PFC_WATCH_INT": "",
-        "ISIS_AUTH_KEYCHAIN_KEY_ID": "",
-        "MGMT_V6PREFIX": "",
-        "abstract_feature_spine": "base_feature_spine_upg",
-        "ENABLE_DEFAULT_QUEUING_POLICY": "false",
-        "PNP_ENABLE_INTERNAL": "",
-        "ANYCAST_BGW_ADVERTISE_PIP": "false",
-        "NETFLOW_EXPORTER_LIST": "",
-        "abstract_vlan_interface": "int_fabric_vlan_11_1",
-        "RP_COUNT": "2",
-        "FABRIC_NAME": "VXLAN",
-        "abstract_pim_interface": "pim_interface",
-        "PM_ENABLE": "false",
-        "LOOPBACK0_IPV6_RANGE": "",
-        "IGNORE_CERT": "false",
-        "DEFAULT_VRF_REDIS_BGP_RMAP": "",
-        "NVE_LB_ID": "1",
-        "OVERLAY_MODE_PREV": "cli",
-        "VPC_DELAY_RESTORE": "150",
-        "IPv6_ANYCAST_RP_IP_RANGE": "",
-        "UNDERLAY_IS_V6_PREV": "false",
-        "SGT_OPER_STATUS": "off",
-        "NXAPI_HTTPS_PORT": "443",
-        "ENABLE_SGT_PREV": "false",
-        "ENABLE_VPC_PEER_LINK_NATIVE_VLAN": "false",
-        "L2_HOST_INTF_MTU": "9216",
-        "abstract_route_map": "route_map",
-        "TRUSTPOINT_LABEL": "",
-        "INBAND_MGMT_PREV": "false",
-        "EXT_FABRIC_TYPE": "",
-        "abstract_vpc_domain": "base_vpc_domain_11_1",
-        "ACTIVE_MIGRATION": "false",
-        "ISIS_AREA_NUM_PREV": "",
-        "COPP_POLICY": "strict",
-        "DHCP_END_INTERNAL": "",
-        "DCI_MACSEC_CIPHER_SUITE": "",
-        "BOOTSTRAP_ENABLE": "false",
-        "default_vrf": "Default_VRF_Universal",
-        "ADVERTISE_PIP_ON_BORDER": "true",
-        "NXC_PROXY_SERVER": "",
-        "OSPF_AREA_ID": "0.0.0.0",
-        "abstract_extra_config_tor": "extra_config_tor",
-        "SYSLOG_SERVER_IP_LIST": "",
-        "BOOTSTRAP_ENABLE_PREV": "false",
-        "ENABLE_TENANT_DHCP": "true",
-        "ANYCAST_RP_IP_RANGE_INTERNAL": "",
-        "RR_COUNT": "2",
-        "BOOTSTRAP_MULTISUBNET_INTERNAL": "",
-        "MGMT_GW": "",
-        "UNNUM_DHCP_START": "",
-        "MGMT_PREFIX": "",
-        "BFD_ENABLE_PREV": "",
-        "abstract_bgp_rr": "evpn_bgp_rr",
-        "INBAND_MGMT": "false",
-        "abstract_bgp": "base_bgp",
-        "SLA_ID_RANGE": "10000-19999",
-        "ENABLE_NETFLOW_PREV": "false",
-        "SUBNET_RANGE": "10.4.0.0/16",
-        "DEAFULT_QUEUING_POLICY_CLOUDSCALE": "queuing_policy_default_8q_cloudscale",
-        "MULTICAST_GROUP_SUBNET": "239.1.1.0/25",
-        "FABRIC_INTERFACE_TYPE": "p2p",
-        "ALLOW_NXC": "true",
-        "OVERWRITE_GLOBAL_NXC": "false",
-        "FABRIC_VPC_QOS": "false",
-        "AAA_REMOTE_IP_ENABLED": "false",
-        "L2_SEGMENT_ID_RANGE": "30000-49000"
     },
-    "vrfTemplate": "Default_VRF_Universal",
-    "networkTemplate": "Default_Network_Universal",
-    "vrfExtensionTemplate": "Default_VRF_Extension_Universal",
-    "networkExtensionTemplate": "Default_Network_Extension_Universal",
-    "createdOn": 1737248896991,
-    "modifiedOn": 1737248902373
-   },
-   "fabric_details": {
-    "createdOn": 1613750822779,
-    "deviceType": "n9k",
-    "fabricId": "FABRIC-15",
-    "fabricName": "MS-fabric",
-    "fabricTechnology": "VXLANFabric",
-    "fabricTechnologyFriendly": "VXLAN Fabric",
-    "fabricType": "MFD",
-    "fabricTypeFriendly": "Multi-Fabric Domain",
-    "id": 15,
-    "modifiedOn": 1613750822779,
-    "networkExtensionTemplate": "Default_Network_Extension_Universal",
-    "networkTemplate": "Default_Network_Universal",
-    "nvPairs": {
-      "ANYCAST_GW_MAC": "2020.0000.00aa",
-      "BGP_RP_ASN": "",
-      "BORDER_GWY_CONNECTIONS": "Direct_To_BGWS",
-      "CLOUDSEC_ALGORITHM": "",
-      "CLOUDSEC_AUTOCONFIG": "false",
-      "CLOUDSEC_ENFORCEMENT": "",
-      "CLOUDSEC_KEY_STRING": "",
-      "DCI_SUBNET_RANGE": "10.10.1.0/24",
-      "DCI_SUBNET_TARGET_MASK": "30",
-      "DELAY_RESTORE": "300",
-      "FABRIC_NAME": "MS-fabric",
-      "FABRIC_TYPE": "MFD",
-      "FF": "MSD",
-      "L2_SEGMENT_ID_RANGE": "30000-49000",
-      "L3_PARTITION_ID_RANGE": "50000-59000",
-      "LOOPBACK100_IP_RANGE": "10.10.0.0/24",
-      "MS_LOOPBACK_ID": "100",
-      "MS_UNDERLAY_AUTOCONFIG": "true",
-      "PER_VRF_LOOPBACK_AUTO_PROVISION": "false",
-      "RP_SERVER_IP": "",
-      "TOR_AUTO_DEPLOY": "false",
-      "default_network": "Default_Network_Universal",
-      "default_vrf": "Default_VRF_Universal",
-      "enableScheduledBackup": "false",
-      "network_extension_template": "Default_Network_Extension_Universal",
-      "scheduledTime": "",
-      "vrf_extension_template": "Default_VRF_Extension_Universal"
-    },
-    "provisionMode": "DCNMTopDown",
-    "replicationMode": "IngressReplication",
-    "templateName": "MSD_Fabric_11_1",
-    "vrfExtensionTemplate": "Default_VRF_Extension_Universal",
-    "vrfTemplate": "Default_VRF_Universal"
-   },
-   "mock_vrf12_object": {
-    "ERROR": "",
-    "RETURN_CODE": 200,
-    "MESSAGE":"OK",
-    "DATA": [
-      {
-        "fabric": "standalone_fabric",
-        "serviceVrfTemplate": "None",
-        "source": "None",
-        "vrfExtensionTemplate": "Default_VRF_Extension_Universal",
-        "vrfId": 9008011,
-        "vrfName": "test_vrf_1",
-        "vrfTemplate": "Default_VRF_Universal",
-        "vrfTemplateConfig": "{\"advertiseDefaultRouteFlag\":\"true\",\"routeTargetImport\":\"\",\"vrfVlanId\":\"202\",\"isRPExternal\":\"false\",\"vrfDescription\":\"\",\"disableRtAuto\":\"false\",\"L3VniMcastGroup\":\"\",\"vrfSegmentId\":\"9008013\",\"maxBgpPaths\":\"1\",\"maxIbgpPaths\":\"2\",\"routeTargetExport\":\"\",\"ipv6LinkLocalFlag\":\"true\",\"vrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"v6VrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"routeTargetExportMvpn\":\"\",\"ENABLE_NETFLOW\":\"false\",\"configureStaticDefaultRouteFlag\":\"true\",\"tag\":\"12345\",\"rpAddress\":\"\",\"trmBGWMSiteEnabled\":\"false\",\"nveId\":\"1\",\"routeTargetExportEvpn\":\"\",\"NETFLOW_MONITOR\":\"\",\"bgpPasswordKeyType\":\"3\",\"bgpPassword\":\"\",\"mtu\":\"9216\",\"multicastGroup\":\"\",\"routeTargetImportMvpn\":\"\",\"isRPAbsent\":\"false\",\"advertiseHostRouteFlag\":\"false\",\"vrfVlanName\":\"\",\"trmEnabled\":\"false\",\"loopbackNumber\":\"\",\"asn\":\"52125\",\"vrfIntfDescription\":\"\",\"vrfName\":\"test_vrf_1\",\"routeTargetImportEvpn\":\"\"}",
-        "vrfStatus": "DEPLOYED"
-      }
-    ]
-  },
-  "mock_pools_top_down_vrf_vlan": {
-    "ERROR": "",
-    "RETURN_CODE": 200,
-    "MESSAGE":"OK",
-    "DATA": [
-      {
-        "allocatedFlag": true,
-        "allocatedIp": "201",
-        "allocatedOn": 1734051260507,
-        "allocatedScopeValue": "FDO211218HH",
-        "entityName": "VRF_1",
-        "entityType": "Device",
-        "hierarchicalKey": "0",
-        "id": 36407,
-        "ipAddress": "172.22.150.104",
-        "resourcePool": {
-            "dynamicSubnetRange": null,
-            "fabricName": "f1",
-            "hierarchicalKey": "f1",
-            "id": 0,
-            "overlapAllowed": false,
-            "poolName": "TOP_DOWN_VRF_VLAN",
-            "poolType": "ID_POOL",
-            "targetSubnet": 0,
-            "vrfName": "VRF_1"
-        },
-        "switchName": "cvd-1313-leaf"
-      }
-    ]
-  },
-  "mock_pools_top_down_dot1q": {
-    "ERROR": "",
-    "RETURN_CODE": 200,
-    "MESSAGE":"OK",
-    "DATA": [
-      {
-        "allocatedFlag": true,
-        "allocatedIp": "5",
-        "allocatedOn": 1734051260507,
-        "allocatedScopeValue": "XYZKSJHSMK1",
-        "entityName": "test_vrf_1",
-        "entityType": "DeviceInterface",
-        "hierarchicalKey": "0",
-        "id": 6613,
-        "ipAddress": "10.10.10.224",
-        "resourcePool": {
-            "dynamicSubnetRange": null,
-            "fabricName": "parent_fabric",
-            "hierarchicalKey": "parent_fabric",
-            "id": 0,
-            "overlapAllowed": false,
-            "poolName": "TOP_DOWN_L3_DOT1Q",
-            "poolType": "ID_POOL",
-            "targetSubnet": 0,
-            "vrfName": "VRF_1"
-        },
-        "switchName": "n9kv_leaf1"
-      }
-    ]
-  },
-  "mock_vrf_lite_obj": {
-   "RETURN_CODE":200,
-   "METHOD":"GET",
-   "MESSAGE":"OK",
-   "DATA": [
-      {
-        "vrfName":"test_vrf",
-        "templateName":"Default_VRF_Extension_Universal",
-        "switchDetailsList":[
-          {
-             "switchName":"poap_test",
-             "vlan":2001,
-             "serialNumber":"9D2DAUJJFQQ",
-             "peerSerialNumber":"None",
-             "extensionValues":"None",
-             "extensionPrototypeValues":[
-               {
-                 "interfaceName":"Ethernet1/3",
-                 "extensionType":"VRF_LITE",
-                 "extensionValues":"{\"PEER_VRF_NAME\": \"\", \"NEIGHBOR_IP\": \"10.33.0.1\", \"VRF_LITE_JYTHON_TEMPLATE\": \"Ext_VRF_Lite_Jython\", \"enableBorderExtension\": \"VRF_LITE\", \"AUTO_VRF_LITE_FLAG\":\"false\", \"IP_MASK\": \"10.33.0.2/30\", \"MTU\": \"9216\", \"NEIGHBOR_ASN\": \"23132\", \"IF_NAME\": \"Ethernet1/3\", \"IPV6_NEIGHBOR\": \"\", \"IPV6_MASK\": \"\", \"DOT1Q_ID\": \"2\", \"asn\": \"52125\"}",
-                 "destInterfaceName":"Ethernet1/1",
-                 "destSwitchName":"poap-import-static"
-               },
-               {
-                 "interfaceName":"Ethernet1/2",
-                 "extensionType":"VRF_LITE",
-                 "extensionValues":"{\"PEER_VRF_NAME\": \"\", \"NEIGHBOR_IP\": \"20.33.0.1\", \"VRF_LITE_JYTHON_TEMPLATE\": \"Ext_VRF_Lite_Jython\", \"enableBorderExtension\": \"VRF_LITE\", \"AUTO_VRF_LITE_FLAG\": \"false\", \"IP_MASK\": \"20.33.0.2/30\", \"MTU\": \"9216\", \"NEIGHBOR_ASN\": \"23132\", \"IF_NAME\": \"Ethernet1/2\", \"IPV6_NEIGHBOR\": \"\", \"IPV6_MASK\": \"\", \"DOT1Q_ID\": \"2\", \"asn\": \"52125\"}",
-                 "destInterfaceName":"Ethernet1/2",
-                 "destSwitchName":"poap-import-static"
-               }
-             ],
-             "islanAttached":false,
-             "lanAttachedState":"NA",
-             "errorMessage":"None",
-             "instanceValues":"None",
-             "freeformConfig":"None",
-             "role":"border gateway",
-             "vlanModifiable":true
-          }
-        ]
-      }
-    ]
-  },
-  "mock_msd_vrf_lite_obj": {
-   "RETURN_CODE":200,
-   "METHOD":"GET",
-   "MESSAGE":"OK",
-   "DATA": [
-      {
-        "vrfName":"test_vrf_1",
-        "templateName":"Default_VRF_Extension_Universal",
-        "switchDetailsList":[
-          {
-             "switchName":"leaf1",
-             "vlan":2000,
-             "serialNumber":"XYZKSJHSMK1",
-             "peerSerialNumber": "None",
-             "extensionValues":"{}",
-             "extensionPrototypeValues":[
-               {
-                 "interfaceName":"Ethernet1/3",
-                 "extensionType":"VRF_LITE",
-                 "extensionValues":"{\"PEER_VRF_NAME\": \"\", \"NEIGHBOR_IP\": \"10.33.0.1\", \"VRF_LITE_JYTHON_TEMPLATE\": \"Ext_VRF_Lite_Jython\", \"enableBorderExtension\": \"VRF_LITE\", \"AUTO_VRF_LITE_FLAG\":\"false\", \"IP_MASK\": \"10.33.0.2/30\", \"MTU\": \"9216\", \"NEIGHBOR_ASN\": \"23132\", \"IF_NAME\": \"Ethernet1/3\", \"IPV6_NEIGHBOR\": \"\", \"IPV6_MASK\": \"\", \"DOT1Q_ID\": \"2\", \"asn\": \"52125\"}",
-                 "destInterfaceName":"Ethernet1/1",
-                 "destSwitchName":"poap-import-static"
-               }
-             ],
-             "islanAttached":false,
-             "lanAttachedState":"DEPLOYED",
-             "errorMessage":"None",
-             "instanceValues": "{\"loopbackIpV6Address\":\"\",\"loopbackId\":\"\",\"deviceSupportL3VniNoVlan\":\"false\",\"switchRouteTargetImportEvpn\":\"\",\"loopbackIpAddress\":\"\",\"switchRouteTargetExportEvpn\":\"\"}",
-             "freeformConfig":"",
-             "role":"leaf",
-             "vlanModifiable":true
-          }
-        ]
-      }
-    ]
-  },
-  "mock_msd_vrf_lite_obj_2": {
-   "RETURN_CODE":200,
-   "METHOD":"GET",
-   "MESSAGE":"OK",
-   "DATA": [
-      {
-        "vrfName":"test_vrf_2",
-        "templateName":"Default_VRF_Extension_Universal",
-        "switchDetailsList":[
-          {
-             "switchName":"leaf1",
-             "vlan":2001,
-             "serialNumber":"XYZKSJHSMK1",
-             "peerSerialNumber": "None",
-             "extensionValues":"{}",
-             "extensionPrototypeValues":[
-               {
-                 "interfaceName":"Ethernet1/3",
-                 "extensionType":"VRF_LITE",
-                 "extensionValues":"{\"PEER_VRF_NAME\": \"\", \"NEIGHBOR_IP\": \"10.33.0.1\", \"VRF_LITE_JYTHON_TEMPLATE\": \"Ext_VRF_Lite_Jython\", \"enableBorderExtension\": \"VRF_LITE\", \"AUTO_VRF_LITE_FLAG\":\"false\", \"IP_MASK\": \"10.33.0.2/30\", \"MTU\": \"9216\", \"NEIGHBOR_ASN\": \"23132\", \"IF_NAME\": \"Ethernet1/3\", \"IPV6_NEIGHBOR\": \"\", \"IPV6_MASK\": \"\", \"DOT1Q_ID\": \"2\", \"asn\": \"52125\"}",
-                 "destInterfaceName":"Ethernet1/1",
-                 "destSwitchName":"poap-import-static"
-               }
-             ],
-             "islanAttached":false,
-             "lanAttachedState":"DEPLOYED",
-             "errorMessage":"None",
-             "instanceValues": "{\"loopbackIpV6Address\":\"\",\"loopbackId\":\"\",\"deviceSupportL3VniNoVlan\":\"false\",\"switchRouteTargetImportEvpn\":\"\",\"loopbackIpAddress\":\"\",\"switchRouteTargetExportEvpn\":\"\"}",
-             "freeformConfig":"",
-             "role":"leaf",
-             "vlanModifiable":true
-          }
-        ]
-      }
-    ]
-  },
-  "multicluster_fabric_associations_empty": {
-   "RETURN_CODE":200,
-   "METHOD":"GET",
-   "MESSAGE":"OK",
-   "DATA": []
-  },
-  "multicluster_fabric_associations": {
-   "RETURN_CODE":200,
-   "METHOD":"GET",
-   "MESSAGE":"OK",
-   "DATA": [
-    {
-        "id": 1,
-        "clusterName": "",
-        "fabricId": "MC-FABRIC-3524b4ad-2d41-415f-a9c7-ab0382f891a3",
-        "fabricName": "parent_fabric",
-        "fabricType": "MFD",
-        "fabricTypeFriendly": "VXLAN EVPN Multi-Site",
+    "fabric_details_vxlan": {
+        "id": 5,
+        "fabricId": "FABRIC-5",
+        "fabricName": "VXLAN",
+        "fabricType": "Switch_Fabric",
+        "fabricTypeFriendly": "Switch Fabric",
         "fabricTechnology": "VXLANFabric",
+        "templateFabricType": "Data Center VXLAN EVPN",
         "fabricTechnologyFriendly": "VXLAN EVPN",
-        "provisionMode": "",
-        "deviceType": "",
-        "replicationMode": "",
-        "operStatus": "HEALTHY",
-        "asn": "",
-        "siteId": "",
-        "templateName": "MSD_Fabric",
+        "provisionMode": "DCNMTopDown",
+        "deviceType": "n9k",
+        "replicationMode": "Multicast",
+        "operStatus": "WARNING",
+        "asn": "65001",
+        "siteId": "65001",
+        "templateName": "Easy_Fabric",
         "nvPairs": {
-            "ANYCAST_GW_MAC": "2020.0000.00aa",
-            "BGP_RP_ASN": "",
-            "BGW_ROUTING_TAG": "54321",
-            "BGW_ROUTING_TAG_PREV": "54321",
-            "BORDER_GWY_CONNECTIONS": "Manual",
-            "CLOUDSEC_ALGORITHM": "AES_128_CMAC",
-            "CLOUDSEC_AUTOCONFIG": "false",
-            "CLOUDSEC_AUTOCONFIG_PREV": "false",
-            "CLOUDSEC_ENFORCEMENT": "",
-            "CLOUDSEC_KEY_STRING": "",
-            "CLOUDSEC_REPORT_TIMER": "5",
-            "DCI_SUBNET_RANGE": "10.10.1.0/24",
-            "DCI_SUBNET_TARGET_MASK": "30",
-            "DCNM_ID": "",
-            "DELAY_RESTORE": "300",
-            "DSVNI_L2VNI_RANGE": "10030000-10049000",
-            "DSVNI_L3VNI_RANGE": "10050000-10059000",
-            "ENABLE_BGP_BFD": false,
-            "ENABLE_BGP_LOG_NEIGHBOR_CHANGE": false,
-            "ENABLE_BGP_SEND_COMM": false,
-            "ENABLE_DSVNI": "false",
-            "ENABLE_DSVNI_PREV": "false",
-            "ENABLE_PVLAN": "false",
-            "ENABLE_PVLAN_PREV": "false",
-            "ENABLE_RS_REDIST_DIRECT": false,
-            "ENABLE_SGT": "off",
-            "ENABLE_SGT_PREV": "off",
-            "ENABLE_TRM_TRMv6": "false",
-            "ENABLE_TRM_TRMv6_PREV": "false",
-            "EXT_FABRIC_TYPE": "",
-            "FABRIC_NAME": "MCFG_PARENT",
-            "FABRIC_TYPE": "MFD",
-            "FF": "MSD",
-            "L2_SEGMENT_ID_RANGE": "30000-49000",
+            "MSO_SITE_ID": "",
+            "PHANTOM_RP_LB_ID1": "",
+            "PHANTOM_RP_LB_ID2": "",
+            "PHANTOM_RP_LB_ID3": "",
+            "IBGP_PEER_TEMPLATE": "",
+            "PHANTOM_RP_LB_ID4": "",
+            "abstract_ospf": "base_ospf",
             "L3_PARTITION_ID_RANGE": "50000-59000",
-            "LOOPBACK100_IPV6_RANGE": "fd00::a10:0/120",
-            "LOOPBACK100_IP_RANGE": "10.10.0.0/24",
-            "MSO_CONTROLER_ID": "",
-            "MSO_SITE_GROUP_NAME": "",
-            "MS_IFC_BGP_AUTH_KEY_TYPE": "",
-            "MS_IFC_BGP_AUTH_KEY_TYPE_PREV": "",
-            "MS_IFC_BGP_PASSWORD": "",
-            "MS_IFC_BGP_PASSWORD_ENABLE": "false",
-            "MS_IFC_BGP_PASSWORD_ENABLE_PREV": "false",
-            "MS_IFC_BGP_PASSWORD_PREV": "",
-            "MS_LOOPBACK_ID": "100",
-            "MS_UNDERLAY_AUTOCONFIG": "false",
-            "PARENT_ONEMANAGE_FABRIC": "",
+            "FEATURE_PTP": "false",
+            "DHCP_START_INTERNAL": "",
+            "SSPINE_COUNT": "0",
+            "ENABLE_SGT": "false",
+            "ENABLE_MACSEC_PREV": "false",
+            "NXC_DEST_VRF": "management",
+            "ADVERTISE_PIP_BGP": "false",
+            "FABRIC_VPC_QOS_POLICY_NAME": "spine_qos_for_fabric_vpc_peering",
+            "BFD_PIM_ENABLE": "false",
+            "DHCP_END": "",
+            "FABRIC_VPC_DOMAIN_ID": "",
+            "SEED_SWITCH_CORE_INTERFACES": "",
+            "UNDERLAY_IS_V6": "false",
+            "ALLOW_NXC_PREV": "true",
+            "FABRIC_MTU_PREV": "9216",
+            "BFD_ISIS_ENABLE": "false",
+            "HD_TIME": "180",
+            "AUTO_UNIQUE_VRF_LITE_IP_PREFIX": "false",
+            "LOOPBACK1_IPV6_RANGE": "",
+            "OSPF_AUTH_ENABLE": "false",
+            "ROUTER_ID_RANGE": "",
+            "MSO_CONNECTIVITY_DEPLOYED": "",
+            "ENABLE_MACSEC": "false",
+            "DEAFULT_QUEUING_POLICY_OTHER": "queuing_policy_default_other",
+            "UNNUM_DHCP_START_INTERNAL": "",
+            "MACSEC_REPORT_TIMER": "",
+            "PFC_WATCH_INT_PREV": "",
             "PREMSO_PARENT_FABRIC": "",
-            "RP_SERVER_IP": "",
-            "RS_ROUTING_TAG": "",
-            "SGT_ID_RANGE": "",
-            "SGT_ID_RANGE_PREV": "",
+            "MPLS_ISIS_AREA_NUM": "0001",
+            "UNNUM_DHCP_END_INTERNAL": "",
+            "PTP_DOMAIN_ID": "",
+            "USE_LINK_LOCAL": "false",
+            "AUTO_SYMMETRIC_VRF_LITE": "false",
+            "BGP_AS_PREV": "65001",
+            "ENABLE_PBR": "false",
+            "DCI_SUBNET_TARGET_MASK": "30",
+            "ENABLE_TRMv6": "false",
+            "VPC_PEER_LINK_PO": "500",
+            "ISIS_AUTH_ENABLE": "false",
+            "PER_VRF_LOOPBACK_AUTO_PROVISION": "false",
+            "REPLICATION_MODE": "Multicast",
+            "ENABLE_DCI_MACSEC_PREV": "false",
+            "SITE_ID_POLICY_ID": "",
             "SGT_NAME_PREFIX": "",
-            "SGT_NAME_PREFIX_PREV": "",
-            "SGT_OPER_STATUS": "off",
-            "SGT_PREPROVISION": false,
-            "SGT_PREPROVISION_PREV": false,
-            "SGT_PREPROV_RECALC_STATUS": "empty",
-            "SGT_RECALC_STATUS": "empty",
-            "V6_DCI_SUBNET_RANGE": "fd00::a11:0/120",
-            "V6_DCI_SUBNET_TARGET_MASK": "126",
-            "VXLAN_UNDERLAY_IS_V6": "false",
-            "default_network": "Default_Network_Universal",
-            "default_pvlan_sec_network": "Pvlan_Secondary_Network",
-            "default_vrf": "Default_VRF_Universal",
-            "enableMsOverlayIfcBgpDesc": false,
+            "ANYCAST_RP_IP_RANGE": "10.254.254.0/24",
+            "VPC_ENABLE_IPv6_ND_SYNC": "true",
+            "abstract_isis_interface": "isis_interface",
+            "TCAM_ALLOCATION": "true",
+            "ENABLE_RT_INTF_STATS": "false",
+            "SERVICE_NETWORK_VLAN_RANGE": "3000-3199",
+            "MACSEC_ALGORITHM": "",
+            "ISIS_LEVEL": "level-2",
+            "SUBNET_TARGET_MASK": "30",
+            "abstract_anycast_rp": "anycast_rp",
+            "AUTO_SYMMETRIC_DEFAULT_VRF": "false",
+            "ENABLE_NETFLOW": "false",
+            "DEAFULT_QUEUING_POLICY_R_SERIES": "queuing_policy_default_r_series",
+            "PER_VRF_LOOPBACK_IP_RANGE_V6": "",
+            "temp_vpc_peer_link": "int_vpc_peer_link_po",
+            "BROWNFIELD_NETWORK_NAME_FORMAT": "Auto_Net_VNI$$VNI$$_VLAN$$VLAN_ID$$",
+            "ENABLE_FABRIC_VPC_DOMAIN_ID": "false",
+            "IBGP_PEER_TEMPLATE_LEAF": "",
+            "DCI_SUBNET_RANGE": "10.33.0.0/16",
+            "MGMT_GW_INTERNAL": "",
+            "ENABLE_NXAPI": "true",
+            "VRF_LITE_AUTOCONFIG": "Manual",
+            "GRFIELD_DEBUG_FLAG": "Disable",
+            "VRF_VLAN_RANGE": "2000-2299",
+            "ISIS_AUTH_KEYCHAIN_NAME": "",
+            "OBJECT_TRACKING_NUMBER_RANGE": "100-299",
+            "SSPINE_ADD_DEL_DEBUG_FLAG": "Disable",
+            "abstract_bgp_neighbor": "evpn_bgp_rr_neighbor",
+            "OSPF_AUTH_KEY_ID": "",
+            "PIM_HELLO_AUTH_ENABLE": "false",
+            "abstract_feature_leaf": "base_feature_leaf_upg",
+            "BFD_AUTH_ENABLE": "false",
+            "INTF_STAT_LOAD_INTERVAL": "",
+            "BGP_LB_ID": "0",
+            "LOOPBACK1_IP_RANGE": "10.3.0.0/22",
+            "AGG_ACC_VPC_PO_ID_RANGE": "",
+            "EXTRA_CONF_TOR": "",
+            "AAA_SERVER_CONF": "",
+            "VPC_PEER_KEEP_ALIVE_OPTION": "management",
+            "AUTO_VRFLITE_IFC_DEFAULT_VRF": "false",
+            "enableRealTimeBackup": "",
+            "DCI_MACSEC_KEY_STRING": "",
+            "ENABLE_AI_ML_QOS_POLICY": "false",
+            "V6_SUBNET_TARGET_MASK": "126",
+            "STRICT_CC_MODE": "false",
+            "BROWNFIELD_SKIP_OVERLAY_NETWORK_ATTACHMENTS": "false",
+            "VPC_PEER_LINK_VLAN": "3600",
+            "abstract_trunk_host": "int_trunk_host",
+            "NXAPI_HTTP_PORT": "80",
+            "MST_INSTANCE_RANGE": "",
+            "BGP_AUTH_ENABLE": "false",
+            "PM_ENABLE_PREV": "false",
+            "NXC_PROXY_PORT": "8080",
+            "ENABLE_AGG_ACC_ID_RANGE": "false",
+            "RP_MODE": "asm",
             "enableScheduledBackup": "",
-            "network_extension_template": "Default_Network_Extension_Universal",
-            "routeServerCollection": "{\"routeServerCollection\":[]}",
+            "abstract_ospf_interface": "ospf_interface_11_1",
+            "BFD_OSPF_ENABLE": "false",
+            "MACSEC_FALLBACK_ALGORITHM": "",
+            "UNNUM_DHCP_END": "",
+            "LOOPBACK0_IP_RANGE": "10.2.0.0/22",
+            "ENABLE_AAA": "false",
+            "DEPLOYMENT_FREEZE": "false",
+            "L2_HOST_INTF_MTU_PREV": "9216",
+            "SGT_RECALC_STATUS": "empty",
+            "NETFLOW_MONITOR_LIST": "",
+            "ENABLE_AGENT": "false",
+            "NTP_SERVER_IP_LIST": "",
+            "MACSEC_FALLBACK_KEY_STRING": "",
+            "OVERLAY_MODE": "cli",
+            "PER_VRF_LOOPBACK_AUTO_PROVISION_PREV": "false",
+            "FF": "Easy_Fabric",
+            "STP_ROOT_OPTION": "unmanaged",
+            "FABRIC_TYPE": "Switch_Fabric",
+            "ISIS_OVERLOAD_ENABLE": "false",
+            "NETFLOW_RECORD_LIST": "",
+            "SPINE_COUNT": "0",
+            "PER_VRF_LOOPBACK_AUTO_PROVISION_V6": "false",
+            "abstract_extra_config_bootstrap": "extra_config_bootstrap_11_1",
+            "L3VNI_IPv6_MCAST_GROUP": "",
+            "MPLS_LOOPBACK_IP_RANGE": "",
+            "LINK_STATE_ROUTING_TAG_PREV": "UNDERLAY",
+            "DHCP_ENABLE": "false",
+            "BFD_AUTH_KEY_ID": "",
+            "ALLOW_L3VNI_NO_VLAN": "true",
+            "MSO_SITE_GROUP_NAME": "",
+            "MGMT_PREFIX_INTERNAL": "",
+            "DHCP_IPV6_ENABLE_INTERNAL": "",
+            "BGP_AUTH_KEY_TYPE": "3",
+            "SITE_ID": "65001",
+            "temp_anycast_gateway": "anycast_gateway",
+            "BRFIELD_DEBUG_FLAG": "Disable",
+            "BGP_AS": "65001",
+            "BOOTSTRAP_MULTISUBNET": "#Scope_Start_IP, Scope_End_IP, Scope_Default_Gateway, Scope_Subnet_Prefix",
+            "ISIS_P2P_ENABLE": "false",
+            "ENABLE_NGOAM": "true",
+            "CDP_ENABLE": "false",
+            "PTP_LB_ID": "",
+            "DHCP_IPV6_ENABLE": "",
+            "MACSEC_KEY_STRING": "",
+            "TOPDOWN_CONFIG_RM_TRACKING": "notstarted",
+            "ENABLE_L3VNI_NO_VLAN": "false",
+            "KME_SERVER_PORT": "",
+            "OSPF_AUTH_KEY": "",
+            "QKD_PROFILE_NAME": "",
+            "ENABLE_FABRIC_VPC_DOMAIN_ID_PREV": "false",
+            "MVPN_VRI_ID_RANGE": "",
+            "ENABLE_DCI_MACSEC": "false",
+            "EXTRA_CONF_LEAF": "",
+            "ENABLE_AI_ML_QOS_POLICY_FLAP": "false",
+            "vrf_extension_template": "Default_VRF_Extension_Universal",
+            "DHCP_START": "",
+            "ENABLE_TRM": "false",
+            "ENABLE_PVLAN_PREV": "false",
+            "FEATURE_PTP_INTERNAL": "false",
+            "SGT_PREPROV_RECALC_STATUS": "empty",
+            "ENABLE_NXAPI_HTTP": "true",
+            "abstract_isis": "base_isis_level2",
+            "MPLS_LB_ID": "",
+            "FABRIC_VPC_DOMAIN_ID_PREV": "",
+            "ROUTE_MAP_SEQUENCE_NUMBER_RANGE": "1-65534",
+            "NETWORK_VLAN_RANGE": "2300-2999",
+            "STATIC_UNDERLAY_IP_ALLOC": "false",
+            "MGMT_V6PREFIX_INTERNAL": "",
+            "MPLS_HANDOFF": "false",
+            "STP_BRIDGE_PRIORITY": "",
             "scheduledTime": "",
-            "securityGroupStatus": "disabled",
-            "unifiedNDFabricType": "vxlan",
-            "vrf_extension_template": "Default_VRF_Extension_Universal"
+            "ANYCAST_LB_ID": "",
+            "MACSEC_CIPHER_SUITE": "",
+            "STP_VLAN_RANGE": "",
+            "MSO_CONTROLER_ID": "",
+            "POWER_REDUNDANCY_MODE": "ps-redundant",
+            "BFD_ENABLE": "false",
+            "abstract_extra_config_leaf": "extra_config_leaf",
+            "ANYCAST_GW_MAC": "2020.0000.00aa",
+            "abstract_dhcp": "base_dhcp",
+            "default_pvlan_sec_network": "",
+            "EXTRA_CONF_SPINE": "",
+            "NTP_SERVER_VRF": "",
+            "SPINE_SWITCH_CORE_INTERFACES": "",
+            "ENABLE_VRI_ID_REALLOC": "false",
+            "LINK_STATE_ROUTING_TAG": "UNDERLAY",
+            "ISIS_OVERLOAD_ELAPSE_TIME": "",
+            "DCI_MACSEC_ALGORITHM": "",
+            "RP_LB_ID": "254",
+            "AI_ML_QOS_POLICY": "AI_Fabric_QOS_400G",
+            "PTP_VLAN_ID": "",
+            "BOOTSTRAP_CONF": "",
+            "PER_VRF_LOOPBACK_AUTO_PROVISION_V6_PREV": "false",
+            "LINK_STATE_ROUTING": "ospf",
+            "ISIS_AUTH_KEY": "",
+            "network_extension_template": "Default_Network_Extension_Universal",
+            "DNS_SERVER_IP_LIST": "",
+            "DOMAIN_NAME_INTERNAL": "",
+            "ENABLE_EVPN": "true",
+            "abstract_multicast": "base_multicast_11_1",
+            "VPC_DELAY_RESTORE_TIME": "60",
+            "BFD_AUTH_KEY": "",
+            "IPv6_MULTICAST_GROUP_SUBNET": "",
+            "AGENT_INTF": "eth0",
+            "FABRIC_MTU": "9216",
+            "QKD_PROFILE_NAME_PREV": "",
+            "L3VNI_MCAST_GROUP": "",
+            "UNNUM_BOOTSTRAP_LB_ID": "",
+            "HOST_INTF_ADMIN_STATE": "true",
+            "VPC_DOMAIN_ID_RANGE": "1-1000",
+            "ALLOW_L3VNI_NO_VLAN_PREV": "true",
+            "BFD_IBGP_ENABLE": "false",
+            "SGT_PREPROVISION": "false",
+            "DCI_MACSEC_FALLBACK_KEY_STRING": "",
+            "AUTO_UNIQUE_VRF_LITE_IP_PREFIX_PREV": "false",
+            "IPv6_ANYCAST_RP_IP_RANGE_INTERNAL": "",
+            "DCI_MACSEC_FALLBACK_ALGORITHM": "",
+            "VPC_AUTO_RECOVERY_TIME": "360",
+            "DNS_SERVER_VRF": "",
+            "UPGRADE_FROM_VERSION": "",
+            "ISIS_AREA_NUM": "0001",
+            "BANNER": "",
+            "NXC_SRC_INTF": "",
+            "SGT_ID_RANGE": "",
+            "ENABLE_QKD": "false",
+            "PER_VRF_LOOPBACK_IP_RANGE": "",
+            "SGT_PREPROVISION_PREV": "false",
+            "SYSLOG_SEV": "",
+            "abstract_loopback_interface": "int_fabric_loopback_11_1",
+            "SYSLOG_SERVER_VRF": "",
+            "EXTRA_CONF_INTRA_LINKS": "",
+            "SNMP_SERVER_HOST_TRAP": "true",
+            "abstract_extra_config_spine": "extra_config_spine",
+            "PIM_HELLO_AUTH_KEY": "",
+            "KME_SERVER_IP": "",
+            "temp_vpc_domain_mgmt": "vpc_domain_mgmt",
+            "V6_SUBNET_RANGE": "",
+            "SUBINTERFACE_RANGE": "2-511",
+            "abstract_routed_host": "int_routed_host",
+            "BGP_AUTH_KEY": "",
+            "INBAND_DHCP_SERVERS": "",
+            "ENABLE_PVLAN": "false",
+            "MPLS_ISIS_AREA_NUM_PREV": "",
+            "default_network": "Default_Network_Universal",
+            "PFC_WATCH_INT": "",
+            "ISIS_AUTH_KEYCHAIN_KEY_ID": "",
+            "MGMT_V6PREFIX": "",
+            "abstract_feature_spine": "base_feature_spine_upg",
+            "ENABLE_DEFAULT_QUEUING_POLICY": "false",
+            "PNP_ENABLE_INTERNAL": "",
+            "ANYCAST_BGW_ADVERTISE_PIP": "false",
+            "NETFLOW_EXPORTER_LIST": "",
+            "abstract_vlan_interface": "int_fabric_vlan_11_1",
+            "RP_COUNT": "2",
+            "FABRIC_NAME": "VXLAN",
+            "abstract_pim_interface": "pim_interface",
+            "PM_ENABLE": "false",
+            "LOOPBACK0_IPV6_RANGE": "",
+            "IGNORE_CERT": "false",
+            "DEFAULT_VRF_REDIS_BGP_RMAP": "",
+            "NVE_LB_ID": "1",
+            "OVERLAY_MODE_PREV": "cli",
+            "VPC_DELAY_RESTORE": "150",
+            "IPv6_ANYCAST_RP_IP_RANGE": "",
+            "UNDERLAY_IS_V6_PREV": "false",
+            "SGT_OPER_STATUS": "off",
+            "NXAPI_HTTPS_PORT": "443",
+            "ENABLE_SGT_PREV": "false",
+            "ENABLE_VPC_PEER_LINK_NATIVE_VLAN": "false",
+            "L2_HOST_INTF_MTU": "9216",
+            "abstract_route_map": "route_map",
+            "TRUSTPOINT_LABEL": "",
+            "INBAND_MGMT_PREV": "false",
+            "EXT_FABRIC_TYPE": "",
+            "abstract_vpc_domain": "base_vpc_domain_11_1",
+            "ACTIVE_MIGRATION": "false",
+            "ISIS_AREA_NUM_PREV": "",
+            "COPP_POLICY": "strict",
+            "DHCP_END_INTERNAL": "",
+            "DCI_MACSEC_CIPHER_SUITE": "",
+            "BOOTSTRAP_ENABLE": "false",
+            "default_vrf": "Default_VRF_Universal",
+            "ADVERTISE_PIP_ON_BORDER": "true",
+            "NXC_PROXY_SERVER": "",
+            "OSPF_AREA_ID": "0.0.0.0",
+            "abstract_extra_config_tor": "extra_config_tor",
+            "SYSLOG_SERVER_IP_LIST": "",
+            "BOOTSTRAP_ENABLE_PREV": "false",
+            "ENABLE_TENANT_DHCP": "true",
+            "ANYCAST_RP_IP_RANGE_INTERNAL": "",
+            "RR_COUNT": "2",
+            "BOOTSTRAP_MULTISUBNET_INTERNAL": "",
+            "MGMT_GW": "",
+            "UNNUM_DHCP_START": "",
+            "MGMT_PREFIX": "",
+            "BFD_ENABLE_PREV": "",
+            "abstract_bgp_rr": "evpn_bgp_rr",
+            "INBAND_MGMT": "false",
+            "abstract_bgp": "base_bgp",
+            "SLA_ID_RANGE": "10000-19999",
+            "ENABLE_NETFLOW_PREV": "false",
+            "SUBNET_RANGE": "10.4.0.0/16",
+            "DEAFULT_QUEUING_POLICY_CLOUDSCALE": "queuing_policy_default_8q_cloudscale",
+            "MULTICAST_GROUP_SUBNET": "239.1.1.0/25",
+            "FABRIC_INTERFACE_TYPE": "p2p",
+            "ALLOW_NXC": "true",
+            "OVERWRITE_GLOBAL_NXC": "false",
+            "FABRIC_VPC_QOS": "false",
+            "AAA_REMOTE_IP_ENABLED": "false",
+            "L2_SEGMENT_ID_RANGE": "30000-49000"
         },
         "vrfTemplate": "Default_VRF_Universal",
         "networkTemplate": "Default_Network_Universal",
         "vrfExtensionTemplate": "Default_VRF_Extension_Universal",
         "networkExtensionTemplate": "Default_Network_Extension_Universal",
-        "createdOn": 1761942870,
-        "modifiedOn": 1761942870,
-        "members": [
+        "createdOn": 1737248896991,
+        "modifiedOn": 1737248902373
+    },
+    "fabric_details": {
+        "createdOn": 1613750822779,
+        "deviceType": "n9k",
+        "fabricId": "FABRIC-15",
+        "fabricName": "MS-fabric",
+        "fabricTechnology": "VXLANFabric",
+        "fabricTechnologyFriendly": "VXLAN Fabric",
+        "fabricType": "MFD",
+        "fabricTypeFriendly": "Multi-Fabric Domain",
+        "id": 15,
+        "modifiedOn": 1613750822779,
+        "networkExtensionTemplate": "Default_Network_Extension_Universal",
+        "networkTemplate": "Default_Network_Universal",
+        "nvPairs": {
+            "ANYCAST_GW_MAC": "2020.0000.00aa",
+            "BGP_RP_ASN": "",
+            "BORDER_GWY_CONNECTIONS": "Direct_To_BGWS",
+            "CLOUDSEC_ALGORITHM": "",
+            "CLOUDSEC_AUTOCONFIG": "false",
+            "CLOUDSEC_ENFORCEMENT": "",
+            "CLOUDSEC_KEY_STRING": "",
+            "DCI_SUBNET_RANGE": "10.10.1.0/24",
+            "DCI_SUBNET_TARGET_MASK": "30",
+            "DELAY_RESTORE": "300",
+            "FABRIC_NAME": "MS-fabric",
+            "FABRIC_TYPE": "MFD",
+            "FF": "MSD",
+            "L2_SEGMENT_ID_RANGE": "30000-49000",
+            "L3_PARTITION_ID_RANGE": "50000-59000",
+            "LOOPBACK100_IP_RANGE": "10.10.0.0/24",
+            "MS_LOOPBACK_ID": "100",
+            "MS_UNDERLAY_AUTOCONFIG": "true",
+            "PER_VRF_LOOPBACK_AUTO_PROVISION": "false",
+            "RP_SERVER_IP": "",
+            "TOR_AUTO_DEPLOY": "false",
+            "default_network": "Default_Network_Universal",
+            "default_vrf": "Default_VRF_Universal",
+            "enableScheduledBackup": "false",
+            "network_extension_template": "Default_Network_Extension_Universal",
+            "scheduledTime": "",
+            "vrf_extension_template": "Default_VRF_Extension_Universal"
+        },
+        "provisionMode": "DCNMTopDown",
+        "replicationMode": "IngressReplication",
+        "templateName": "MSD_Fabric_11_1",
+        "vrfExtensionTemplate": "Default_VRF_Extension_Universal",
+        "vrfTemplate": "Default_VRF_Universal"
+    },
+    "mock_vrf12_object": {
+        "ERROR": "",
+        "RETURN_CODE": 200,
+        "MESSAGE": "OK",
+        "DATA": [
             {
-                "clusterName": "ND41-CL1",
-                "fabricId": 2010,
-                "fabricName": "child_fabric",
-                "templateName": "Easy_Fabric",
-                "fabricType": "Switch_Fabric",
-                "fabricState": "member",
-                "fabricParent": "parent_fabric",
+                "fabric": "standalone_fabric",
+                "serviceVrfTemplate": "None",
+                "source": "None",
+                "vrfExtensionTemplate": "Default_VRF_Extension_Universal",
+                "vrfId": 9008011,
+                "vrfName": "test_vrf_1",
+                "vrfTemplate": "Default_VRF_Universal",
+                "vrfTemplateConfig": "{\"advertiseDefaultRouteFlag\":\"true\",\"routeTargetImport\":\"\",\"vrfVlanId\":\"202\",\"isRPExternal\":\"false\",\"vrfDescription\":\"\",\"disableRtAuto\":\"false\",\"L3VniMcastGroup\":\"\",\"vrfSegmentId\":\"9008013\",\"maxBgpPaths\":\"1\",\"maxIbgpPaths\":\"2\",\"routeTargetExport\":\"\",\"ipv6LinkLocalFlag\":\"true\",\"vrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"v6VrfRouteMap\":\"FABRIC-RMAP-REDIST-SUBNET\",\"routeTargetExportMvpn\":\"\",\"ENABLE_NETFLOW\":\"false\",\"configureStaticDefaultRouteFlag\":\"true\",\"tag\":\"12345\",\"rpAddress\":\"\",\"trmBGWMSiteEnabled\":\"false\",\"nveId\":\"1\",\"routeTargetExportEvpn\":\"\",\"NETFLOW_MONITOR\":\"\",\"bgpPasswordKeyType\":\"3\",\"bgpPassword\":\"\",\"mtu\":\"9216\",\"multicastGroup\":\"\",\"routeTargetImportMvpn\":\"\",\"isRPAbsent\":\"false\",\"advertiseHostRouteFlag\":\"false\",\"vrfVlanName\":\"\",\"trmEnabled\":\"false\",\"loopbackNumber\":\"\",\"asn\":\"52125\",\"vrfIntfDescription\":\"\",\"vrfName\":\"test_vrf_1\",\"routeTargetImportEvpn\":\"\"}",
+                "vrfStatus": "DEPLOYED"
+            }
+        ]
+    },
+    "mock_pools_top_down_vrf_vlan": {
+        "ERROR": "",
+        "RETURN_CODE": 200,
+        "MESSAGE": "OK",
+        "DATA": [
+            {
+                "allocatedFlag": true,
+                "allocatedIp": "201",
+                "allocatedOn": 1734051260507,
+                "allocatedScopeValue": "FDO211218HH",
+                "entityName": "VRF_1",
+                "entityType": "Device",
+                "hierarchicalKey": "0",
+                "id": 36407,
+                "ipAddress": "172.22.150.104",
+                "resourcePool": {
+                    "dynamicSubnetRange": null,
+                    "fabricName": "f1",
+                    "hierarchicalKey": "f1",
+                    "id": 0,
+                    "overlapAllowed": false,
+                    "poolName": "TOP_DOWN_VRF_VLAN",
+                    "poolType": "ID_POOL",
+                    "targetSubnet": 0,
+                    "vrfName": "VRF_1"
+                },
+                "switchName": "cvd-1313-leaf"
+            }
+        ]
+    },
+    "mock_pools_top_down_dot1q": {
+        "ERROR": "",
+        "RETURN_CODE": 200,
+        "MESSAGE": "OK",
+        "DATA": [
+            {
+                "allocatedFlag": true,
+                "allocatedIp": "5",
+                "allocatedOn": 1734051260507,
+                "allocatedScopeValue": "XYZKSJHSMK1",
+                "entityName": "test_vrf_1",
+                "entityType": "DeviceInterface",
+                "hierarchicalKey": "0",
+                "id": 6613,
+                "ipAddress": "10.10.10.224",
+                "resourcePool": {
+                    "dynamicSubnetRange": null,
+                    "fabricName": "parent_fabric",
+                    "hierarchicalKey": "parent_fabric",
+                    "id": 0,
+                    "overlapAllowed": false,
+                    "poolName": "TOP_DOWN_L3_DOT1Q",
+                    "poolType": "ID_POOL",
+                    "targetSubnet": 0,
+                    "vrfName": "VRF_1"
+                },
+                "switchName": "n9kv_leaf1"
+            }
+        ]
+    },
+    "mock_vrf_lite_obj": {
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "MESSAGE": "OK",
+        "DATA": [
+            {
+                "vrfName": "test_vrf",
+                "templateName": "Default_VRF_Extension_Universal",
+                "switchDetailsList": [
+                    {
+                        "switchName": "poap_test",
+                        "vlan": 2001,
+                        "serialNumber": "9D2DAUJJFQQ",
+                        "peerSerialNumber": "None",
+                        "extensionValues": "None",
+                        "extensionPrototypeValues": [
+                            {
+                                "interfaceName": "Ethernet1/3",
+                                "extensionType": "VRF_LITE",
+                                "extensionValues": "{\"PEER_VRF_NAME\": \"\", \"NEIGHBOR_IP\": \"10.33.0.1\", \"VRF_LITE_JYTHON_TEMPLATE\": \"Ext_VRF_Lite_Jython\", \"enableBorderExtension\": \"VRF_LITE\", \"AUTO_VRF_LITE_FLAG\":\"false\", \"IP_MASK\": \"10.33.0.2/30\", \"MTU\": \"9216\", \"NEIGHBOR_ASN\": \"23132\", \"IF_NAME\": \"Ethernet1/3\", \"IPV6_NEIGHBOR\": \"\", \"IPV6_MASK\": \"\", \"DOT1Q_ID\": \"2\", \"asn\": \"52125\"}",
+                                "destInterfaceName": "Ethernet1/1",
+                                "destSwitchName": "poap-import-static"
+                            },
+                            {
+                                "interfaceName": "Ethernet1/2",
+                                "extensionType": "VRF_LITE",
+                                "extensionValues": "{\"PEER_VRF_NAME\": \"\", \"NEIGHBOR_IP\": \"20.33.0.1\", \"VRF_LITE_JYTHON_TEMPLATE\": \"Ext_VRF_Lite_Jython\", \"enableBorderExtension\": \"VRF_LITE\", \"AUTO_VRF_LITE_FLAG\": \"false\", \"IP_MASK\": \"20.33.0.2/30\", \"MTU\": \"9216\", \"NEIGHBOR_ASN\": \"23132\", \"IF_NAME\": \"Ethernet1/2\", \"IPV6_NEIGHBOR\": \"\", \"IPV6_MASK\": \"\", \"DOT1Q_ID\": \"2\", \"asn\": \"52125\"}",
+                                "destInterfaceName": "Ethernet1/2",
+                                "destSwitchName": "poap-import-static"
+                            }
+                        ],
+                        "islanAttached": false,
+                        "lanAttachedState": "NA",
+                        "errorMessage": "None",
+                        "instanceValues": "None",
+                        "freeformConfig": "None",
+                        "role": "border gateway",
+                        "vlanModifiable": true
+                    }
+                ]
+            }
+        ]
+    },
+    "mock_msd_vrf_lite_obj": {
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "MESSAGE": "OK",
+        "DATA": [
+            {
+                "vrfName": "test_vrf_1",
+                "templateName": "Default_VRF_Extension_Universal",
+                "switchDetailsList": [
+                    {
+                        "switchName": "leaf1",
+                        "vlan": 2000,
+                        "serialNumber": "XYZKSJHSMK1",
+                        "peerSerialNumber": "None",
+                        "extensionValues": "{}",
+                        "extensionPrototypeValues": [
+                            {
+                                "interfaceName": "Ethernet1/3",
+                                "extensionType": "VRF_LITE",
+                                "extensionValues": "{\"PEER_VRF_NAME\": \"\", \"NEIGHBOR_IP\": \"10.33.0.1\", \"VRF_LITE_JYTHON_TEMPLATE\": \"Ext_VRF_Lite_Jython\", \"enableBorderExtension\": \"VRF_LITE\", \"AUTO_VRF_LITE_FLAG\":\"false\", \"IP_MASK\": \"10.33.0.2/30\", \"MTU\": \"9216\", \"NEIGHBOR_ASN\": \"23132\", \"IF_NAME\": \"Ethernet1/3\", \"IPV6_NEIGHBOR\": \"\", \"IPV6_MASK\": \"\", \"DOT1Q_ID\": \"2\", \"asn\": \"52125\"}",
+                                "destInterfaceName": "Ethernet1/1",
+                                "destSwitchName": "poap-import-static"
+                            }
+                        ],
+                        "islanAttached": false,
+                        "lanAttachedState": "DEPLOYED",
+                        "errorMessage": "None",
+                        "instanceValues": "{\"loopbackIpV6Address\":\"\",\"loopbackId\":\"\",\"deviceSupportL3VniNoVlan\":\"false\",\"switchRouteTargetImportEvpn\":\"\",\"loopbackIpAddress\":\"\",\"switchRouteTargetExportEvpn\":\"\"}",
+                        "freeformConfig": "",
+                        "role": "leaf",
+                        "vlanModifiable": true
+                    }
+                ]
+            }
+        ]
+    },
+    "mock_msd_vrf_lite_obj_2": {
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "MESSAGE": "OK",
+        "DATA": [
+            {
+                "vrfName": "test_vrf_2",
+                "templateName": "Default_VRF_Extension_Universal",
+                "switchDetailsList": [
+                    {
+                        "switchName": "leaf1",
+                        "vlan": 2001,
+                        "serialNumber": "XYZKSJHSMK1",
+                        "peerSerialNumber": "None",
+                        "extensionValues": "{}",
+                        "extensionPrototypeValues": [
+                            {
+                                "interfaceName": "Ethernet1/3",
+                                "extensionType": "VRF_LITE",
+                                "extensionValues": "{\"PEER_VRF_NAME\": \"\", \"NEIGHBOR_IP\": \"10.33.0.1\", \"VRF_LITE_JYTHON_TEMPLATE\": \"Ext_VRF_Lite_Jython\", \"enableBorderExtension\": \"VRF_LITE\", \"AUTO_VRF_LITE_FLAG\":\"false\", \"IP_MASK\": \"10.33.0.2/30\", \"MTU\": \"9216\", \"NEIGHBOR_ASN\": \"23132\", \"IF_NAME\": \"Ethernet1/3\", \"IPV6_NEIGHBOR\": \"\", \"IPV6_MASK\": \"\", \"DOT1Q_ID\": \"2\", \"asn\": \"52125\"}",
+                                "destInterfaceName": "Ethernet1/1",
+                                "destSwitchName": "poap-import-static"
+                            }
+                        ],
+                        "islanAttached": false,
+                        "lanAttachedState": "DEPLOYED",
+                        "errorMessage": "None",
+                        "instanceValues": "{\"loopbackIpV6Address\":\"\",\"loopbackId\":\"\",\"deviceSupportL3VniNoVlan\":\"false\",\"switchRouteTargetImportEvpn\":\"\",\"loopbackIpAddress\":\"\",\"switchRouteTargetExportEvpn\":\"\"}",
+                        "freeformConfig": "",
+                        "role": "leaf",
+                        "vlanModifiable": true
+                    }
+                ]
+            }
+        ]
+    },
+    "multicluster_fabric_associations_empty": {
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "MESSAGE": "OK",
+        "DATA": []
+    },
+    "multicluster_fabric_associations": {
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "MESSAGE": "OK",
+        "DATA": [
+            {
+                "id": 1,
+                "clusterName": "",
+                "fabricId": "MC-FABRIC-3524b4ad-2d41-415f-a9c7-ab0382f891a3",
+                "fabricName": "parent_fabric",
+                "fabricType": "MFD",
+                "fabricTypeFriendly": "VXLAN EVPN Multi-Site",
                 "fabricTechnology": "VXLANFabric",
-                "fabricTypeFriendly": "Data Center VXLAN EVPN",
                 "fabricTechnologyFriendly": "VXLAN EVPN",
-                "asn": "88",
-                "ndfcIpAddress": "10.122.84.116",
-                "clusterIpAddresses": [
-                    "10.122.84.116"
-                ],
-                "operStatus": "MINOR",
+                "provisionMode": "",
+                "deviceType": "",
+                "replicationMode": "",
+                "operStatus": "HEALTHY",
+                "asn": "",
+                "siteId": "",
+                "templateName": "MSD_Fabric",
                 "nvPairs": {
-                    "AAA_REMOTE_IP_ENABLED": "false",
-                    "AAA_SERVER_CONF": "",
-                    "ACTIVE_MIGRATION": "false",
-                    "ADVERTISE_PIP_BGP": "false",
-                    "ADVERTISE_PIP_ON_BORDER": "true",
-                    "AGENT_INTF": "eth0",
-                    "AGG_ACC_VPC_PO_ID_RANGE": "",
-                    "AI_ML_QOS_POLICY": "AI_Fabric_QOS_400G",
-                    "AI_QOS_400G_MIN_BW": "950",
-                    "ALLOW_NXC": "true",
-                    "ALLOW_NXC_PREV": "true",
-                    "ANYCAST_BGW_ADVERTISE_PIP": "false",
                     "ANYCAST_GW_MAC": "2020.0000.00aa",
-                    "ANYCAST_LB_ID": "",
-                    "ANYCAST_RP_IP_RANGE": "10.254.254.0/24",
-                    "ANYCAST_RP_IP_RANGE_INTERNAL": "10.254.254.0/24",
-                    "AUTO_BGP_NEIGHBOR_DESC": "true",
-                    "AUTO_SYMMETRIC_DEFAULT_VRF": "false",
-                    "AUTO_SYMMETRIC_VRF_LITE": "false",
-                    "AUTO_UNIQUE_VRF_LITE_IP_PREFIX": "false",
-                    "AUTO_UNIQUE_VRF_LITE_IP_PREFIX_PREV": "false",
-                    "AUTO_VRFLITE_IFC_DEFAULT_VRF": "false",
-                    "BANNER": "",
-                    "BFD_AUTH_ENABLE": "false",
-                    "BFD_AUTH_KEY": "",
-                    "BFD_AUTH_KEY_ID": "",
-                    "BFD_ENABLE": "false",
-                    "BFD_ENABLE_PREV": "false",
-                    "BFD_IBGP_ENABLE": "false",
-                    "BFD_ISIS_ENABLE": "false",
-                    "BFD_OSPF_ENABLE": "false",
-                    "BFD_PIM_ENABLE": "false",
-                    "BGP_AS": "88",
-                    "BGP_AS_PREV": "88",
-                    "BGP_AUTH_ENABLE": "false",
-                    "BGP_AUTH_KEY": "",
-                    "BGP_AUTH_KEY_TYPE": "3",
-                    "BGP_LB_ID": "0",
-                    "BOOTSTRAP_CONF": "",
-                    "BOOTSTRAP_ENABLE": "false",
-                    "BOOTSTRAP_ENABLE_PREV": "false",
-                    "BOOTSTRAP_MULTISUBNET": "#Scope_Start_IP, Scope_End_IP, Scope_Default_Gateway, Scope_Subnet_Prefix",
-                    "BOOTSTRAP_MULTISUBNET_INTERNAL": "",
-                    "BRFIELD_DEBUG_FLAG": "Disable",
-                    "BROWNFIELD_NETWORK_NAME_FORMAT": "Auto_Net_VNI$$VNI$$_VLAN$$VLAN_ID$$",
-                    "BROWNFIELD_SKIP_OVERLAY_NETWORK_ATTACHMENTS": "false",
-                    "CDP_ENABLE": "false",
-                    "COPP_POLICY": "strict",
-                    "DCI_MACSEC_ALGORITHM": "",
-                    "DCI_MACSEC_CIPHER_SUITE": "",
-                    "DCI_MACSEC_FALLBACK_ALGORITHM": "",
-                    "DCI_MACSEC_FALLBACK_KEY_STRING": "",
-                    "DCI_MACSEC_KEY_STRING": "",
-                    "DCI_SUBNET_RANGE": "10.33.0.0/16",
+                    "BGP_RP_ASN": "",
+                    "BGW_ROUTING_TAG": "54321",
+                    "BGW_ROUTING_TAG_PREV": "54321",
+                    "BORDER_GWY_CONNECTIONS": "Manual",
+                    "CLOUDSEC_ALGORITHM": "AES_128_CMAC",
+                    "CLOUDSEC_AUTOCONFIG": "false",
+                    "CLOUDSEC_AUTOCONFIG_PREV": "false",
+                    "CLOUDSEC_ENFORCEMENT": "",
+                    "CLOUDSEC_KEY_STRING": "",
+                    "CLOUDSEC_REPORT_TIMER": "5",
+                    "DCI_SUBNET_RANGE": "10.10.1.0/24",
                     "DCI_SUBNET_TARGET_MASK": "30",
-                    "DEAFULT_QUEUING_POLICY_CLOUDSCALE": "queuing_policy_default_8q_cloudscale",
-                    "DEAFULT_QUEUING_POLICY_OTHER": "queuing_policy_default_other",
-                    "DEAFULT_QUEUING_POLICY_R_SERIES": "queuing_policy_default_r_series",
-                    "DEFAULT_VRF_REDIS_BGP_RMAP": "",
-                    "DEPLOYMENT_FREEZE": "false",
-                    "DHCP_ENABLE": "false",
-                    "DHCP_END": "",
-                    "DHCP_END_INTERNAL": "",
-                    "DHCP_IPV6_ENABLE": "",
-                    "DHCP_IPV6_ENABLE_INTERNAL": "",
-                    "DHCP_START": "",
-                    "DHCP_START_INTERNAL": "",
-                    "DNS_SERVER_IP_LIST": "",
-                    "DNS_SERVER_VRF": "",
-                    "DOMAIN_NAME_INTERNAL": "",
-                    "ENABLE_AAA": "false",
-                    "ENABLE_AGENT": "false",
-                    "ENABLE_AGG_ACC_ID_RANGE": "false",
-                    "ENABLE_AI_ML_QOS_POLICY": "false",
-                    "ENABLE_AI_ML_QOS_POLICY_FLAP": "false",
-                    "ENABLE_DCI_MACSEC": "false",
-                    "ENABLE_DCI_MACSEC_PREV": "false",
-                    "ENABLE_DEFAULT_QUEUING_POLICY": "false",
-                    "ENABLE_EVPN": "true",
-                    "ENABLE_FABRIC_VPC_DOMAIN_ID": "false",
-                    "ENABLE_FABRIC_VPC_DOMAIN_ID_PREV": "false",
-                    "ENABLE_L3VNI_NO_VLAN": "false",
-                    "ENABLE_MACSEC": "false",
-                    "ENABLE_MACSEC_PREV": "false",
-                    "ENABLE_NETFLOW": "false",
-                    "ENABLE_NETFLOW_PREV": "false",
-                    "ENABLE_NGOAM": "true",
-                    "ENABLE_NXAPI": "true",
-                    "ENABLE_NXAPI_HTTP": "true",
-                    "ENABLE_PBR": "false",
+                    "DCNM_ID": "",
+                    "DELAY_RESTORE": "300",
+                    "DSVNI_L2VNI_RANGE": "10030000-10049000",
+                    "DSVNI_L3VNI_RANGE": "10050000-10059000",
+                    "ENABLE_BGP_BFD": false,
+                    "ENABLE_BGP_LOG_NEIGHBOR_CHANGE": false,
+                    "ENABLE_BGP_SEND_COMM": false,
+                    "ENABLE_DSVNI": "false",
+                    "ENABLE_DSVNI_PREV": "false",
                     "ENABLE_PVLAN": "false",
                     "ENABLE_PVLAN_PREV": "false",
-                    "ENABLE_QKD": "",
-                    "ENABLE_RT_INTF_STATS": "false",
-                    "ENABLE_SGT": "false",
-                    "ENABLE_SGT_PREV": "false",
-                    "ENABLE_TENANT_DHCP": "true",
-                    "ENABLE_TRM": "false",
-                    "ENABLE_TRM_PREV": "false",
-                    "ENABLE_TRMv6": "false",
-                    "ENABLE_TRMv6_PREV": "false",
-                    "ENABLE_VPC_PEER_LINK_NATIVE_VLAN": "false",
-                    "ENABLE_VRI_ID_REALLOC": "false",
-                    "EXTRA_CONF_INTRA_LINKS": "",
-                    "EXTRA_CONF_LEAF": "",
-                    "EXTRA_CONF_SPINE": "",
-                    "EXTRA_CONF_TOR": "",
+                    "ENABLE_RS_REDIST_DIRECT": false,
+                    "ENABLE_SGT": "off",
+                    "ENABLE_SGT_PREV": "off",
+                    "ENABLE_TRM_TRMv6": "false",
+                    "ENABLE_TRM_TRMv6_PREV": "false",
                     "EXT_FABRIC_TYPE": "",
-                    "FABRIC_INTERFACE_TYPE": "p2p",
-                    "FABRIC_MTU": "9216",
-                    "FABRIC_MTU_PREV": "9216",
-                    "FABRIC_NAME": "child_fabric_cluster2",
-                    "FABRIC_TYPE": "Switch_Fabric",
-                    "FABRIC_VPC_DOMAIN_ID": "",
-                    "FABRIC_VPC_DOMAIN_ID_PREV": "",
-                    "FABRIC_VPC_QOS": "false",
-                    "FABRIC_VPC_QOS_POLICY_NAME": "spine_qos_for_fabric_vpc_peering",
-                    "FEATURE_PTP": "false",
-                    "FEATURE_PTP_INTERNAL": "false",
-                    "FF": "Easy_Fabric",
-                    "GRFIELD_DEBUG_FLAG": "Disable",
-                    "HD_TIME": "180",
-                    "HOST_INTF_ADMIN_STATE": "true",
-                    "IBGP_PEER_TEMPLATE": "",
-                    "IBGP_PEER_TEMPLATE_LEAF": "",
-                    "IGNORE_CERT": "",
-                    "INBAND_DHCP_SERVERS": "",
-                    "INBAND_MGMT": "false",
-                    "INBAND_MGMT_PREV": "false",
-                    "INTF_STAT_LOAD_INTERVAL": "",
-                    "IPv6_ANYCAST_RP_IP_RANGE": "",
-                    "IPv6_ANYCAST_RP_IP_RANGE_INTERNAL": "",
-                    "IPv6_DCI_SUBNET_RANGE": "fd00::a33:0/112",
-                    "IPv6_DCI_SUBNET_TARGET_MASK": "126",
-                    "IPv6_MULTICAST_GROUP_SUBNET": "",
-                    "ISIS_AREA_NUM": "0001",
-                    "ISIS_AREA_NUM_PREV": "",
-                    "ISIS_AUTH_ENABLE": "false",
-                    "ISIS_AUTH_KEY": "",
-                    "ISIS_AUTH_KEYCHAIN_KEY_ID": "",
-                    "ISIS_AUTH_KEYCHAIN_NAME": "",
-                    "ISIS_LEVEL": "level-2",
-                    "ISIS_OVERLOAD_ELAPSE_TIME": "",
-                    "ISIS_OVERLOAD_ENABLE": "",
-                    "ISIS_P2P_ENABLE": "",
-                    "KME_SERVER_IP": "",
-                    "KME_SERVER_PORT": "",
-                    "L2_HOST_INTF_MTU": "9216",
-                    "L2_HOST_INTF_MTU_PREV": "9216",
+                    "FABRIC_NAME": "MCFG_PARENT",
+                    "FABRIC_TYPE": "MFD",
+                    "FF": "MSD",
                     "L2_SEGMENT_ID_RANGE": "30000-49000",
-                    "L3VNI_IPv6_MCAST_GROUP": "",
-                    "L3VNI_MCAST_GROUP": "",
                     "L3_PARTITION_ID_RANGE": "50000-59000",
-                    "LINK_STATE_ROUTING": "ospf",
-                    "LINK_STATE_ROUTING_TAG": "UNDERLAY",
-                    "LINK_STATE_ROUTING_TAG_PREV": "UNDERLAY",
-                    "LOOPBACK0_IPV6_RANGE": "",
-                    "LOOPBACK0_IP_RANGE": "10.2.0.0/22",
-                    "LOOPBACK1_IPV6_RANGE": "",
-                    "LOOPBACK1_IP_RANGE": "10.3.0.0/22",
-                    "MACSEC_ALGORITHM": "",
-                    "MACSEC_CIPHER_SUITE": "",
-                    "MACSEC_FALLBACK_ALGORITHM": "",
-                    "MACSEC_FALLBACK_KEY_STRING": "",
-                    "MACSEC_KEY_STRING": "",
-                    "MACSEC_REPORT_TIMER": "",
-                    "MGMT_GW": "",
-                    "MGMT_GW_INTERNAL": "",
-                    "MGMT_PREFIX": "",
-                    "MGMT_PREFIX_INTERNAL": "",
-                    "MGMT_V6PREFIX": "",
-                    "MGMT_V6PREFIX_INTERNAL": "",
-                    "MPLS_HANDOFF": "false",
-                    "MPLS_ISIS_AREA_NUM": "0001",
-                    "MPLS_ISIS_AREA_NUM_PREV": "",
-                    "MPLS_LB_ID": "",
-                    "MPLS_LOOPBACK_IP_RANGE": "",
-                    "MSO_CONNECTIVITY_DEPLOYED": "",
+                    "LOOPBACK100_IPV6_RANGE": "fd00::a10:0/120",
+                    "LOOPBACK100_IP_RANGE": "10.10.0.0/24",
                     "MSO_CONTROLER_ID": "",
                     "MSO_SITE_GROUP_NAME": "",
-                    "MSO_SITE_ID": "",
-                    "MST_INSTANCE_RANGE": "",
-                    "MULTICAST_GROUP_SUBNET": "239.1.1.0/25",
-                    "MVPN_VRI_ID_RANGE": "",
-                    "NETFLOW_EXPORTER_LIST": "",
-                    "NETFLOW_MONITOR_LIST": "",
-                    "NETFLOW_RECORD_LIST": "",
-                    "NETWORK_VLAN_RANGE": "2300-2999",
-                    "NTP_SERVER_IP_LIST": "",
-                    "NTP_SERVER_VRF": "",
-                    "NVE_LB_ID": "1",
-                    "NXAPI_HTTPS_PORT": "443",
-                    "NXAPI_HTTP_PORT": "80",
-                    "NXC_DEST_VRF": "",
-                    "NXC_PROXY_PORT": "8080",
-                    "NXC_PROXY_SERVER": "",
-                    "NXC_SRC_INTF": "",
-                    "OBJECT_TRACKING_NUMBER_RANGE": "100-299",
-                    "OSPF_AREA_ID": "0.0.0.0",
-                    "OSPF_AUTH_ENABLE": "false",
-                    "OSPF_AUTH_KEY": "",
-                    "OSPF_AUTH_KEY_ID": "",
-                    "OVERLAY_MODE": "cli",
-                    "OVERLAY_MODE_PREV": "cli",
-                    "OVERWRITE_GLOBAL_NXC": "false",
-                    "PER_VRF_LOOPBACK_AUTO_PROVISION": "false",
-                    "PER_VRF_LOOPBACK_AUTO_PROVISION_PREV": "false",
-                    "PER_VRF_LOOPBACK_AUTO_PROVISION_V6": "false",
-                    "PER_VRF_LOOPBACK_AUTO_PROVISION_V6_PREV": "false",
-                    "PER_VRF_LOOPBACK_IP_RANGE": "",
-                    "PER_VRF_LOOPBACK_IP_RANGE_V6": "",
-                    "PFC_WATCH_INT": "",
-                    "PFC_WATCH_INT_PREV": "",
-                    "PHANTOM_RP_LB_ID1": "",
-                    "PHANTOM_RP_LB_ID2": "",
-                    "PHANTOM_RP_LB_ID3": "",
-                    "PHANTOM_RP_LB_ID4": "",
-                    "PIM_HELLO_AUTH_ENABLE": "false",
-                    "PIM_HELLO_AUTH_KEY": "",
-                    "PM_ENABLE": "false",
-                    "PM_ENABLE_PREV": "false",
-                    "PNP_ENABLE_INTERNAL": "",
-                    "POWER_REDUNDANCY_MODE": "ps-redundant",
+                    "MS_IFC_BGP_AUTH_KEY_TYPE": "",
+                    "MS_IFC_BGP_AUTH_KEY_TYPE_PREV": "",
+                    "MS_IFC_BGP_PASSWORD": "",
+                    "MS_IFC_BGP_PASSWORD_ENABLE": "false",
+                    "MS_IFC_BGP_PASSWORD_ENABLE_PREV": "false",
+                    "MS_IFC_BGP_PASSWORD_PREV": "",
+                    "MS_LOOPBACK_ID": "100",
+                    "MS_UNDERLAY_AUTOCONFIG": "false",
+                    "PARENT_ONEMANAGE_FABRIC": "",
                     "PREMSO_PARENT_FABRIC": "",
-                    "PTP_DOMAIN_ID": "",
-                    "PTP_LB_ID": "",
-                    "PTP_VLAN_ID": "",
-                    "QKD_PROFILE_NAME": "",
-                    "QKD_PROFILE_NAME_PREV": "",
-                    "REPLICATION_MODE": "Multicast",
-                    "ROUTER_ID_RANGE": "",
-                    "ROUTE_MAP_SEQUENCE_NUMBER_RANGE": "1-65534",
-                    "RP_COUNT": "2",
-                    "RP_LB_ID": "254",
-                    "RP_MODE": "asm",
-                    "RR_COUNT": "2",
-                    "SEED_SWITCH_CORE_INTERFACES": "",
-                    "SERVICE_NETWORK_VLAN_RANGE": "3000-3199",
+                    "RP_SERVER_IP": "",
+                    "RS_ROUTING_TAG": "",
                     "SGT_ID_RANGE": "",
+                    "SGT_ID_RANGE_PREV": "",
                     "SGT_NAME_PREFIX": "",
+                    "SGT_NAME_PREFIX_PREV": "",
                     "SGT_OPER_STATUS": "off",
-                    "SGT_PREPROVISION": "",
-                    "SGT_PREPROVISION_PREV": "",
+                    "SGT_PREPROVISION": false,
+                    "SGT_PREPROVISION_PREV": false,
                     "SGT_PREPROV_RECALC_STATUS": "empty",
                     "SGT_RECALC_STATUS": "empty",
-                    "SITE_ID": "88",
-                    "SITE_ID_POLICY_ID": "",
-                    "SLA_ID_RANGE": "10000-19999",
-                    "SNMP_SERVER_HOST_TRAP": "true",
-                    "SPINE_COUNT": "2",
-                    "SPINE_SWITCH_CORE_INTERFACES": "",
-                    "SSPINE_ADD_DEL_DEBUG_FLAG": "Disable",
-                    "SSPINE_COUNT": "0",
-                    "STATIC_UNDERLAY_IP_ALLOC": "false",
-                    "STP_BRIDGE_PRIORITY": "",
-                    "STP_ROOT_OPTION": "unmanaged",
-                    "STP_VLAN_RANGE": "",
-                    "STRICT_CC_MODE": "false",
-                    "SUBINTERFACE_RANGE": "2-511",
-                    "SUBNET_RANGE": "10.4.0.0/16",
-                    "SUBNET_TARGET_MASK": "30",
-                    "SYSLOG_SERVER_IP_LIST": "",
-                    "SYSLOG_SERVER_VRF": "",
-                    "SYSLOG_SEV": "",
-                    "TCAM_ALLOCATION": "true",
-                    "TOPDOWN_CONFIG_RM_TRACKING": "notstarted",
-                    "TRUSTPOINT_LABEL": "",
-                    "UNDERLAY_IS_V6": "false",
-                    "UNDERLAY_IS_V6_PREV": "false",
-                    "UNNUM_BOOTSTRAP_LB_ID": "",
-                    "UNNUM_DHCP_END": "",
-                    "UNNUM_DHCP_END_INTERNAL": "",
-                    "UNNUM_DHCP_START": "",
-                    "UNNUM_DHCP_START_INTERNAL": "",
-                    "UPGRADE_FROM_VERSION": "",
-                    "USE_LINK_LOCAL": "true",
-                    "V6_SUBNET_RANGE": "",
-                    "V6_SUBNET_TARGET_MASK": "126",
-                    "VPC_AUTO_RECOVERY_TIME": "360",
-                    "VPC_DELAY_RESTORE": "150",
-                    "VPC_DELAY_RESTORE_TIME": "60",
-                    "VPC_DOMAIN_ID_RANGE": "1-1000",
-                    "VPC_ENABLE_IPv6_ND_SYNC": "true",
-                    "VPC_LAYER3_PEER_ROUTER": "true",
-                    "VPC_PEER_KEEP_ALIVE_OPTION": "management",
-                    "VPC_PEER_LINK_PO": "500",
-                    "VPC_PEER_LINK_VLAN": "3600",
-                    "VRF_LITE_AUTOCONFIG": "Manual",
-                    "VRF_VLAN_RANGE": "2000-2299",
-                    "abstract_anycast_rp": "anycast_rp",
-                    "abstract_bgp": "base_bgp",
-                    "abstract_bgp_neighbor": "evpn_bgp_rr_neighbor",
-                    "abstract_bgp_rr": "evpn_bgp_rr",
-                    "abstract_dhcp": "base_dhcp",
-                    "abstract_extra_config_bootstrap": "extra_config_bootstrap_11_1",
-                    "abstract_extra_config_leaf": "extra_config_leaf",
-                    "abstract_extra_config_spine": "extra_config_spine",
-                    "abstract_extra_config_tor": "extra_config_tor",
-                    "abstract_feature_leaf": "base_feature_leaf_upg",
-                    "abstract_feature_spine": "base_feature_spine_upg",
-                    "abstract_isis": "base_isis_level2",
-                    "abstract_isis_interface": "isis_interface",
-                    "abstract_loopback_interface": "int_fabric_loopback_11_1",
-                    "abstract_multicast": "base_multicast_11_1",
-                    "abstract_ospf": "base_ospf",
-                    "abstract_ospf_interface": "ospf_interface_11_1",
-                    "abstract_pim_interface": "pim_interface",
-                    "abstract_route_map": "route_map",
-                    "abstract_routed_host": "int_routed_host",
-                    "abstract_trunk_host": "int_trunk_host",
-                    "abstract_vlan_interface": "int_fabric_vlan_11_1",
-                    "abstract_vpc_domain": "base_vpc_domain_11_1",
-                    "allowVlanOnLeafTorPairing": "none",
-                    "autoGenerateMulticastGroupAddress": "false",
-                    "bootstrapSubnetCollection": "{\"bootstrapSubnetCollection\":[]}",
-                    "dcnmUser": "admin",
+                    "V6_DCI_SUBNET_RANGE": "fd00::a11:0/120",
+                    "V6_DCI_SUBNET_TARGET_MASK": "126",
+                    "VXLAN_UNDERLAY_IS_V6": "false",
                     "default_network": "Default_Network_Universal",
-                    "default_pvlan_sec_network": "",
+                    "default_pvlan_sec_network": "Pvlan_Secondary_Network",
                     "default_vrf": "Default_VRF_Universal",
-                    "enableMvpnVriId": "",
-                    "enableMvpnVriIdPrev": "",
-                    "enableRealTimeBackup": "",
+                    "enableMsOverlayIfcBgpDesc": false,
                     "enableScheduledBackup": "",
-                    "heartbeatInterval": "190",
                     "network_extension_template": "Default_Network_Extension_Universal",
-                    "ngoamSouthBoundLoopDetect": "false",
-                    "ngoamSouthBoundLoopDetectProbeInterval": "",
-                    "ngoamSouthBoundLoopDetectRecoveryInterval": "",
-                    "ngoamSouthBoundLoopDetect_PREV": "false",
-                    "preInterfaceConfigLeaf": "",
-                    "preInterfaceConfigSpine": "",
-                    "preInterfaceConfigTor": "",
+                    "routeServerCollection": "{\"routeServerCollection\":[]}",
                     "scheduledTime": "",
                     "securityGroupStatus": "disabled",
-                    "temp_anycast_gateway": "anycast_gateway",
-                    "temp_vpc_domain_mgmt": "vpc_domain_mgmt",
-                    "temp_vpc_peer_link": "int_vpc_peer_link_po",
-                    "underlayMulticastGroupAddressLimit": "128",
-                    "unifiedNDFabricType": "vxlanIbgp",
-                    "vpcTorDelayRestoreTimer": "30",
+                    "unifiedNDFabricType": "vxlan",
                     "vrf_extension_template": "Default_VRF_Extension_Universal"
-                }
+                },
+                "vrfTemplate": "Default_VRF_Universal",
+                "networkTemplate": "Default_Network_Universal",
+                "vrfExtensionTemplate": "Default_VRF_Extension_Universal",
+                "networkExtensionTemplate": "Default_Network_Extension_Universal",
+                "createdOn": 1761942870,
+                "modifiedOn": 1761942870,
+                "members": [
+                    {
+                        "clusterName": "ND41-CL1",
+                        "fabricId": 2010,
+                        "fabricName": "child_fabric",
+                        "templateName": "Easy_Fabric",
+                        "fabricType": "Switch_Fabric",
+                        "fabricState": "member",
+                        "fabricParent": "parent_fabric",
+                        "fabricTechnology": "VXLANFabric",
+                        "fabricTypeFriendly": "Data Center VXLAN EVPN",
+                        "fabricTechnologyFriendly": "VXLAN EVPN",
+                        "asn": "88",
+                        "ndfcIpAddress": "10.122.84.116",
+                        "clusterIpAddresses": [
+                            "10.122.84.116"
+                        ],
+                        "operStatus": "MINOR",
+                        "nvPairs": {
+                            "AAA_REMOTE_IP_ENABLED": "false",
+                            "AAA_SERVER_CONF": "",
+                            "ACTIVE_MIGRATION": "false",
+                            "ADVERTISE_PIP_BGP": "false",
+                            "ADVERTISE_PIP_ON_BORDER": "true",
+                            "AGENT_INTF": "eth0",
+                            "AGG_ACC_VPC_PO_ID_RANGE": "",
+                            "AI_ML_QOS_POLICY": "AI_Fabric_QOS_400G",
+                            "AI_QOS_400G_MIN_BW": "950",
+                            "ALLOW_NXC": "true",
+                            "ALLOW_NXC_PREV": "true",
+                            "ANYCAST_BGW_ADVERTISE_PIP": "false",
+                            "ANYCAST_GW_MAC": "2020.0000.00aa",
+                            "ANYCAST_LB_ID": "",
+                            "ANYCAST_RP_IP_RANGE": "10.254.254.0/24",
+                            "ANYCAST_RP_IP_RANGE_INTERNAL": "10.254.254.0/24",
+                            "AUTO_BGP_NEIGHBOR_DESC": "true",
+                            "AUTO_SYMMETRIC_DEFAULT_VRF": "false",
+                            "AUTO_SYMMETRIC_VRF_LITE": "false",
+                            "AUTO_UNIQUE_VRF_LITE_IP_PREFIX": "false",
+                            "AUTO_UNIQUE_VRF_LITE_IP_PREFIX_PREV": "false",
+                            "AUTO_VRFLITE_IFC_DEFAULT_VRF": "false",
+                            "BANNER": "",
+                            "BFD_AUTH_ENABLE": "false",
+                            "BFD_AUTH_KEY": "",
+                            "BFD_AUTH_KEY_ID": "",
+                            "BFD_ENABLE": "false",
+                            "BFD_ENABLE_PREV": "false",
+                            "BFD_IBGP_ENABLE": "false",
+                            "BFD_ISIS_ENABLE": "false",
+                            "BFD_OSPF_ENABLE": "false",
+                            "BFD_PIM_ENABLE": "false",
+                            "BGP_AS": "88",
+                            "BGP_AS_PREV": "88",
+                            "BGP_AUTH_ENABLE": "false",
+                            "BGP_AUTH_KEY": "",
+                            "BGP_AUTH_KEY_TYPE": "3",
+                            "BGP_LB_ID": "0",
+                            "BOOTSTRAP_CONF": "",
+                            "BOOTSTRAP_ENABLE": "false",
+                            "BOOTSTRAP_ENABLE_PREV": "false",
+                            "BOOTSTRAP_MULTISUBNET": "#Scope_Start_IP, Scope_End_IP, Scope_Default_Gateway, Scope_Subnet_Prefix",
+                            "BOOTSTRAP_MULTISUBNET_INTERNAL": "",
+                            "BRFIELD_DEBUG_FLAG": "Disable",
+                            "BROWNFIELD_NETWORK_NAME_FORMAT": "Auto_Net_VNI$$VNI$$_VLAN$$VLAN_ID$$",
+                            "BROWNFIELD_SKIP_OVERLAY_NETWORK_ATTACHMENTS": "false",
+                            "CDP_ENABLE": "false",
+                            "COPP_POLICY": "strict",
+                            "DCI_MACSEC_ALGORITHM": "",
+                            "DCI_MACSEC_CIPHER_SUITE": "",
+                            "DCI_MACSEC_FALLBACK_ALGORITHM": "",
+                            "DCI_MACSEC_FALLBACK_KEY_STRING": "",
+                            "DCI_MACSEC_KEY_STRING": "",
+                            "DCI_SUBNET_RANGE": "10.33.0.0/16",
+                            "DCI_SUBNET_TARGET_MASK": "30",
+                            "DEAFULT_QUEUING_POLICY_CLOUDSCALE": "queuing_policy_default_8q_cloudscale",
+                            "DEAFULT_QUEUING_POLICY_OTHER": "queuing_policy_default_other",
+                            "DEAFULT_QUEUING_POLICY_R_SERIES": "queuing_policy_default_r_series",
+                            "DEFAULT_VRF_REDIS_BGP_RMAP": "",
+                            "DEPLOYMENT_FREEZE": "false",
+                            "DHCP_ENABLE": "false",
+                            "DHCP_END": "",
+                            "DHCP_END_INTERNAL": "",
+                            "DHCP_IPV6_ENABLE": "",
+                            "DHCP_IPV6_ENABLE_INTERNAL": "",
+                            "DHCP_START": "",
+                            "DHCP_START_INTERNAL": "",
+                            "DNS_SERVER_IP_LIST": "",
+                            "DNS_SERVER_VRF": "",
+                            "DOMAIN_NAME_INTERNAL": "",
+                            "ENABLE_AAA": "false",
+                            "ENABLE_AGENT": "false",
+                            "ENABLE_AGG_ACC_ID_RANGE": "false",
+                            "ENABLE_AI_ML_QOS_POLICY": "false",
+                            "ENABLE_AI_ML_QOS_POLICY_FLAP": "false",
+                            "ENABLE_DCI_MACSEC": "false",
+                            "ENABLE_DCI_MACSEC_PREV": "false",
+                            "ENABLE_DEFAULT_QUEUING_POLICY": "false",
+                            "ENABLE_EVPN": "true",
+                            "ENABLE_FABRIC_VPC_DOMAIN_ID": "false",
+                            "ENABLE_FABRIC_VPC_DOMAIN_ID_PREV": "false",
+                            "ENABLE_L3VNI_NO_VLAN": "false",
+                            "ENABLE_MACSEC": "false",
+                            "ENABLE_MACSEC_PREV": "false",
+                            "ENABLE_NETFLOW": "false",
+                            "ENABLE_NETFLOW_PREV": "false",
+                            "ENABLE_NGOAM": "true",
+                            "ENABLE_NXAPI": "true",
+                            "ENABLE_NXAPI_HTTP": "true",
+                            "ENABLE_PBR": "false",
+                            "ENABLE_PVLAN": "false",
+                            "ENABLE_PVLAN_PREV": "false",
+                            "ENABLE_QKD": "",
+                            "ENABLE_RT_INTF_STATS": "false",
+                            "ENABLE_SGT": "false",
+                            "ENABLE_SGT_PREV": "false",
+                            "ENABLE_TENANT_DHCP": "true",
+                            "ENABLE_TRM": "false",
+                            "ENABLE_TRM_PREV": "false",
+                            "ENABLE_TRMv6": "false",
+                            "ENABLE_TRMv6_PREV": "false",
+                            "ENABLE_VPC_PEER_LINK_NATIVE_VLAN": "false",
+                            "ENABLE_VRI_ID_REALLOC": "false",
+                            "EXTRA_CONF_INTRA_LINKS": "",
+                            "EXTRA_CONF_LEAF": "",
+                            "EXTRA_CONF_SPINE": "",
+                            "EXTRA_CONF_TOR": "",
+                            "EXT_FABRIC_TYPE": "",
+                            "FABRIC_INTERFACE_TYPE": "p2p",
+                            "FABRIC_MTU": "9216",
+                            "FABRIC_MTU_PREV": "9216",
+                            "FABRIC_NAME": "child_fabric_cluster2",
+                            "FABRIC_TYPE": "Switch_Fabric",
+                            "FABRIC_VPC_DOMAIN_ID": "",
+                            "FABRIC_VPC_DOMAIN_ID_PREV": "",
+                            "FABRIC_VPC_QOS": "false",
+                            "FABRIC_VPC_QOS_POLICY_NAME": "spine_qos_for_fabric_vpc_peering",
+                            "FEATURE_PTP": "false",
+                            "FEATURE_PTP_INTERNAL": "false",
+                            "FF": "Easy_Fabric",
+                            "GRFIELD_DEBUG_FLAG": "Disable",
+                            "HD_TIME": "180",
+                            "HOST_INTF_ADMIN_STATE": "true",
+                            "IBGP_PEER_TEMPLATE": "",
+                            "IBGP_PEER_TEMPLATE_LEAF": "",
+                            "IGNORE_CERT": "",
+                            "INBAND_DHCP_SERVERS": "",
+                            "INBAND_MGMT": "false",
+                            "INBAND_MGMT_PREV": "false",
+                            "INTF_STAT_LOAD_INTERVAL": "",
+                            "IPv6_ANYCAST_RP_IP_RANGE": "",
+                            "IPv6_ANYCAST_RP_IP_RANGE_INTERNAL": "",
+                            "IPv6_DCI_SUBNET_RANGE": "fd00::a33:0/112",
+                            "IPv6_DCI_SUBNET_TARGET_MASK": "126",
+                            "IPv6_MULTICAST_GROUP_SUBNET": "",
+                            "ISIS_AREA_NUM": "0001",
+                            "ISIS_AREA_NUM_PREV": "",
+                            "ISIS_AUTH_ENABLE": "false",
+                            "ISIS_AUTH_KEY": "",
+                            "ISIS_AUTH_KEYCHAIN_KEY_ID": "",
+                            "ISIS_AUTH_KEYCHAIN_NAME": "",
+                            "ISIS_LEVEL": "level-2",
+                            "ISIS_OVERLOAD_ELAPSE_TIME": "",
+                            "ISIS_OVERLOAD_ENABLE": "",
+                            "ISIS_P2P_ENABLE": "",
+                            "KME_SERVER_IP": "",
+                            "KME_SERVER_PORT": "",
+                            "L2_HOST_INTF_MTU": "9216",
+                            "L2_HOST_INTF_MTU_PREV": "9216",
+                            "L2_SEGMENT_ID_RANGE": "30000-49000",
+                            "L3VNI_IPv6_MCAST_GROUP": "",
+                            "L3VNI_MCAST_GROUP": "",
+                            "L3_PARTITION_ID_RANGE": "50000-59000",
+                            "LINK_STATE_ROUTING": "ospf",
+                            "LINK_STATE_ROUTING_TAG": "UNDERLAY",
+                            "LINK_STATE_ROUTING_TAG_PREV": "UNDERLAY",
+                            "LOOPBACK0_IPV6_RANGE": "",
+                            "LOOPBACK0_IP_RANGE": "10.2.0.0/22",
+                            "LOOPBACK1_IPV6_RANGE": "",
+                            "LOOPBACK1_IP_RANGE": "10.3.0.0/22",
+                            "MACSEC_ALGORITHM": "",
+                            "MACSEC_CIPHER_SUITE": "",
+                            "MACSEC_FALLBACK_ALGORITHM": "",
+                            "MACSEC_FALLBACK_KEY_STRING": "",
+                            "MACSEC_KEY_STRING": "",
+                            "MACSEC_REPORT_TIMER": "",
+                            "MGMT_GW": "",
+                            "MGMT_GW_INTERNAL": "",
+                            "MGMT_PREFIX": "",
+                            "MGMT_PREFIX_INTERNAL": "",
+                            "MGMT_V6PREFIX": "",
+                            "MGMT_V6PREFIX_INTERNAL": "",
+                            "MPLS_HANDOFF": "false",
+                            "MPLS_ISIS_AREA_NUM": "0001",
+                            "MPLS_ISIS_AREA_NUM_PREV": "",
+                            "MPLS_LB_ID": "",
+                            "MPLS_LOOPBACK_IP_RANGE": "",
+                            "MSO_CONNECTIVITY_DEPLOYED": "",
+                            "MSO_CONTROLER_ID": "",
+                            "MSO_SITE_GROUP_NAME": "",
+                            "MSO_SITE_ID": "",
+                            "MST_INSTANCE_RANGE": "",
+                            "MULTICAST_GROUP_SUBNET": "239.1.1.0/25",
+                            "MVPN_VRI_ID_RANGE": "",
+                            "NETFLOW_EXPORTER_LIST": "",
+                            "NETFLOW_MONITOR_LIST": "",
+                            "NETFLOW_RECORD_LIST": "",
+                            "NETWORK_VLAN_RANGE": "2300-2999",
+                            "NTP_SERVER_IP_LIST": "",
+                            "NTP_SERVER_VRF": "",
+                            "NVE_LB_ID": "1",
+                            "NXAPI_HTTPS_PORT": "443",
+                            "NXAPI_HTTP_PORT": "80",
+                            "NXC_DEST_VRF": "",
+                            "NXC_PROXY_PORT": "8080",
+                            "NXC_PROXY_SERVER": "",
+                            "NXC_SRC_INTF": "",
+                            "OBJECT_TRACKING_NUMBER_RANGE": "100-299",
+                            "OSPF_AREA_ID": "0.0.0.0",
+                            "OSPF_AUTH_ENABLE": "false",
+                            "OSPF_AUTH_KEY": "",
+                            "OSPF_AUTH_KEY_ID": "",
+                            "OVERLAY_MODE": "cli",
+                            "OVERLAY_MODE_PREV": "cli",
+                            "OVERWRITE_GLOBAL_NXC": "false",
+                            "PER_VRF_LOOPBACK_AUTO_PROVISION": "false",
+                            "PER_VRF_LOOPBACK_AUTO_PROVISION_PREV": "false",
+                            "PER_VRF_LOOPBACK_AUTO_PROVISION_V6": "false",
+                            "PER_VRF_LOOPBACK_AUTO_PROVISION_V6_PREV": "false",
+                            "PER_VRF_LOOPBACK_IP_RANGE": "",
+                            "PER_VRF_LOOPBACK_IP_RANGE_V6": "",
+                            "PFC_WATCH_INT": "",
+                            "PFC_WATCH_INT_PREV": "",
+                            "PHANTOM_RP_LB_ID1": "",
+                            "PHANTOM_RP_LB_ID2": "",
+                            "PHANTOM_RP_LB_ID3": "",
+                            "PHANTOM_RP_LB_ID4": "",
+                            "PIM_HELLO_AUTH_ENABLE": "false",
+                            "PIM_HELLO_AUTH_KEY": "",
+                            "PM_ENABLE": "false",
+                            "PM_ENABLE_PREV": "false",
+                            "PNP_ENABLE_INTERNAL": "",
+                            "POWER_REDUNDANCY_MODE": "ps-redundant",
+                            "PREMSO_PARENT_FABRIC": "",
+                            "PTP_DOMAIN_ID": "",
+                            "PTP_LB_ID": "",
+                            "PTP_VLAN_ID": "",
+                            "QKD_PROFILE_NAME": "",
+                            "QKD_PROFILE_NAME_PREV": "",
+                            "REPLICATION_MODE": "Multicast",
+                            "ROUTER_ID_RANGE": "",
+                            "ROUTE_MAP_SEQUENCE_NUMBER_RANGE": "1-65534",
+                            "RP_COUNT": "2",
+                            "RP_LB_ID": "254",
+                            "RP_MODE": "asm",
+                            "RR_COUNT": "2",
+                            "SEED_SWITCH_CORE_INTERFACES": "",
+                            "SERVICE_NETWORK_VLAN_RANGE": "3000-3199",
+                            "SGT_ID_RANGE": "",
+                            "SGT_NAME_PREFIX": "",
+                            "SGT_OPER_STATUS": "off",
+                            "SGT_PREPROVISION": "",
+                            "SGT_PREPROVISION_PREV": "",
+                            "SGT_PREPROV_RECALC_STATUS": "empty",
+                            "SGT_RECALC_STATUS": "empty",
+                            "SITE_ID": "88",
+                            "SITE_ID_POLICY_ID": "",
+                            "SLA_ID_RANGE": "10000-19999",
+                            "SNMP_SERVER_HOST_TRAP": "true",
+                            "SPINE_COUNT": "2",
+                            "SPINE_SWITCH_CORE_INTERFACES": "",
+                            "SSPINE_ADD_DEL_DEBUG_FLAG": "Disable",
+                            "SSPINE_COUNT": "0",
+                            "STATIC_UNDERLAY_IP_ALLOC": "false",
+                            "STP_BRIDGE_PRIORITY": "",
+                            "STP_ROOT_OPTION": "unmanaged",
+                            "STP_VLAN_RANGE": "",
+                            "STRICT_CC_MODE": "false",
+                            "SUBINTERFACE_RANGE": "2-511",
+                            "SUBNET_RANGE": "10.4.0.0/16",
+                            "SUBNET_TARGET_MASK": "30",
+                            "SYSLOG_SERVER_IP_LIST": "",
+                            "SYSLOG_SERVER_VRF": "",
+                            "SYSLOG_SEV": "",
+                            "TCAM_ALLOCATION": "true",
+                            "TOPDOWN_CONFIG_RM_TRACKING": "notstarted",
+                            "TRUSTPOINT_LABEL": "",
+                            "UNDERLAY_IS_V6": "false",
+                            "UNDERLAY_IS_V6_PREV": "false",
+                            "UNNUM_BOOTSTRAP_LB_ID": "",
+                            "UNNUM_DHCP_END": "",
+                            "UNNUM_DHCP_END_INTERNAL": "",
+                            "UNNUM_DHCP_START": "",
+                            "UNNUM_DHCP_START_INTERNAL": "",
+                            "UPGRADE_FROM_VERSION": "",
+                            "USE_LINK_LOCAL": "true",
+                            "V6_SUBNET_RANGE": "",
+                            "V6_SUBNET_TARGET_MASK": "126",
+                            "VPC_AUTO_RECOVERY_TIME": "360",
+                            "VPC_DELAY_RESTORE": "150",
+                            "VPC_DELAY_RESTORE_TIME": "60",
+                            "VPC_DOMAIN_ID_RANGE": "1-1000",
+                            "VPC_ENABLE_IPv6_ND_SYNC": "true",
+                            "VPC_LAYER3_PEER_ROUTER": "true",
+                            "VPC_PEER_KEEP_ALIVE_OPTION": "management",
+                            "VPC_PEER_LINK_PO": "500",
+                            "VPC_PEER_LINK_VLAN": "3600",
+                            "VRF_LITE_AUTOCONFIG": "Manual",
+                            "VRF_VLAN_RANGE": "2000-2299",
+                            "abstract_anycast_rp": "anycast_rp",
+                            "abstract_bgp": "base_bgp",
+                            "abstract_bgp_neighbor": "evpn_bgp_rr_neighbor",
+                            "abstract_bgp_rr": "evpn_bgp_rr",
+                            "abstract_dhcp": "base_dhcp",
+                            "abstract_extra_config_bootstrap": "extra_config_bootstrap_11_1",
+                            "abstract_extra_config_leaf": "extra_config_leaf",
+                            "abstract_extra_config_spine": "extra_config_spine",
+                            "abstract_extra_config_tor": "extra_config_tor",
+                            "abstract_feature_leaf": "base_feature_leaf_upg",
+                            "abstract_feature_spine": "base_feature_spine_upg",
+                            "abstract_isis": "base_isis_level2",
+                            "abstract_isis_interface": "isis_interface",
+                            "abstract_loopback_interface": "int_fabric_loopback_11_1",
+                            "abstract_multicast": "base_multicast_11_1",
+                            "abstract_ospf": "base_ospf",
+                            "abstract_ospf_interface": "ospf_interface_11_1",
+                            "abstract_pim_interface": "pim_interface",
+                            "abstract_route_map": "route_map",
+                            "abstract_routed_host": "int_routed_host",
+                            "abstract_trunk_host": "int_trunk_host",
+                            "abstract_vlan_interface": "int_fabric_vlan_11_1",
+                            "abstract_vpc_domain": "base_vpc_domain_11_1",
+                            "allowVlanOnLeafTorPairing": "none",
+                            "autoGenerateMulticastGroupAddress": "false",
+                            "bootstrapSubnetCollection": "{\"bootstrapSubnetCollection\":[]}",
+                            "dcnmUser": "admin",
+                            "default_network": "Default_Network_Universal",
+                            "default_pvlan_sec_network": "",
+                            "default_vrf": "Default_VRF_Universal",
+                            "enableMvpnVriId": "",
+                            "enableMvpnVriIdPrev": "",
+                            "enableRealTimeBackup": "",
+                            "enableScheduledBackup": "",
+                            "heartbeatInterval": "190",
+                            "network_extension_template": "Default_Network_Extension_Universal",
+                            "ngoamSouthBoundLoopDetect": "false",
+                            "ngoamSouthBoundLoopDetectProbeInterval": "",
+                            "ngoamSouthBoundLoopDetectRecoveryInterval": "",
+                            "ngoamSouthBoundLoopDetect_PREV": "false",
+                            "preInterfaceConfigLeaf": "",
+                            "preInterfaceConfigSpine": "",
+                            "preInterfaceConfigTor": "",
+                            "scheduledTime": "",
+                            "securityGroupStatus": "disabled",
+                            "temp_anycast_gateway": "anycast_gateway",
+                            "temp_vpc_domain_mgmt": "vpc_domain_mgmt",
+                            "temp_vpc_peer_link": "int_vpc_peer_link_po",
+                            "underlayMulticastGroupAddressLimit": "128",
+                            "unifiedNDFabricType": "vxlanIbgp",
+                            "vpcTorDelayRestoreTimer": "30",
+                            "vrf_extension_template": "Default_VRF_Extension_Universal"
+                        }
+                    }
+                ],
+                "consistencyStatus": "unknown"
             }
-        ],
-        "consistencyStatus": "unknown"
+        ]
+    },
+    "mock_vrf_attach_get_ext_object_combined_sn1_sn2": {
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200,
+        "DATA": [
+            {
+                "switchDetailsList": [
+                    {
+                        "errorMessage": null,
+                        "extensionPrototypeValues": [],
+                        "extensionValues": "",
+                        "freeformConfig": "",
+                        "instanceValues": "",
+                        "islanAttached": true,
+                        "lanAttachedState": "DEPLOYED",
+                        "peerSerialNumber": null,
+                        "role": "leaf",
+                        "serialNumber": "XYZKSJHSMK1",
+                        "switchName": "n9kv_leaf1",
+                        "vlan": "202",
+                        "vlanModifiable": true
+                    },
+                    {
+                        "errorMessage": null,
+                        "extensionPrototypeValues": [],
+                        "extensionValues": "",
+                        "freeformConfig": "",
+                        "instanceValues": "",
+                        "islanAttached": true,
+                        "lanAttachedState": "DEPLOYED",
+                        "peerSerialNumber": null,
+                        "role": "leaf",
+                        "serialNumber": "XYZKSJHSMK2",
+                        "switchName": "n9kv_leaf2",
+                        "vlan": "202",
+                        "vlanModifiable": true
+                    }
+                ],
+                "templateName": "Default_VRF_Universal",
+                "vrfName": "test_vrf_1"
+            }
+        ]
+    },
+    "mock_vrf_attach_get_ext_object_combined_sn1_sn4": {
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200,
+        "DATA": [
+            {
+                "switchDetailsList": [
+                    {
+                        "errorMessage": null,
+                        "extensionPrototypeValues": [],
+                        "extensionValues": "",
+                        "freeformConfig": "",
+                        "instanceValues": "",
+                        "islanAttached": true,
+                        "lanAttachedState": "DEPLOYED",
+                        "peerSerialNumber": null,
+                        "role": "leaf",
+                        "serialNumber": "XYZKSJHSMK1",
+                        "switchName": "n9kv_leaf1",
+                        "vlan": "202",
+                        "vlanModifiable": true
+                    },
+                    {
+                        "errorMessage": null,
+                        "extensionPrototypeValues": [
+                            {
+                                "destInterfaceName": "Ethernet1/16",
+                                "destSwitchName": "dt-n9k2-1",
+                                "extensionType": "VRF_LITE",
+                                "extensionValues": "{\"PEER_VRF_NAME\": \"\", \"NEIGHBOR_IP\": \"10.33.0.1\", \"VRF_LITE_JYTHON_TEMPLATE\": \"Ext_VRF_Lite_Jython\", \"enableBorderExtension\": \"VRF_LITE\", \"AUTO_VRF_LITE_FLAG\": \"false\", \"IP_MASK\": \"10.33.0.2/30\", \"MTU\": \"9216\", \"NEIGHBOR_ASN\": \"65535\", \"IF_NAME\": \"Ethernet1/16\", \"IPV6_NEIGHBOR\": \"\", \"IPV6_MASK\": \"\", \"DOT1Q_ID\": \"3\", \"asn\": \"65535\"}",
+                                "interfaceName": "Ethernet1/16"
+                            }
+                        ],
+                        "extensionValues": "{\"VRF_LITE_CONN\":\"{\\\"VRF_LITE_CONN\\\":[{\\\"IF_NAME\\\":\\\"Ethernet1/16\\\",\\\"DOT1Q_ID\\\":\\\"2\\\",\\\"IP_MASK\\\":\\\"10.33.0.2/30\\\",\\\"NEIGHBOR_IP\\\":\\\"10.33.0.1\\\",\\\"NEIGHBOR_ASN\\\":\\\"65535\\\",\\\"IPV6_MASK\\\":\\\"2010::10:34:0:7/64\\\",\\\"IPV6_NEIGHBOR\\\":\\\"2010::10:34:0:3\\\",\\\"AUTO_VRF_LITE_FLAG\\\":\\\"false\\\",\\\"PEER_VRF_NAME\\\":\\\"test_vrf_1\\\",\\\"VRF_LITE_JYTHON_TEMPLATE\\\":\\\"Ext_VRF_Lite_Jython\\\"}]}\",\"MULTISITE_CONN\":\"{\\\"MULTISITE_CONN\\\":[]}\"}",
+                        "freeformConfig": "",
+                        "instanceValues": "{\"loopbackId\":\"\",\"loopbackIpAddress\":\"\",\"loopbackIpV6Address\":\"\"}",
+                        "islanAttached": true,
+                        "lanAttachedState": "DEPLOYED",
+                        "peerSerialNumber": null,
+                        "role": "border",
+                        "serialNumber": "XYZKSJHSMK4",
+                        "switchName": "n9kv_leaf4",
+                        "vlan": 202,
+                        "vlanModifiable": true
+                    }
+                ],
+                "templateName": "Default_VRF_Universal",
+                "vrfName": "test_vrf_1"
+            }
+        ]
     }
-   ]
-  }
 }

--- a/tests/unit/modules/dcnm/test_dcnm_intf.py
+++ b/tests/unit/modules/dcnm/test_dcnm_intf.py
@@ -364,7 +364,7 @@ class TestDcnmIntfModule(TestDcnmModule):
             ]
 
         if "_multi_intf_merged_exist" in self._testMethodName:
-            # No I/F exists case
+            # Interfaces exist case
             playbook_pc_intf = self.payloads_data.get("pc_payload")
             playbook_lo_intf = self.payloads_data.get("lo_payload")
             playbook_eth_intf = self.payloads_data.get("eth_payload")
@@ -377,15 +377,33 @@ class TestDcnmIntfModule(TestDcnmModule):
                 "deployed_payloads"
             )
 
+            # Bulk IF_WITH_SNO response for SAL1819SAN8 (PC, subint, lo, eth)
+            multi_bulk_sal = {
+                "MESSAGE": "OK",
+                "RETURN_CODE": 200,
+                "DATA": [
+                    playbook_pc_intf["DATA"][0],
+                    playbook_subint_intf["DATA"][0],
+                    playbook_lo_intf["DATA"][0],
+                    playbook_eth_intf["DATA"][0],
+                ],
+            }
+            # Bulk IF_WITH_SNO response for FOX1821H035 (VPC)
+            multi_bulk_fox = {
+                "MESSAGE": "OK",
+                "RETURN_CODE": 200,
+                "DATA": [
+                    playbook_vpc_intf["DATA"][0],
+                ],
+            }
+
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
                 self.playbook_mock_vpc_resp,
                 self.playbook_mock_vpc_resp,
-                playbook_pc_intf,
-                playbook_vpc_intf,
-                playbook_subint_intf,
-                playbook_lo_intf,
-                playbook_eth_intf,
+                multi_bulk_sal,                      # IF_WITH_SNO bulk prefetch for SAL1819SAN8
+                multi_bulk_fox,                      # IF_WITH_SNO bulk prefetch for FOX1821H035
+                # Individual GETs eliminated — all cache hits
                 playbook_have_all_data,
                 playbook_have_all_data,
                 self.playbook_mock_succ_resp,
@@ -497,16 +515,6 @@ class TestDcnmIntfModule(TestDcnmModule):
 
         if "_bunched_intf_merged_new" in self._testMethodName:
             # No I/F exists case
-            playbook_pc_intf1 = []
-            playbook_pc_intf2 = []
-            playbook_pc_intf3 = []
-            playbook_pc_intf4 = []
-            playbook_eth_intf1 = []
-            playbook_eth_intf2 = []
-            playbook_eth_intf3 = []
-            playbook_eth_intf4 = []
-            playbook_vpc_intf1 = []
-            playbook_vpc_intf2 = []
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
             )
@@ -514,20 +522,25 @@ class TestDcnmIntfModule(TestDcnmModule):
                 "deployed_payloads"
             )
 
+            # Bulk IF_WITH_SNO responses — empty since no interfaces exist yet
+            bunched_bulk_sal_empty = {
+                "MESSAGE": "OK",
+                "RETURN_CODE": 200,
+                "DATA": [],
+            }
+            bunched_bulk_fox_empty = {
+                "MESSAGE": "OK",
+                "RETURN_CODE": 200,
+                "DATA": [],
+            }
+
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
                 self.playbook_mock_vpc_resp,
                 self.playbook_mock_vpc_resp,
-                playbook_pc_intf1,
-                playbook_pc_intf2,
-                playbook_pc_intf3,
-                playbook_pc_intf4,
-                playbook_eth_intf1,
-                playbook_eth_intf2,
-                playbook_eth_intf3,
-                playbook_eth_intf4,
-                playbook_vpc_intf1,
-                playbook_vpc_intf2,
+                bunched_bulk_sal_empty,               # IF_WITH_SNO bulk prefetch for SAL1819SAN8
+                bunched_bulk_fox_empty,               # IF_WITH_SNO bulk prefetch for FOX1821H035
+                # Individual GETs eliminated — all cache misses
                 playbook_have_all_data,
                 playbook_have_all_data,
                 self.playbook_mock_succ_resp,
@@ -919,17 +932,34 @@ class TestDcnmIntfModule(TestDcnmModule):
                 "payloads"
             )
 
+            # Bulk IF_WITH_SNO responses.  AA_FEX with vpc-prefixed name
+            # uses vpc_ip_sn → FOX1821H035 for lookups.  Prefetch order:
+            # SAL (from ip_sn) then FOX (from vpc_ip_sn split).
+            aa_fex_bulk_sal_empty = {
+                "MESSAGE": "OK",
+                "RETURN_CODE": 200,
+                "DATA": [],
+            }
+            aa_fex_bulk_fox = {
+                "MESSAGE": "OK",
+                "RETURN_CODE": 200,
+                "DATA": [
+                    playbook_aa_fex_intf1["DATA"][0],
+                ],
+            }
+
             self.run_dcnm_send.side_effect = [
-                self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_aa_fex_intf1,
+                self.mock_monitor_false_resp,       # FABRIC_ACCESS_MODE
+                self.playbook_mock_vpc_resp,         # VPC_SNO for 192.168.1.108
+                aa_fex_bulk_sal_empty,               # IF_WITH_SNO bulk prefetch for SAL1819SAN8
+                aa_fex_bulk_fox,                     # IF_WITH_SNO bulk prefetch for FOX1821H035
+                # intf_info for vPC150 is now a cache hit (FOX serial)
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
             ]
 
         if "_aa_fex_deleted_non_existing" in self._testMethodName:
-            playbook_aa_fex_intf1 = []
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
             )
@@ -937,12 +967,33 @@ class TestDcnmIntfModule(TestDcnmModule):
             self.breakout_policies_data = loadPlaybookData("dcnm_intf_breakout_policies")
             empty_breakout_resp = self.breakout_policies_data.get("empty_breakout_policies")
 
+            # Bulk IF_WITH_SNO responses.  vPC111 does not exist, so the
+            # FOX bulk response is empty.  After prefetch, the intf_info
+            # lookup for vPC111 on FOX returns [] from cache (SNO already
+            # fetched, interface not found) — no individual HTTP call.
+            # However, when intf_payload==[] for a non-ETH interface, the
+            # code falls through to dcnm_intf_get_have_all(sw) which makes
+            # 2 additional calls (have_all_with_sno + breakout_policies).
+            aa_fex_bulk_sal_empty = {
+                "MESSAGE": "OK",
+                "RETURN_CODE": 200,
+                "DATA": [],
+            }
+            aa_fex_bulk_fox_empty = {
+                "MESSAGE": "OK",
+                "RETURN_CODE": 200,
+                "DATA": [],
+            }
+
             self.run_dcnm_send.side_effect = [
-                self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_aa_fex_intf1,
-                empty_breakout_resp,
-                playbook_aa_fex_intf1,
+                self.mock_monitor_false_resp,       # FABRIC_ACCESS_MODE
+                self.playbook_mock_vpc_resp,         # VPC_SNO for 192.168.1.108
+                aa_fex_bulk_sal_empty,               # IF_WITH_SNO bulk prefetch for SAL1819SAN8
+                aa_fex_bulk_fox_empty,               # IF_WITH_SNO bulk prefetch for FOX1821H035
+                # intf_info for vPC111 returns [] from cache — no HTTP call
+                # Since intf_payload==[], code falls through to have_all:
+                playbook_have_all_data,              # have_all_with_sno for SAL1819SAN8
+                empty_breakout_resp,                 # breakout_policies for SAL1819SAN8
             ]
 
         if "_aa_fex_replaced_existing" in self._testMethodName:
@@ -1297,21 +1348,22 @@ class TestDcnmIntfModule(TestDcnmModule):
 
         if "_pc_merged_new" in self._testMethodName:
             # No I/F exists case
-            playbook_pc_intf1 = []
-            playbook_pc_intf2 = []
-            playbook_pc_intf3 = []
-            playbook_pc_intf4 = []
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
             )
 
+            # Bulk IF_WITH_SNO response — empty since no interfaces exist yet
+            pc_bulk_sal_empty = {
+                "MESSAGE": "OK",
+                "RETURN_CODE": 200,
+                "DATA": [],
+            }
+
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
                 self.playbook_mock_vpc_resp,
-                playbook_pc_intf1,
-                playbook_pc_intf2,
-                playbook_pc_intf3,
-                playbook_pc_intf4,
+                pc_bulk_sal_empty,                   # IF_WITH_SNO bulk prefetch for SAL1819SAN8
+                # Individual GETs eliminated — all cache misses
                 playbook_have_all_data,
                 playbook_have_all_data,
                 self.playbook_mock_succ_resp,
@@ -1393,13 +1445,23 @@ class TestDcnmIntfModule(TestDcnmModule):
                 "payloads"
             )
 
+            # Bulk IF_WITH_SNO response for SAL1819SAN8 combining all 4 PCs
+            pc_bulk_sal = {
+                "MESSAGE": "OK",
+                "RETURN_CODE": 200,
+                "DATA": [
+                    playbook_pc_intf1["DATA"][0],
+                    playbook_pc_intf2["DATA"][0],
+                    playbook_pc_intf3["DATA"][0],
+                    playbook_pc_intf4["DATA"][0],
+                ],
+            }
+
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
                 self.playbook_mock_vpc_resp,
-                playbook_pc_intf1,
-                playbook_pc_intf2,
-                playbook_pc_intf3,
-                playbook_pc_intf4,
+                pc_bulk_sal,                         # IF_WITH_SNO bulk prefetch for SAL1819SAN8
+                # Individual GETs eliminated — all cache hits
                 playbook_have_all_data,
                 playbook_have_all_data,
                 self.playbook_mock_succ_resp,
@@ -1433,13 +1495,23 @@ class TestDcnmIntfModule(TestDcnmModule):
                 "payloads"
             )
 
+            # Bulk IF_WITH_SNO response for SAL1819SAN8 combining all 4 PCs.
+            pc_bulk_sal = {
+                "MESSAGE": "OK",
+                "RETURN_CODE": 200,
+                "DATA": [
+                    playbook_pc_intf1["DATA"][0],
+                    playbook_pc_intf2["DATA"][0],
+                    playbook_pc_intf3["DATA"][0],
+                    playbook_pc_intf4["DATA"][0],
+                ],
+            }
+
             self.run_dcnm_send.side_effect = [
-                self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_pc_intf1,
-                playbook_pc_intf2,
-                playbook_pc_intf3,
-                playbook_pc_intf4,
+                self.mock_monitor_false_resp,       # FABRIC_ACCESS_MODE
+                self.playbook_mock_vpc_resp,         # VPC_SNO for 192.168.1.108
+                pc_bulk_sal,                         # IF_WITH_SNO bulk prefetch for SAL1819SAN8
+                # intf_info calls for all 4 PCs are now cache hits
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -1534,13 +1606,23 @@ class TestDcnmIntfModule(TestDcnmModule):
                 "payloads"
             )
 
+            # Bulk IF_WITH_SNO response for SAL1819SAN8 combining all 4 PCs
+            pc_bulk_sal = {
+                "MESSAGE": "OK",
+                "RETURN_CODE": 200,
+                "DATA": [
+                    playbook_pc_intf1["DATA"][0],
+                    playbook_pc_intf2["DATA"][0],
+                    playbook_pc_intf3["DATA"][0],
+                    playbook_pc_intf4["DATA"][0],
+                ],
+            }
+
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
                 self.playbook_mock_vpc_resp,
-                playbook_pc_intf1,
-                playbook_pc_intf2,
-                playbook_pc_intf3,
-                playbook_pc_intf4,
+                pc_bulk_sal,                         # IF_WITH_SNO bulk prefetch for SAL1819SAN8
+                # Individual GETs eliminated — all cache hits
                 playbook_have_all_data,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -1609,11 +1691,6 @@ class TestDcnmIntfModule(TestDcnmModule):
 
         if "_eth_merged_new" in self._testMethodName:
             # No I/F exists case
-            playbook_eth_intf1 = []
-            playbook_eth_intf2 = []
-            playbook_eth_intf3 = []
-            playbook_eth_intf4 = []
-            playbook_eth_intf5 = []
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
             )
@@ -1621,14 +1698,18 @@ class TestDcnmIntfModule(TestDcnmModule):
                 "deployed_payloads"
             )
 
+            # Bulk IF_WITH_SNO response — empty since no interfaces exist yet
+            eth_bulk_sal_empty = {
+                "MESSAGE": "OK",
+                "RETURN_CODE": 200,
+                "DATA": [],
+            }
+
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
                 self.playbook_mock_vpc_resp,
-                playbook_eth_intf1,
-                playbook_eth_intf2,
-                playbook_eth_intf3,
-                playbook_eth_intf4,
-                playbook_eth_intf5,
+                eth_bulk_sal_empty,                  # IF_WITH_SNO bulk prefetch for SAL1819SAN8
+                # Individual GETs eliminated — all cache misses (SNO cached, interfaces not found)
                 playbook_have_all_data,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -1698,14 +1779,24 @@ class TestDcnmIntfModule(TestDcnmModule):
                 "payloads"
             )
 
+            # Bulk IF_WITH_SNO response for SAL1819SAN8 combining all 5 ETH interfaces
+            eth_bulk_sal = {
+                "MESSAGE": "OK",
+                "RETURN_CODE": 200,
+                "DATA": [
+                    playbook_eth_intf1["DATA"][0],
+                    playbook_eth_intf2["DATA"][0],
+                    playbook_eth_intf3["DATA"][0],
+                    playbook_eth_intf4["DATA"][0],
+                    playbook_eth_intf5["DATA"][0],
+                ],
+            }
+
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
                 self.playbook_mock_vpc_resp,
-                playbook_eth_intf1,
-                playbook_eth_intf2,
-                playbook_eth_intf3,
-                playbook_eth_intf4,
-                playbook_eth_intf5,
+                eth_bulk_sal,                        # IF_WITH_SNO bulk prefetch for SAL1819SAN8
+                # Individual GETs eliminated — all cache hits
                 playbook_have_all_data,
                 playbook_have_all_data,
                 self.playbook_mock_succ_resp,
@@ -1748,14 +1839,24 @@ class TestDcnmIntfModule(TestDcnmModule):
                 "deployed_payloads"
             )
 
+            # Bulk IF_WITH_SNO response for SAL1819SAN8 combining all 5 ETH interfaces
+            eth_bulk_sal = {
+                "MESSAGE": "OK",
+                "RETURN_CODE": 200,
+                "DATA": [
+                    playbook_eth_intf1["DATA"][0],
+                    playbook_eth_intf2["DATA"][0],
+                    playbook_eth_intf3["DATA"][0],
+                    playbook_eth_intf4["DATA"][0],
+                    playbook_eth_intf5["DATA"][0],
+                ],
+            }
+
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
                 self.playbook_mock_vpc_resp,
-                playbook_eth_intf1,
-                playbook_eth_intf2,
-                playbook_eth_intf3,
-                playbook_eth_intf4,
-                playbook_eth_intf5,
+                eth_bulk_sal,                        # IF_WITH_SNO bulk prefetch for SAL1819SAN8
+                # Individual GETs eliminated — all cache hits
                 playbook_have_all_data,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -1795,16 +1896,28 @@ class TestDcnmIntfModule(TestDcnmModule):
                 "eth_payloads"
             )
 
+            # Bulk IF_WITH_SNO response for SAL1819SAN8 combining all 5 ETH
+            # interfaces.  The deleted-state prefetch makes one bulk GET per
+            # unique serial number, replacing 5 individual GETs.
+            eth_bulk_sal = {
+                "MESSAGE": "OK",
+                "RETURN_CODE": 200,
+                "DATA": [
+                    playbook_eth_intf1["DATA"][0],
+                    playbook_eth_intf2["DATA"][0],
+                    playbook_eth_intf3["DATA"][0],
+                    playbook_eth_intf4["DATA"][0],
+                    playbook_eth_intf5["DATA"][0],
+                ],
+            }
+
             self.run_dcnm_send.side_effect = [
-                self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_have_all_data,
-                playbook_eth_intf1,
-                playbook_eth_intf2,
-                playbook_eth_intf3,
-                playbook_eth_intf4,
-                playbook_eth_intf5,
-                self.playbook_mock_succ_resp,
+                self.mock_monitor_false_resp,       # FABRIC_ACCESS_MODE
+                self.playbook_mock_vpc_resp,         # VPC_SNO for 192.168.1.108
+                eth_bulk_sal,                        # IF_WITH_SNO bulk prefetch for SAL1819SAN8
+                playbook_have_all_data,              # IF_DETAIL_WITH_SNO (have_all)
+                self.playbook_mock_succ_resp,         # breakout_policies (harmless, no breakout match)
+                # intf_info calls for all 5 ETH interfaces are now cache hits
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -1917,11 +2030,21 @@ class TestDcnmIntfModule(TestDcnmModule):
                 "payloads"
             )
 
+            # Bulk IF_WITH_SNO response for SAL1819SAN8 with both sub-interfaces
+            subint_bulk_sal = {
+                "MESSAGE": "OK",
+                "RETURN_CODE": 200,
+                "DATA": [
+                    playbook_subint_intf1["DATA"][0],
+                    playbook_subint_intf2["DATA"][0],
+                ],
+            }
+
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
                 self.playbook_mock_vpc_resp,
-                playbook_subint_intf1,
-                playbook_subint_intf2,
+                subint_bulk_sal,                     # IF_WITH_SNO bulk prefetch for SAL1819SAN8
+                # Individual GETs eliminated — all cache hits
                 playbook_have_all_data,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -1942,11 +2065,21 @@ class TestDcnmIntfModule(TestDcnmModule):
                 "deployed_payloads"
             )
 
+            # Bulk IF_WITH_SNO response for SAL1819SAN8 with both sub-interfaces
+            subint_bulk_sal = {
+                "MESSAGE": "OK",
+                "RETURN_CODE": 200,
+                "DATA": [
+                    playbook_subint_intf1["DATA"][0],
+                    playbook_subint_intf2["DATA"][0],
+                ],
+            }
+
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
                 self.playbook_mock_vpc_resp,
-                playbook_subint_intf1,
-                playbook_subint_intf2,
+                subint_bulk_sal,                     # IF_WITH_SNO bulk prefetch for SAL1819SAN8
+                # Individual GETs eliminated — all cache hits
                 playbook_have_all_data,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -2003,11 +2136,21 @@ class TestDcnmIntfModule(TestDcnmModule):
                 "payloads"
             )
 
+            # Bulk IF_WITH_SNO response for SAL1819SAN8 with both sub-interfaces.
+            subint_bulk_sal = {
+                "MESSAGE": "OK",
+                "RETURN_CODE": 200,
+                "DATA": [
+                    playbook_subint_intf1["DATA"][0],
+                    playbook_subint_intf2["DATA"][0],
+                ],
+            }
+
             self.run_dcnm_send.side_effect = [
-                self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_subint_intf1,
-                playbook_subint_intf2,
+                self.mock_monitor_false_resp,       # FABRIC_ACCESS_MODE
+                self.playbook_mock_vpc_resp,         # VPC_SNO for 192.168.1.108
+                subint_bulk_sal,                     # IF_WITH_SNO bulk prefetch for SAL1819SAN8
+                # intf_info calls for both sub-interfaces are now cache hits
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -2131,11 +2274,21 @@ class TestDcnmIntfModule(TestDcnmModule):
                 "payloads"
             )
 
+            # Bulk IF_WITH_SNO response for SAL1819SAN8 with both loopbacks
+            lo_bulk_sal = {
+                "MESSAGE": "OK",
+                "RETURN_CODE": 200,
+                "DATA": [
+                    playbook_lo_intf1["DATA"][0],
+                    playbook_lo_intf2["DATA"][0],
+                ],
+            }
+
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
                 self.playbook_mock_vpc_resp,
-                playbook_lo_intf1,
-                playbook_lo_intf2,
+                lo_bulk_sal,                         # IF_WITH_SNO bulk prefetch for SAL1819SAN8
+                # Individual GETs eliminated — all cache hits
                 playbook_have_all_data,
                 playbook_have_all_data,
                 self.playbook_mock_succ_resp,
@@ -2189,11 +2342,21 @@ class TestDcnmIntfModule(TestDcnmModule):
                 "deployed_payloads"
             )
 
+            # Bulk IF_WITH_SNO response for SAL1819SAN8 with both loopbacks
+            lo_bulk_sal = {
+                "MESSAGE": "OK",
+                "RETURN_CODE": 200,
+                "DATA": [
+                    playbook_lo_intf1["DATA"][0],
+                    playbook_lo_intf2["DATA"][0],
+                ],
+            }
+
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
                 self.playbook_mock_vpc_resp,
-                playbook_lo_intf1,
-                playbook_lo_intf2,
+                lo_bulk_sal,                         # IF_WITH_SNO bulk prefetch for SAL1819SAN8
+                # Individual GETs eliminated — all cache hits
                 playbook_have_all_data,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -2216,11 +2379,21 @@ class TestDcnmIntfModule(TestDcnmModule):
                 "payloads"
             )
 
+            # Bulk IF_WITH_SNO response for SAL1819SAN8 with both loopbacks.
+            lo_bulk_sal = {
+                "MESSAGE": "OK",
+                "RETURN_CODE": 200,
+                "DATA": [
+                    playbook_lo_intf1["DATA"][0],
+                    playbook_lo_intf2["DATA"][0],
+                ],
+            }
+
             self.run_dcnm_send.side_effect = [
-                self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_lo_intf1,
-                playbook_lo_intf2,
+                self.mock_monitor_false_resp,       # FABRIC_ACCESS_MODE
+                self.playbook_mock_vpc_resp,         # VPC_SNO for 192.168.1.108
+                lo_bulk_sal,                         # IF_WITH_SNO bulk prefetch for SAL1819SAN8
+                # intf_info calls for both loopbacks are now cache hits
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -2256,11 +2429,22 @@ class TestDcnmIntfModule(TestDcnmModule):
                 "eth_3_2_access_payload"
             )
 
+            # Bulk IF_WITH_SNO response for SAL1819SAN8 with both loopbacks
+            # (consumed by get_have bulk prefetch for the overridden state)
+            lo_bulk_sal = {
+                "MESSAGE": "OK",
+                "RETURN_CODE": 200,
+                "DATA": [
+                    playbook_lo_intf1["DATA"][0],
+                    playbook_lo_intf2["DATA"][0],
+                ],
+            }
+
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
                 self.playbook_mock_vpc_resp,
-                playbook_lo_intf1,
-                playbook_lo_intf2,
+                lo_bulk_sal,                         # IF_WITH_SNO bulk prefetch for SAL1819SAN8
+                # Individual GETs eliminated — all cache hits
                 playbook_have_all_data,
                 eth_1_1_access_intf,
                 eth_1_2_access_intf,
@@ -2417,12 +2601,22 @@ class TestDcnmIntfModule(TestDcnmModule):
                 "payloads"
             )
 
+            # Bulk IF_WITH_SNO response for FOX1821H035 (first part of VPC pair)
+            vpc_bulk_fox = {
+                "MESSAGE": "OK",
+                "RETURN_CODE": 200,
+                "DATA": [
+                    playbook_vpc_intf1["DATA"][0],
+                    playbook_vpc_intf2["DATA"][0],
+                ],
+            }
+
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
                 self.playbook_mock_vpc_resp,
                 self.playbook_mock_vpc_resp,
-                playbook_vpc_intf1,
-                playbook_vpc_intf2,
+                vpc_bulk_fox,                        # IF_WITH_SNO bulk prefetch for FOX1821H035
+                # Individual GETs eliminated — all cache hits
                 playbook_have_all_data,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -2451,12 +2645,31 @@ class TestDcnmIntfModule(TestDcnmModule):
                 "payloads"
             )
 
+            # Bulk IF_WITH_SNO responses.  VPC interfaces use the first
+            # part of the combined serial (FOX1821H035).  The prefetch
+            # fetches both ip_sn serials (FOX, SAL) plus the VPC serial
+            # (FOX again, deduped).  Order: FOX first, then SAL.
+            vpc_bulk_fox = {
+                "MESSAGE": "OK",
+                "RETURN_CODE": 200,
+                "DATA": [
+                    playbook_vpc_intf1["DATA"][0],
+                    playbook_vpc_intf2["DATA"][0],
+                ],
+            }
+            vpc_bulk_sal_empty = {
+                "MESSAGE": "OK",
+                "RETURN_CODE": 200,
+                "DATA": [],
+            }
+
             self.run_dcnm_send.side_effect = [
-                self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_vpc_intf1,
-                playbook_vpc_intf2,
+                self.mock_monitor_false_resp,       # FABRIC_ACCESS_MODE
+                self.playbook_mock_vpc_resp,         # VPC_SNO for 192.168.1.109
+                self.playbook_mock_vpc_resp,         # VPC_SNO for 192.168.1.108
+                vpc_bulk_fox,                        # IF_WITH_SNO bulk prefetch for FOX1821H035
+                vpc_bulk_sal_empty,                  # IF_WITH_SNO bulk prefetch for SAL1819SAN8
+                # intf_info calls for both VPCs are now cache hits (FOX serial)
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -2482,12 +2695,22 @@ class TestDcnmIntfModule(TestDcnmModule):
                 "deployed_payloads"
             )
 
+            # Bulk IF_WITH_SNO response for FOX1821H035 (first part of VPC pair)
+            vpc_bulk_fox = {
+                "MESSAGE": "OK",
+                "RETURN_CODE": 200,
+                "DATA": [
+                    playbook_vpc_intf1["DATA"][0],
+                    playbook_vpc_intf2["DATA"][0],
+                ],
+            }
+
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
                 self.playbook_mock_vpc_resp,
                 self.playbook_mock_vpc_resp,
-                playbook_vpc_intf1,
-                playbook_vpc_intf2,
+                vpc_bulk_fox,                        # IF_WITH_SNO bulk prefetch for FOX1821H035
+                # Individual GETs eliminated — all cache hits
                 playbook_have_all_data,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,

--- a/tests/unit/modules/dcnm/test_dcnm_intf.py
+++ b/tests/unit/modules/dcnm/test_dcnm_intf.py
@@ -212,18 +212,55 @@ class TestDcnmIntfModule(TestDcnmModule):
             eth_3_2_access_intf = self.have_all_payloads_data.get(
                 "eth_3_2_access_payload"
             )
+
+            # Build combined bulk response for SAL1819SAN8 containing all
+            # Ethernet interface details.  The real NDFC API groups interfaces
+            # that share the same policy into a single DATA element with
+            # multiple entries in the "interfaces" array.  Simulate that here
+            # to verify the bulk-fetch cache correctly unpacks grouped data.
+            shared_policy = eth_1_1_access_intf["DATA"][0]["policy"]
+            eth_bulk_payload = {
+                "MESSAGE": "OK",
+                "RETURN_CODE": 200,
+                "DATA": [
+                    {
+                        "policy": shared_policy,
+                        "interfaces": (
+                            eth_1_1_access_intf["DATA"][0]["interfaces"]
+                            + eth_1_2_access_intf["DATA"][0]["interfaces"]
+                            + eth_3_2_access_intf["DATA"][0]["interfaces"]
+                        ),
+                    }
+                ],
+            }
+            # Empty bulk response for the VPC switch (no eth interfaces there)
+            eth_vpc_empty_payload = {
+                "MESSAGE": "OK",
+                "RETURN_CODE": 200,
+                "DATA": [],
+            }
+
             # Load breakout policies fixture
             self.breakout_policies_data = loadPlaybookData("dcnm_intf_breakout_policies")
             empty_breakout_resp = self.breakout_policies_data.get("empty_breakout_policies")
 
+            # Call sequence with bulk interface detail prefetch:
+            # [0] FABRIC_ACCESS_MODE
+            # [1] IF_DETAIL_WITH_SNO for FOX1821H035 (returns empty)
+            # [2] breakout policies for FOX1821H035 (returns empty)
+            # [3] IF_DETAIL_WITH_SNO for SAL1819SAN8 (populates have_all)
+            # [4] breakout policies for SAL1819SAN8 (returns empty)
+            # [5] bulk IF_WITH_SNO for SAL1819SAN8 (all 3 Eth interface details)
+            # [6] bulk IF_WITH_SNO for SAL1821T9EF (empty - VPC switch)
+            # [7+] PUT/POST for replace/deploy
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
                 empty_breakout_resp,
                 empty_breakout_resp,
                 playbook_have_all_data,
-                eth_1_1_access_intf,
-                eth_1_2_access_intf,
-                eth_3_2_access_intf,
+                empty_breakout_resp,
+                eth_bulk_payload,
+                eth_vpc_empty_payload,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -5809,7 +5846,7 @@ class TestDcnmIntfModule(TestDcnmModule):
             )
 
         self.assertEqual(len(result["diff"][0]["deleted"]), 0)
-        self.assertEqual(len(result["diff"][0]["replaced"]), 2)
+        self.assertEqual(len(result["diff"][0]["replaced"]), 3)
         self.assertEqual(len(result["diff"][0]["overridden"]), 0)
 
     def test_dcnm_intf_override_sub_int_intf_types_only(self):

--- a/tests/unit/modules/dcnm/test_dcnm_intf.py
+++ b/tests/unit/modules/dcnm/test_dcnm_intf.py
@@ -1728,6 +1728,35 @@ class TestDcnmIntfModule(TestDcnmModule):
                 playbook_deployed_data,
             ]
 
+        if "_eth_merged_missing_native_vlan" in self._testMethodName:
+            playbook_eth_intf1 = self.payloads_data.get(
+                "eth_merged_trunk_missing_native_vlan_payloads"
+            )
+            playbook_have_all_data = self.have_all_payloads_data.get(
+                "payloads"
+            )
+
+            self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
+                self.playbook_mock_vpc_resp,
+                playbook_eth_intf1,
+                playbook_have_all_data,
+                self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+            ]
+
         if "_eth_merged_existing" in self._testMethodName:
             # No I/F exists case
             playbook_eth_intf1 = self.payloads_data.get(
@@ -3484,6 +3513,46 @@ class TestDcnmIntfModule(TestDcnmModule):
         for d in result["diff"][0]["merged"]:
             for intf in d["interfaces"]:
                 self.assertEqual((intf["ifName"] in ["Ethernet1/2"]), True)
+
+    def test_dcnm_intf_eth_merged_missing_native_vlan(self):
+
+        # Use Version 12 For This Test Case
+        self.run_dcnm_version_supported.side_effect = [12]
+
+        # load the json from playbooks
+        self.config_data = loadPlaybookData("dcnm_intf_eth_configs")
+        self.payloads_data = loadPlaybookData("dcnm_intf_eth_payloads")
+        self.have_all_payloads_data = loadPlaybookData(
+            "dcnm_intf_have_all_payloads"
+        )
+
+        # load required config data
+        self.playbook_config = self.config_data.get(
+            "eth_merged_config_missing_native_vlan"
+        )
+        self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
+        self.mock_ip_sn = self.config_data.get("mock_ip_sn")
+        self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
+        self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
+
+        set_module_args(
+            dict(
+                state="merged",
+                fabric="test_fabric",
+                config=self.playbook_config,
+            )
+        )
+        result = self.execute_module(changed=True, failed=False)
+        self.assertEqual(len(result["diff"][0]["merged"]), 1)
+        for d in result["diff"][0]["merged"]:
+            for intf in d["interfaces"]:
+                self.assertEqual((intf["ifName"] in ["Ethernet1/30"]), True)
 
     def test_dcnm_intf_eth_merged_new(self):
 

--- a/tests/unit/modules/dcnm/test_dcnm_intf.py
+++ b/tests/unit/modules/dcnm/test_dcnm_intf.py
@@ -40,6 +40,19 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.fd.write(msg)
         self.fd.flush()
 
+    def build_bulk_payload(self, *payloads):
+        data = []
+
+        for payload in payloads:
+            if isinstance(payload, dict):
+                data.extend(payload.get("DATA") or [])
+
+        return {
+            "MESSAGE": "OK",
+            "RETURN_CODE": 200,
+            "DATA": data,
+        }
+
     def setUp(self):
 
         super(TestDcnmIntfModule, self).setUp()
@@ -116,7 +129,6 @@ class TestDcnmIntfModule(TestDcnmModule):
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
                 [],
                 empty_breakout_resp,
                 empty_breakout_resp,
@@ -605,7 +617,6 @@ class TestDcnmIntfModule(TestDcnmModule):
             )
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
                 playbook_pc_intf,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -626,15 +637,13 @@ class TestDcnmIntfModule(TestDcnmModule):
     def load_missing_state_fixtures(self):
 
         if "_missing_state" in self._testMethodName:
-            # No I/F exists case
-            playbook_pc_intf = []
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
             )
+            pc_bulk_sal_empty = self.build_bulk_payload()
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_pc_intf,
+                pc_bulk_sal_empty,
                 playbook_have_all_data,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -706,16 +715,14 @@ class TestDcnmIntfModule(TestDcnmModule):
     def load_svi_fixtures(self):
 
         if "_svi_merged_new" in self._testMethodName:
-            # No I/F exists case
-            playbook_svi_intf1 = []
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
             )
+            svi_bulk_empty = self.build_bulk_payload()
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_svi_intf1,
+                svi_bulk_empty,
                 playbook_have_all_data,
                 playbook_have_all_data,
                 self.playbook_mock_succ_resp,
@@ -728,11 +735,11 @@ class TestDcnmIntfModule(TestDcnmModule):
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
             )
+            svi_bulk_sal = self.build_bulk_payload(playbook_svi_intf1)
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_svi_intf1,
+                svi_bulk_sal,
                 playbook_have_all_data,
                 playbook_have_all_data,
                 self.playbook_mock_succ_resp,
@@ -743,49 +750,41 @@ class TestDcnmIntfModule(TestDcnmModule):
         # Use the same payloads that we use for creating new.
         if "_svi_deleted_existing" in self._testMethodName:
             playbook_svi_intf1 = self.payloads_data.get("svi_merged_payloads")
-            playbook_have_all_data = self.have_all_payloads_data.get(
-                "payloads"
-            )
+            svi_bulk_sal = self.build_bulk_payload(playbook_svi_intf1)
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_svi_intf1,
+                svi_bulk_sal,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
             ]
 
         if "_svi_deleted_non_existing" in self._testMethodName:
-            playbook_svi_intf1 = []
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
             )
             # Load breakout policies fixture
             self.breakout_policies_data = loadPlaybookData("dcnm_intf_breakout_policies")
             empty_breakout_resp = self.breakout_policies_data.get("empty_breakout_policies")
+            svi_bulk_empty = self.build_bulk_payload()
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_svi_intf1,
+                svi_bulk_empty,
+                playbook_have_all_data,
                 empty_breakout_resp,
-                playbook_svi_intf1,
             ]
         if "_svi_replaced_existing" in self._testMethodName:
             playbook_svi_intf1 = self.payloads_data.get("svi_merged_payloads")
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
             )
-            # Load breakout policies fixture
-            self.breakout_policies_data = loadPlaybookData("dcnm_intf_breakout_policies")
-            empty_breakout_resp = self.breakout_policies_data.get("empty_breakout_policies")
+            svi_bulk_sal = self.build_bulk_payload(playbook_svi_intf1)
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_svi_intf1,
-                empty_breakout_resp,
+                svi_bulk_sal,
                 playbook_have_all_data,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -807,11 +806,11 @@ class TestDcnmIntfModule(TestDcnmModule):
             eth_3_2_access_intf = self.have_all_payloads_data.get(
                 "eth_3_2_access_payload"
             )
+            svi_bulk_sal = self.build_bulk_payload(playbook_svi_intf1)
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_svi_intf1,
+                svi_bulk_sal,
                 playbook_have_all_data,
                 eth_1_1_access_intf,
                 eth_1_2_access_intf,
@@ -885,15 +884,14 @@ class TestDcnmIntfModule(TestDcnmModule):
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
             )
-            # Load breakout policies fixture
-            self.breakout_policies_data = loadPlaybookData("dcnm_intf_breakout_policies")
-            empty_breakout_resp = self.breakout_policies_data.get("empty_breakout_policies")
+            aa_fex_bulk_sal_empty = self.build_bulk_payload()
+            aa_fex_bulk_fox = self.build_bulk_payload(playbook_aa_fex_intf1)
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
                 self.playbook_mock_vpc_resp,
-                playbook_aa_fex_intf1,
-                empty_breakout_resp,
+                aa_fex_bulk_sal_empty,
+                aa_fex_bulk_fox,
                 playbook_have_all_data,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -1003,15 +1001,14 @@ class TestDcnmIntfModule(TestDcnmModule):
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
             )
-            # Load breakout policies fixture
-            self.breakout_policies_data = loadPlaybookData("dcnm_intf_breakout_policies")
-            empty_breakout_resp = self.breakout_policies_data.get("empty_breakout_policies")
+            aa_fex_bulk_sal_empty = self.build_bulk_payload()
+            aa_fex_bulk_fox = self.build_bulk_payload(playbook_aa_fex_intf1)
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
                 self.playbook_mock_vpc_resp,
-                playbook_aa_fex_intf1,
-                empty_breakout_resp,
+                aa_fex_bulk_sal_empty,
+                aa_fex_bulk_fox,
                 playbook_have_all_data,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -1113,20 +1110,14 @@ class TestDcnmIntfModule(TestDcnmModule):
     def load_st_fex_fixtures(self):
 
         if "_st_fex_merged_new" in self._testMethodName:
-            # No I/F exists case
-            playbook_st_fex_intf1 = []
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
             )
-            # Load breakout policies fixture
-            self.breakout_policies_data = loadPlaybookData("dcnm_intf_breakout_policies")
-            empty_breakout_resp = self.breakout_policies_data.get("empty_breakout_policies")
+            st_fex_bulk_empty = self.build_bulk_payload()
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_st_fex_intf1,
-                empty_breakout_resp,
+                st_fex_bulk_empty,
                 playbook_have_all_data,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -1140,11 +1131,11 @@ class TestDcnmIntfModule(TestDcnmModule):
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
             )
+            st_fex_bulk_sal = self.build_bulk_payload(playbook_st_fex_intf1)
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_st_fex_intf1,
+                st_fex_bulk_sal,
                 playbook_have_all_data,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -1158,15 +1149,11 @@ class TestDcnmIntfModule(TestDcnmModule):
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
             )
-            # Load breakout policies fixture
-            self.breakout_policies_data = loadPlaybookData("dcnm_intf_breakout_policies")
-            empty_breakout_resp = self.breakout_policies_data.get("empty_breakout_policies")
+            st_fex_bulk_sal = self.build_bulk_payload(playbook_st_fex_intf1)
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_st_fex_intf1,
-                empty_breakout_resp,
+                st_fex_bulk_sal,
                 playbook_have_all_data,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -1174,19 +1161,15 @@ class TestDcnmIntfModule(TestDcnmModule):
             ]
 
         if "_st_fex_merged_multi" in self._testMethodName:
-            # No I/F exists case
-            playbook_st_fex_intf1 = []
-            playbook_st_fex_intf2 = []
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
             )
+            st_fex_bulk_empty = self.build_bulk_payload()
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_st_fex_intf1,
-                playbook_st_fex_intf2,
+                st_fex_bulk_empty,
+                st_fex_bulk_empty,
                 playbook_have_all_data,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -1201,34 +1184,30 @@ class TestDcnmIntfModule(TestDcnmModule):
             playbook_st_fex_intf1 = self.payloads_data.get(
                 "st_fex_merged_payloads_150"
             )
-            playbook_have_all_data = self.have_all_payloads_data.get(
-                "payloads"
-            )
+            st_fex_bulk_sal = self.build_bulk_payload(playbook_st_fex_intf1)
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_st_fex_intf1,
+                st_fex_bulk_sal,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
             ]
 
         if "_st_fex_deleted_non_existing" in self._testMethodName:
-            playbook_st_fex_intf1 = []
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
             )
             # Load breakout policies fixture
             self.breakout_policies_data = loadPlaybookData("dcnm_intf_breakout_policies")
             empty_breakout_resp = self.breakout_policies_data.get("empty_breakout_policies")
+            st_fex_bulk_empty = self.build_bulk_payload()
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_st_fex_intf1,
+                st_fex_bulk_empty,
+                playbook_have_all_data,
                 empty_breakout_resp,
-                playbook_st_fex_intf1,
             ]
         if "_st_fex_replaced_existing" in self._testMethodName:
             playbook_st_fex_intf1 = self.payloads_data.get(
@@ -1237,15 +1216,11 @@ class TestDcnmIntfModule(TestDcnmModule):
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
             )
-            # Load breakout policies fixture
-            self.breakout_policies_data = loadPlaybookData("dcnm_intf_breakout_policies")
-            empty_breakout_resp = self.breakout_policies_data.get("empty_breakout_policies")
+            st_fex_bulk_sal = self.build_bulk_payload(playbook_st_fex_intf1)
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_st_fex_intf1,
-                empty_breakout_resp,
+                st_fex_bulk_sal,
                 playbook_have_all_data,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -1269,11 +1244,11 @@ class TestDcnmIntfModule(TestDcnmModule):
             eth_3_2_access_intf = self.have_all_payloads_data.get(
                 "eth_3_2_access_payload"
             )
+            st_fex_bulk_sal = self.build_bulk_payload(playbook_st_fex_intf1)
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_st_fex_intf1,
+                st_fex_bulk_sal,
                 playbook_have_all_data,
                 eth_1_1_access_intf,
                 eth_1_2_access_intf,
@@ -1314,11 +1289,11 @@ class TestDcnmIntfModule(TestDcnmModule):
             eth_3_2_access_intf = self.have_all_payloads_data.get(
                 "eth_3_2_access_payload"
             )
+            st_fex_bulk_sal = self.build_bulk_payload(playbook_st_fex_intf1)
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_st_fex_intf1,
+                st_fex_bulk_sal,
                 playbook_have_all_data,
                 eth_1_1_access_intf,
                 eth_1_2_access_intf,
@@ -1361,7 +1336,6 @@ class TestDcnmIntfModule(TestDcnmModule):
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
                 pc_bulk_sal_empty,                   # IF_WITH_SNO bulk prefetch for SAL1819SAN8
                 # Individual GETs eliminated — all cache misses
                 playbook_have_all_data,
@@ -1382,20 +1356,14 @@ class TestDcnmIntfModule(TestDcnmModule):
             ]
 
         if "_pc_merged_vlan_range_new" in self._testMethodName:
-            # No I/F exists case
-            playbook_pc_intf1 = []
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
             )
-            # Load breakout policies fixture
-            self.breakout_policies_data = loadPlaybookData("dcnm_intf_breakout_policies")
-            empty_breakout_resp = self.breakout_policies_data.get("empty_breakout_policies")
+            pc_bulk_sal_empty = self.build_bulk_payload()
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_pc_intf1,
-                empty_breakout_resp,
+                pc_bulk_sal_empty,
                 playbook_have_all_data,
                 playbook_have_all_data,
                 self.playbook_mock_succ_resp,
@@ -1409,11 +1377,11 @@ class TestDcnmIntfModule(TestDcnmModule):
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
             )
+            pc_bulk_sal = self.build_bulk_payload(playbook_pc_intf1)
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_pc_intf1,
+                pc_bulk_sal,
                 playbook_have_all_data,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -1459,7 +1427,6 @@ class TestDcnmIntfModule(TestDcnmModule):
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
                 pc_bulk_sal,                         # IF_WITH_SNO bulk prefetch for SAL1819SAN8
                 # Individual GETs eliminated — all cache hits
                 playbook_have_all_data,
@@ -1509,7 +1476,6 @@ class TestDcnmIntfModule(TestDcnmModule):
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,       # FABRIC_ACCESS_MODE
-                self.playbook_mock_vpc_resp,         # VPC_SNO for 192.168.1.108
                 pc_bulk_sal,                         # IF_WITH_SNO bulk prefetch for SAL1819SAN8
                 # intf_info calls for all 4 PCs are now cache hits
                 self.playbook_mock_succ_resp,
@@ -1527,14 +1493,11 @@ class TestDcnmIntfModule(TestDcnmModule):
             playbook_pc_intf1 = self.payloads_data.get(
                 "pc_merged_trunk_payloads"
             )
-            playbook_have_all_data = self.have_all_payloads_data.get(
-                "payloads"
-            )
+            pc_bulk_sal = self.build_bulk_payload(playbook_pc_intf1)
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_pc_intf1,
+                pc_bulk_sal,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -1547,15 +1510,14 @@ class TestDcnmIntfModule(TestDcnmModule):
             ]
 
         if "_intf_deleted_deploy" in self._testMethodName:
-            playbook_pc_intf1 = []
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "deleted_intf_payloads"
             )
+            pc_bulk_sal_empty = self.build_bulk_payload()
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_pc_intf1,
+                pc_bulk_sal_empty,
                 playbook_have_all_data,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -1572,14 +1534,11 @@ class TestDcnmIntfModule(TestDcnmModule):
             playbook_pc_intf1 = self.payloads_data.get(
                 "pc_merged_trunk_payloads"
             )
-            playbook_have_all_data = self.have_all_payloads_data.get(
-                "payloads"
-            )
+            pc_bulk_sal = self.build_bulk_payload(playbook_pc_intf1)
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_pc_intf1,
+                pc_bulk_sal,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -1620,7 +1579,6 @@ class TestDcnmIntfModule(TestDcnmModule):
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
                 pc_bulk_sal,                         # IF_WITH_SNO bulk prefetch for SAL1819SAN8
                 # Individual GETs eliminated — all cache hits
                 playbook_have_all_data,
@@ -1657,11 +1615,11 @@ class TestDcnmIntfModule(TestDcnmModule):
             eth_3_2_access_intf = self.have_all_payloads_data.get(
                 "eth_3_2_access_payload"
             )
+            pc_bulk_sal = self.build_bulk_payload(playbook_pc_intf1)
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_pc_intf1,
+                pc_bulk_sal,
                 playbook_have_all_data,
                 eth_1_1_access_intf,
                 eth_1_2_access_intf,
@@ -1707,7 +1665,6 @@ class TestDcnmIntfModule(TestDcnmModule):
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
                 eth_bulk_sal_empty,                  # IF_WITH_SNO bulk prefetch for SAL1819SAN8
                 # Individual GETs eliminated — all cache misses (SNO cached, interfaces not found)
                 playbook_have_all_data,
@@ -1735,11 +1692,11 @@ class TestDcnmIntfModule(TestDcnmModule):
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
             )
+            eth_bulk_sal = self.build_bulk_payload(playbook_eth_intf1)
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_eth_intf1,
+                eth_bulk_sal,
                 playbook_have_all_data,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -1758,18 +1715,17 @@ class TestDcnmIntfModule(TestDcnmModule):
             ]
 
         if "_eth_merged_existing" in self._testMethodName:
-            # No I/F exists case
             playbook_eth_intf1 = self.payloads_data.get(
                 "eth_merged_routed_payloads_eth_1_2"
             )
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
             )
+            eth_bulk_sal = self.build_bulk_payload(playbook_eth_intf1)
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_eth_intf1,
+                eth_bulk_sal,
                 playbook_have_all_data,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -1823,7 +1779,6 @@ class TestDcnmIntfModule(TestDcnmModule):
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
                 eth_bulk_sal,                        # IF_WITH_SNO bulk prefetch for SAL1819SAN8
                 # Individual GETs eliminated — all cache hits
                 playbook_have_all_data,
@@ -1883,7 +1838,6 @@ class TestDcnmIntfModule(TestDcnmModule):
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
                 eth_bulk_sal,                        # IF_WITH_SNO bulk prefetch for SAL1819SAN8
                 # Individual GETs eliminated — all cache hits
                 playbook_have_all_data,
@@ -1942,7 +1896,6 @@ class TestDcnmIntfModule(TestDcnmModule):
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,       # FABRIC_ACCESS_MODE
-                self.playbook_mock_vpc_resp,         # VPC_SNO for 192.168.1.108
                 eth_bulk_sal,                        # IF_WITH_SNO bulk prefetch for SAL1819SAN8
                 playbook_have_all_data,              # IF_DETAIL_WITH_SNO (have_all)
                 self.playbook_mock_succ_resp,         # breakout_policies (harmless, no breakout match)
@@ -1983,11 +1936,11 @@ class TestDcnmIntfModule(TestDcnmModule):
             eth_3_2_access_intf = self.have_all_payloads_data.get(
                 "eth_3_2_access_payload"
             )
+            eth_bulk_sal = self.build_bulk_payload(playbook_eth_intf1)
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_eth_intf1,
+                eth_bulk_sal,
                 playbook_have_all_data,
                 eth_1_1_access_intf,
                 eth_1_2_access_intf,
@@ -2017,21 +1970,17 @@ class TestDcnmIntfModule(TestDcnmModule):
     def load_subint_fixtures(self):
 
         if "_subint_merged_new" in self._testMethodName:
-            # No I/F exists case
-            playbook_sub_intf1 = []
-            playbook_sub_intf2 = []
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
             )
             playbook_deployed_data = self.have_all_payloads_data.get(
                 "deployed_payloads"
             )
+            subint_bulk_sal_empty = self.build_bulk_payload()
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_sub_intf1,
-                playbook_sub_intf2,
+                subint_bulk_sal_empty,
                 playbook_have_all_data,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -2071,7 +2020,6 @@ class TestDcnmIntfModule(TestDcnmModule):
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
                 subint_bulk_sal,                     # IF_WITH_SNO bulk prefetch for SAL1819SAN8
                 # Individual GETs eliminated — all cache hits
                 playbook_have_all_data,
@@ -2106,7 +2054,6 @@ class TestDcnmIntfModule(TestDcnmModule):
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
                 subint_bulk_sal,                     # IF_WITH_SNO bulk prefetch for SAL1819SAN8
                 # Individual GETs eliminated — all cache hits
                 playbook_have_all_data,
@@ -2134,11 +2081,11 @@ class TestDcnmIntfModule(TestDcnmModule):
             playbook_deployed_data = self.have_all_payloads_data.get(
                 "deployed_payloads"
             )
+            subint_bulk_sal = self.build_bulk_payload(playbook_subint_intf1)
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_subint_intf1,
+                subint_bulk_sal,
                 playbook_have_all_data,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -2177,7 +2124,6 @@ class TestDcnmIntfModule(TestDcnmModule):
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,       # FABRIC_ACCESS_MODE
-                self.playbook_mock_vpc_resp,         # VPC_SNO for 192.168.1.108
                 subint_bulk_sal,                     # IF_WITH_SNO bulk prefetch for SAL1819SAN8
                 # intf_info calls for both sub-interfaces are now cache hits
                 self.playbook_mock_succ_resp,
@@ -2199,7 +2145,6 @@ class TestDcnmIntfModule(TestDcnmModule):
             )
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
                 [],
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -2234,11 +2179,11 @@ class TestDcnmIntfModule(TestDcnmModule):
             eth_3_2_access_intf = self.have_all_payloads_data.get(
                 "eth_3_2_access_payload"
             )
+            subint_bulk_sal = self.build_bulk_payload(playbook_subint_intf1)
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_subint_intf1,
+                subint_bulk_sal,
                 playbook_have_all_data,
                 eth_1_1_access_intf,
                 eth_1_2_access_intf,
@@ -2265,21 +2210,17 @@ class TestDcnmIntfModule(TestDcnmModule):
     def load_lo_fixtures(self):
 
         if "_lo_merged_new" in self._testMethodName:
-            # No I/F exists case
-            playbook_lo_intf1 = []
-            playbook_lo_intf2 = []
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
             )
             playbook_deployed_data = self.have_all_payloads_data.get(
                 "deployed_payloads"
             )
+            lo_bulk_sal_empty = self.build_bulk_payload()
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_lo_intf1,
-                playbook_lo_intf2,
+                lo_bulk_sal_empty,
                 playbook_have_all_data,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -2315,7 +2256,6 @@ class TestDcnmIntfModule(TestDcnmModule):
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
                 lo_bulk_sal,                         # IF_WITH_SNO bulk prefetch for SAL1819SAN8
                 # Individual GETs eliminated — all cache hits
                 playbook_have_all_data,
@@ -2341,11 +2281,11 @@ class TestDcnmIntfModule(TestDcnmModule):
             playbook_deployed_data = self.have_all_payloads_data.get(
                 "deployed_payloads"
             )
+            lo_bulk_sal = self.build_bulk_payload(playbook_lo_intf1)
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_lo_intf1,
+                lo_bulk_sal,
                 playbook_have_all_data,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -2383,7 +2323,6 @@ class TestDcnmIntfModule(TestDcnmModule):
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
                 lo_bulk_sal,                         # IF_WITH_SNO bulk prefetch for SAL1819SAN8
                 # Individual GETs eliminated — all cache hits
                 playbook_have_all_data,
@@ -2420,7 +2359,6 @@ class TestDcnmIntfModule(TestDcnmModule):
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,       # FABRIC_ACCESS_MODE
-                self.playbook_mock_vpc_resp,         # VPC_SNO for 192.168.1.108
                 lo_bulk_sal,                         # IF_WITH_SNO bulk prefetch for SAL1819SAN8
                 # intf_info calls for both loopbacks are now cache hits
                 self.playbook_mock_succ_resp,
@@ -2471,7 +2409,6 @@ class TestDcnmIntfModule(TestDcnmModule):
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
                 lo_bulk_sal,                         # IF_WITH_SNO bulk prefetch for SAL1819SAN8
                 # Individual GETs eliminated — all cache hits
                 playbook_have_all_data,
@@ -2514,11 +2451,11 @@ class TestDcnmIntfModule(TestDcnmModule):
             eth_3_2_access_intf = self.have_all_payloads_data.get(
                 "eth_3_2_access_payload"
             )
+            lo_bulk_sal = self.build_bulk_payload(playbook_lo_intf1)
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_lo_intf1,
+                lo_bulk_sal,
                 playbook_have_all_data,
                 eth_1_1_access_intf,
                 eth_1_2_access_intf,
@@ -2556,11 +2493,11 @@ class TestDcnmIntfModule(TestDcnmModule):
             eth_3_2_access_intf = self.have_all_payloads_data.get(
                 "eth_3_2_access_payload"
             )
+            lo_bulk_sal = self.build_bulk_payload(playbook_lo_intf1)
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
-                self.playbook_mock_vpc_resp,
-                playbook_lo_intf1,
+                lo_bulk_sal,
                 playbook_have_all_data,
                 eth_1_1_access_intf,
                 eth_1_2_access_intf,
@@ -2586,22 +2523,19 @@ class TestDcnmIntfModule(TestDcnmModule):
     def load_vpc_fixtures(self):
 
         if "_vpc_merged_new" in self._testMethodName:
-            # No I/F exists case
-            playbook_vpc_intf1 = []
-            playbook_vpc_intf2 = []
             playbook_have_all_data = self.have_all_payloads_data.get(
                 "payloads"
             )
             playbook_deployed_data = self.have_all_payloads_data.get(
                 "deployed_payloads"
             )
+            vpc_bulk_fox_empty = self.build_bulk_payload()
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
                 self.playbook_mock_vpc_resp,
                 self.playbook_mock_vpc_resp,
-                playbook_vpc_intf1,
-                playbook_vpc_intf2,
+                vpc_bulk_fox_empty,
                 playbook_have_all_data,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -2777,12 +2711,13 @@ class TestDcnmIntfModule(TestDcnmModule):
             eth_3_2_access_intf = self.have_all_payloads_data.get(
                 "eth_3_2_access_payload"
             )
+            vpc_bulk_fox = self.build_bulk_payload(playbook_vpc_intf1)
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
                 self.playbook_mock_vpc_resp,
                 self.playbook_mock_vpc_resp,
-                playbook_vpc_intf1,
+                vpc_bulk_fox,
                 playbook_have_all_data,
                 eth_1_1_access_intf,
                 eth_1_2_access_intf,
@@ -5292,6 +5227,8 @@ class TestDcnmIntfModule(TestDcnmModule):
             "FEX_ID",
             "MTU",
             "DESC",
+            "PEER1_PCID",
+            "PEER2_PCID",
             "PEER1_PO_DESC",
             "PEER2_PO_DESC",
             "ADMIN_STATE",

--- a/tests/unit/modules/dcnm/test_dcnm_inventory.py
+++ b/tests/unit/modules/dcnm/test_dcnm_inventory.py
@@ -235,6 +235,81 @@ class TestDcnmInvModule(TestDcnmModule):
         self.mock_dcnm_fabric_details.stop()
         self.mock_dcnm_ip_sn.stop()
 
+    def _send_route(self, method, pattern, responses, repeat_last=False, match="contains"):
+        if isinstance(responses, (list, tuple)):
+            response_list = list(responses)
+        else:
+            response_list = [responses]
+
+        return {
+            "method": method,
+            "pattern": pattern,
+            "responses": response_list,
+            "repeat_last": repeat_last,
+            "match": match,
+        }
+
+    def _route_matches(self, route, method, path):
+        if route["method"] != method:
+            return False
+
+        if route["match"] == "contains":
+            return route["pattern"] in path
+        if route["match"] == "endswith":
+            return path.endswith(route["pattern"])
+        if route["match"] == "exact":
+            return path == route["pattern"]
+
+        raise AssertionError("Unsupported route match mode: {0}".format(route["match"]))
+
+    def _set_send_routes(self, *routes):
+        prepared_routes = []
+
+        for route in routes:
+            prepared_route = copy.deepcopy(route)
+            prepared_route["last"] = None
+            prepared_routes.append(prepared_route)
+
+        def side_effect(module, method, path, data=None):
+            for route in prepared_routes:
+                if not self._route_matches(route, method, path):
+                    continue
+
+                if route["responses"]:
+                    response = copy.deepcopy(route["responses"].pop(0))
+                    route["last"] = copy.deepcopy(response)
+                    return response
+
+                if route["repeat_last"] and route["last"] is not None:
+                    return copy.deepcopy(route["last"])
+
+            raise AssertionError(
+                "Unexpected dcnm_send call: {0} {1}".format(method, path)
+            )
+
+        self.run_dcnm_send.side_effect = side_effect
+
+    def _inventory_route(self, responses, repeat_last=True):
+        return self._send_route(
+            "GET",
+            "/inventory/switchesByFabric",
+            responses,
+            repeat_last=repeat_last,
+        )
+
+    def _poap_inventory_route(self, responses, repeat_last=True):
+        return self._send_route(
+            "GET", "/inventory/poap", responses, repeat_last=repeat_last
+        )
+
+    def _fabric_id_route(self, response):
+        return self._send_route(
+            "GET",
+            "/rest/control/fabrics/kharicha-fabric",
+            response,
+            match="endswith",
+        )
+
     def load_fixtures(self, response=None, device=""):
 
         if self.version == 12:
@@ -247,543 +322,802 @@ class TestDcnmInvModule(TestDcnmModule):
         }
 
         self.run_dcnm_ip_sn.side_effect = [self.rma_inv_data]
+        self._set_send_routes()
 
         if "get_have_failure" in self._testMethodName:
-            self.run_dcnm_send.side_effect = [
-                self.get_have_failure,
-            ]
-
-        elif "merge_switch" in self._testMethodName:
-            self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_inventory_initial_switch_success,
-                self.mock_inv_discover_params,
-                self.get_have_initial_success,
-                self.import_switch_discover_success,
-                self.get_inventory_initial_switch_success,
-                self.get_inventory_initial_switch_success,
-                self.rediscover_switch_success,
-                self.get_inventory_initial_switch_success,
-                self.get_inventory_initial_switch_success,
-                self.get_lan_switch_cred_success,
-                self.set_lan_switch_cred_success,
-                self.get_inventory_initial_switch_success,
-                self.set_assign_role_success,
-                self.get_fabric_id_success,
-                self.config_save_switch_success,
-                self.config_deploy_switch_success,
-            ]
+            self._set_send_routes(
+                self._inventory_route(self.get_have_failure, repeat_last=False)
+            )
 
         elif "merge_role_switch" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_inventory_initial_switch_success,
-                self.mock_inv_discover_params,
-                self.get_have_initial_success,
-                self.import_switch_discover_success,
-                self.get_inventory_initial_switch_success,
-                self.get_inventory_initial_switch_success,
-                self.rediscover_switch_success,
-                self.get_inventory_initial_switch_success,
-                self.get_inventory_initial_switch_success,
-                self.get_lan_switch_cred_success,
-                self.set_lan_switch_cred_success,
-                self.get_inventory_initial_switch_success,
-                self.set_assign_bg_role_success,
-                self.get_fabric_id_success,
-                self.config_save_switch_success,
-                self.config_deploy_switch_success,
-            ]
+            self._set_send_routes(
+                self._inventory_route(self.get_inventory_initial_switch_success),
+                self._send_route(
+                    "POST",
+                    "/inventory/discover?setAndUseDiscoveryCredForLan=true",
+                    self.import_switch_discover_success,
+                ),
+                self._send_route(
+                    "POST", "/inventory/rediscover/", self.rediscover_switch_success
+                ),
+                self._send_route(
+                    "GET",
+                    "getLanSwitchCredentials",
+                    self.get_lan_switch_cred_success,
+                ),
+                self._send_route(
+                    "POST",
+                    "saveSwitchCredentials",
+                    self.set_lan_switch_cred_success,
+                ),
+                self._send_route("PUT", "/topology/role/", self.set_assign_bg_role_success),
+                self._fabric_id_route(self.get_fabric_id_success),
+                self._send_route("POST", "/config-save", self.config_save_switch_success),
+                self._send_route(
+                    "POST", "/config-deploy/", self.config_deploy_switch_success
+                ),
+            )
 
         elif "merge_brownfield_switch" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_inventory_initial_switch_success,
-                self.mock_inv_discover_params,
-                self.get_have_initial_success,
-                self.import_switch_discover_success,
-                self.get_inventory_initial_switch_success,
-                self.rediscover_switch_success,
-                self.get_inventory_initial_switch_success,
-                self.get_inventory_initial_switch_success,
-                self.get_lan_switch_cred_success,
-                self.set_lan_switch_cred_success,
-                self.get_inventory_initial_switch_success,
-                self.set_assign_role_success,
-                self.get_fabric_id_success,
-                self.config_save_switch_success,
-                self.config_deploy_switch_success,
-            ]
-
-        elif "merge_multiple_switch" in self._testMethodName:
-            self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_have_initial_success,
-                self.mock_inv_discover109_params,
-                self.mock_inv_discover_params,
-                self.import_switch_discover_success,
-                self.import_switch_discover_success,
-                self.get_inventory_multiple_switch_success,
-                self.get_inventory_multiple_switch_success,
-                self.get_inventory_multiple_switch_success,
-                self.rediscover_switch_success,
-                self.rediscover_switch_success,
-                self.get_inventory_multiple_switch_success,
-                self.get_inventory_multiple_switch_success,
-                self.get_lan_multiple_new_switch_cred_success,
-                self.set_lan_switch_cred_success,
-                self.set_lan_switch_cred_success,
-                self.get_inventory_multiple_switch_success,
-                self.set_assign_role_success,
-                self.set_assign_role_success,
-                self.get_fabric_id_success,
-                self.config_save_switch_success,
-                self.config_deploy_switch_success,
-            ]
-
-        elif "merge_multiple_brownfield_switch" in self._testMethodName:
-            self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_have_initial_success,
-                self.mock_inv_discover_params,
-                self.mock_inv_discover107_params,
-                self.import_switch_discover_success,
-                self.import_switch_discover_success,
-                self.get_inventory_multiple_bf_switch_success,
-                self.get_inventory_multiple_bf_switch_success,
-                self.rediscover_switch_success,
-                self.rediscover_switch_success,
-                self.get_inventory_multiple_bf_switch_success,
-                self.get_inventory_multiple_bf_switch_success,
-                self.get_lan_multiple_new_bf_switch_cred_success,
-                self.set_lan_switch_cred_success,
-                self.set_lan_switch_cred_success,
-                self.get_inventory_multiple_bf_switch_success,
-                self.set_assign_role_success,
-                self.set_assign_role_success,
-                self.get_fabric_id_success,
-                self.config_save_switch_success,
-                self.config_deploy_switch_success,
-            ]
+            self._set_send_routes(
+                self._inventory_route(self.get_inventory_initial_switch_success),
+                self._send_route(
+                    "POST",
+                    "/inventory/discover?setAndUseDiscoveryCredForLan=true",
+                    self.import_switch_discover_success,
+                ),
+                self._send_route(
+                    "POST", "/inventory/rediscover/", self.rediscover_switch_success
+                ),
+                self._send_route(
+                    "GET",
+                    "getLanSwitchCredentials",
+                    self.get_lan_switch_cred_success,
+                ),
+                self._send_route(
+                    "POST",
+                    "saveSwitchCredentials",
+                    self.set_lan_switch_cred_success,
+                ),
+                self._send_route("PUT", "/topology/role/", self.set_assign_role_success),
+                self._fabric_id_route(self.get_fabric_id_success),
+                self._send_route("POST", "/config-save", self.config_save_switch_success),
+                self._send_route(
+                    "POST", "/config-deploy/", self.config_deploy_switch_success
+                ),
+            )
 
         elif "merge_multiple_dcnm12_brown_green_field_switch" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_have_initial_success,
-                self.mock_inv_discover_params,
-                self.mock_inv_discover107_params,
-                self.import_switch_discover_success,
-                self.import_switch_discover_success,
-                self.get_inventory_multiple_bf_gf_switch_success,
-                self.get_inventory_multiple_bf_gf_switch_success,
-                self.rediscover_switch107_success,
-                self.rediscover_switch_success,
-                self.get_inventory_multiple_bf_gf_switch_success,
-                self.get_inventory_multiple_bf_gf_switch_success,
-                self.get_lan_multiple_new_bf_switch_cred_success,
-                self.get_inventory_multiple_bf_gf_switch_success,
-                self.set_assign_role_success,
-                self.set_assign_role_success,
-                self.get_fabric_id_success,
-                self.config_save_switch_success,
-                self.config_deploy_switch_success,
-            ]
+            self._set_send_routes(
+                self._inventory_route(
+                    [
+                        self.get_have_initial_success,
+                        self.get_inventory_multiple_bf_gf_switch_success,
+                    ]
+                ),
+                self._send_route(
+                    "POST",
+                    "/inventory/test-reachability",
+                    [self.mock_inv_discover_params, self.mock_inv_discover107_params],
+                ),
+                self._send_route(
+                    "POST",
+                    "/inventory/discover?setAndUseDiscoveryCredForLan=true",
+                    [
+                        self.import_switch_discover_success,
+                        self.import_switch_discover_success,
+                    ],
+                ),
+                self._send_route(
+                    "POST",
+                    "/inventory/rediscover/",
+                    [self.rediscover_switch107_success, self.rediscover_switch_success],
+                ),
+                self._send_route(
+                    "GET",
+                    "getLanSwitchCredentials",
+                    self.get_lan_multiple_new_bf_switch_cred_success,
+                ),
+                self._send_route(
+                    "POST", "/rest/control/switches/roles", self.set_assign_role_success
+                ),
+                self._fabric_id_route(self.get_fabric_id_success),
+                self._send_route("POST", "/config-save", self.config_save_switch_success),
+                self._send_route(
+                    "POST", "/config-deploy/", self.config_deploy_switch_success
+                ),
+            )
 
         elif "merge_multiple_brown_green_field_switch" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_have_initial_success,
-                self.mock_inv_discover_params,
-                self.mock_inv_discover107_params,
-                self.import_switch_discover_success,
-                self.import_switch_discover_success,
-                self.get_inventory_multiple_bf_gf_switch_success,
-                self.get_inventory_multiple_bf_gf_switch_success,
-                self.rediscover_switch107_success,
-                self.rediscover_switch_success,
-                self.get_inventory_multiple_bf_gf_switch_success,
-                self.get_inventory_multiple_bf_gf_switch_success,
-                self.get_lan_multiple_new_bf_switch_cred_success,
-                self.set_lan_switch_cred_success,
-                self.set_lan_switch_cred_success,
-                self.get_inventory_multiple_bf_gf_switch_success,
-                self.set_assign_role_success,
-                self.set_assign_role_success,
-                self.get_fabric_id_success,
-                self.config_save_switch_success,
-                self.config_deploy_switch_success,
-            ]
+            self._set_send_routes(
+                self._inventory_route(
+                    [
+                        self.get_have_initial_success,
+                        self.get_inventory_multiple_bf_gf_switch_success,
+                    ]
+                ),
+                self._send_route(
+                    "POST",
+                    "/inventory/test-reachability",
+                    [self.mock_inv_discover_params, self.mock_inv_discover107_params],
+                ),
+                self._send_route(
+                    "POST",
+                    "/inventory/discover?setAndUseDiscoveryCredForLan=true",
+                    [
+                        self.import_switch_discover_success,
+                        self.import_switch_discover_success,
+                    ],
+                ),
+                self._send_route(
+                    "POST",
+                    "/inventory/rediscover/",
+                    [self.rediscover_switch107_success, self.rediscover_switch_success],
+                ),
+                self._send_route(
+                    "GET",
+                    "getLanSwitchCredentials",
+                    self.get_lan_multiple_new_bf_switch_cred_success,
+                ),
+                self._send_route(
+                    "POST",
+                    "saveSwitchCredentials",
+                    [
+                        self.set_lan_switch_cred_success,
+                        self.set_lan_switch_cred_success,
+                    ],
+                ),
+                self._send_route(
+                    "PUT",
+                    "/topology/role/",
+                    [self.set_assign_role_success, self.set_assign_role_success],
+                ),
+                self._fabric_id_route(self.get_fabric_id_success),
+                self._send_route("POST", "/config-save", self.config_save_switch_success),
+                self._send_route(
+                    "POST", "/config-deploy/", self.config_deploy_switch_success
+                ),
+            )
+
+        elif "merge_multiple_brownfield_switch" in self._testMethodName:
+            self.init_data()
+            self._set_send_routes(
+                self._inventory_route(
+                    [
+                        self.get_have_initial_success,
+                        self.get_inventory_multiple_bf_switch_success,
+                    ]
+                ),
+                self._send_route(
+                    "POST",
+                    "/inventory/test-reachability",
+                    [self.mock_inv_discover_params, self.mock_inv_discover107_params],
+                ),
+                self._send_route(
+                    "POST",
+                    "/inventory/discover?setAndUseDiscoveryCredForLan=true",
+                    self.import_switch_discover_success,
+                ),
+                self._send_route(
+                    "POST",
+                    "/inventory/rediscover/",
+                    [self.rediscover_switch_success, self.rediscover_switch_success],
+                ),
+                self._send_route(
+                    "GET",
+                    "getLanSwitchCredentials",
+                    self.get_lan_multiple_new_bf_switch_cred_success,
+                ),
+                self._send_route(
+                    "POST",
+                    "saveSwitchCredentials",
+                    [
+                        self.set_lan_switch_cred_success,
+                        self.set_lan_switch_cred_success,
+                    ],
+                ),
+                self._send_route(
+                    "PUT",
+                    "/topology/role/",
+                    [self.set_assign_role_success, self.set_assign_role_success],
+                ),
+                self._fabric_id_route(self.get_fabric_id_success),
+                self._send_route("POST", "/config-save", self.config_save_switch_success),
+                self._send_route(
+                    "POST", "/config-deploy/", self.config_deploy_switch_success
+                ),
+            )
+
+        elif "merge_multiple_switch" in self._testMethodName:
+            self.init_data()
+            self._set_send_routes(
+                self._inventory_route(
+                    [self.get_have_initial_success, self.get_inventory_multiple_switch_success]
+                ),
+                self._send_route(
+                    "POST",
+                    "/inventory/test-reachability",
+                    [self.mock_inv_discover109_params, self.mock_inv_discover_params],
+                ),
+                self._send_route(
+                    "POST",
+                    "/inventory/discover?setAndUseDiscoveryCredForLan=true",
+                    self.import_switch_discover_success,
+                ),
+                self._send_route(
+                    "POST",
+                    "/inventory/rediscover/",
+                    [self.rediscover_switch_success, self.rediscover_switch_success],
+                ),
+                self._send_route(
+                    "GET",
+                    "getLanSwitchCredentials",
+                    self.get_lan_multiple_new_switch_cred_success,
+                ),
+                self._send_route(
+                    "POST",
+                    "saveSwitchCredentials",
+                    [
+                        self.set_lan_switch_cred_success,
+                        self.set_lan_switch_cred_success,
+                    ],
+                ),
+                self._send_route(
+                    "PUT",
+                    "/topology/role/",
+                    [self.set_assign_role_success, self.set_assign_role_success],
+                ),
+                self._fabric_id_route(self.get_fabric_id_success),
+                self._send_route("POST", "/config-save", self.config_save_switch_success),
+                self._send_route(
+                    "POST", "/config-deploy/", self.config_deploy_switch_success
+                ),
+            )
+
+        elif "merge_switch" in self._testMethodName:
+            self.init_data()
+            self._set_send_routes(
+                self._inventory_route(self.get_inventory_initial_switch_success),
+                self._send_route(
+                    "POST",
+                    "/inventory/discover?setAndUseDiscoveryCredForLan=true",
+                    self.import_switch_discover_success,
+                ),
+                self._send_route(
+                    "POST", "/inventory/rediscover/", self.rediscover_switch_success
+                ),
+                self._send_route(
+                    "GET",
+                    "getLanSwitchCredentials",
+                    self.get_lan_switch_cred_success,
+                ),
+                self._send_route(
+                    "POST",
+                    "saveSwitchCredentials",
+                    self.set_lan_switch_cred_success,
+                ),
+                self._send_route("PUT", "/topology/role/", self.set_assign_role_success),
+                self._fabric_id_route(self.get_fabric_id_success),
+                self._send_route("POST", "/config-save", self.config_save_switch_success),
+                self._send_route(
+                    "POST", "/config-deploy/", self.config_deploy_switch_success
+                ),
+            )
 
         elif "delete_dcnm12_switch" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_have_one_switch_success,
-                self.delete_switch_success,
-            ]
+            self._set_send_routes(
+                self._inventory_route(self.get_have_one_switch_success, repeat_last=False),
+                self._send_route("DELETE", "/switches/", self.delete_switch_success),
+            )
 
         elif "delete_switch" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_have_one_switch_success,
-                self.delete_switch_success,
-            ]
+            self._set_send_routes(
+                self._inventory_route(self.get_have_one_switch_success, repeat_last=False),
+                self._send_route("DELETE", "/switches/", self.delete_switch_success),
+            )
 
         elif "delete_multiple_switch" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_have_multiple_switch_success,
-                self.delete_switch109_success,
-                self.delete_switch_success,
-            ]
+            self._set_send_routes(
+                self._inventory_route(
+                    self.get_have_multiple_switch_success, repeat_last=False
+                ),
+                self._send_route(
+                    "DELETE",
+                    "/switches/",
+                    [self.delete_switch109_success, self.delete_switch_success],
+                ),
+            )
 
         elif "delete_all_switch" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_have_null_config_switch_success,
-                self.delete_switch_success,
-            ]
+            self._set_send_routes(
+                self._inventory_route(
+                    self.get_have_null_config_switch_success, repeat_last=False
+                ),
+                self._send_route("DELETE", "/switches/", self.delete_switch_success),
+            )
 
         elif "query_dcnm12_switch" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_have_one_switch_success,
-                self.get_inventory_query_switch_success,
-            ]
+            self._set_send_routes(
+                self._inventory_route(
+                    [self.get_have_one_switch_success, self.get_inventory_query_switch_success],
+                    repeat_last=False,
+                )
+            )
 
         elif "query_switch" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_have_one_switch_success,
-                self.get_inventory_query_switch_success,
-            ]
+            self._set_send_routes(
+                self._inventory_route(
+                    [self.get_have_one_switch_success, self.get_inventory_query_switch_success],
+                    repeat_last=False,
+                )
+            )
 
         elif "query_no_switch" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_have_one_switch_success,
-                self.get_inventory_query_no_switch_success,
-            ]
+            self._set_send_routes(
+                self._inventory_route(
+                    [self.get_have_one_switch_success, self.get_inventory_query_no_switch_success],
+                    repeat_last=False,
+                )
+            )
 
         elif "override_switch" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_have_override_switch_success,
-                self.mock_inv_discover_params,
-                self.delete_switch107_success,
-                self.import_switch_discover_success,
-                self.get_inventory_override_switch_success,
-                self.get_inventory_initial_switch_success,
-                self.get_inventory_initial_switch_success,
-                self.rediscover_switch_success,
-                self.get_inventory_override_switch_success,
-                self.get_inventory_override_switch_success,
-                self.get_lan_switch_override_cred_success,
-                self.set_lan_switch_cred_success,
-                self.get_inventory_override_switch_success,
-                self.set_assign_role_success,
-                self.get_fabric_id_success,
-                self.config_save_switch_success,
-                self.config_deploy_switch_success,
-            ]
+            self._set_send_routes(
+                self._inventory_route(
+                    [
+                        self.get_have_override_switch_success,
+                        self.get_inventory_override_switch_success,
+                    ]
+                ),
+                self._send_route(
+                    "POST", "/inventory/test-reachability", self.mock_inv_discover_params
+                ),
+                self._send_route("DELETE", "/switches/", self.delete_switch107_success),
+                self._send_route(
+                    "POST",
+                    "/inventory/discover?setAndUseDiscoveryCredForLan=true",
+                    self.import_switch_discover_success,
+                ),
+                self._send_route(
+                    "POST", "/inventory/rediscover/", self.rediscover_switch_success
+                ),
+                self._send_route(
+                    "GET",
+                    "getLanSwitchCredentials",
+                    self.get_lan_switch_override_cred_success,
+                ),
+                self._send_route(
+                    "POST",
+                    "saveSwitchCredentials",
+                    self.set_lan_switch_cred_success,
+                ),
+                self._send_route("PUT", "/topology/role/", self.set_assign_role_success),
+                self._fabric_id_route(self.get_fabric_id_success),
+                self._send_route("POST", "/config-save", self.config_save_switch_success),
+                self._send_route(
+                    "POST", "/config-deploy/", self.config_deploy_switch_success
+                ),
+            )
 
         elif "migration_switch" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_have_migration_switch_success,
-                self.mock_inv_discover_params,
-                self.get_inventory_initial_switch_success,
-                self.set_assign_role_success,
-                self.get_inventory_initial_switch_success,
-                self.get_fabric_id_success,
-                self.config_save_switch_success,
-                self.config_deploy_switch_success,
-            ]
+            self._set_send_routes(
+                self._inventory_route(
+                    [
+                        self.get_have_migration_switch_success,
+                        self.get_inventory_initial_switch_success,
+                    ]
+                ),
+                self._send_route("PUT", "/topology/role/", self.set_assign_role_success),
+                self._fabric_id_route(self.get_fabric_id_success),
+                self._send_route("POST", "/config-save", self.config_save_switch_success),
+                self._send_route(
+                    "POST", "/config-deploy/", self.config_deploy_switch_success
+                ),
+            )
 
         elif "invalid_param_switch" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = []
 
         elif "have_initial_failure" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_have_initial_failure,
-            ]
+            self._set_send_routes(
+                self._inventory_route(self.get_have_initial_failure, repeat_last=False)
+            )
 
         elif "import_switch_discover_failure" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_have_initial_success,
-                self.mock_inv_discover_params,
-                self.import_switch_discover_failure,
-            ]
+            self._set_send_routes(
+                self._inventory_route(self.get_have_initial_success, repeat_last=False),
+                self._send_route(
+                    "POST", "/inventory/test-reachability", self.mock_inv_discover_params
+                ),
+                self._send_route(
+                    "POST",
+                    "/inventory/discover?setAndUseDiscoveryCredForLan=true",
+                    self.import_switch_discover_failure,
+                ),
+            )
 
         elif "get_inventory_initial_switch_failure" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_inventory_initial_switch_failure,
-                self.mock_inv_discover_params,
-                self.get_have_initial_success,
-                self.import_switch_discover_success,
-            ]
+            self._set_send_routes(
+                self._inventory_route(
+                    self.get_inventory_initial_switch_failure, repeat_last=False
+                )
+            )
 
         elif "rediscover_switch_failure" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_inventory_initial_switch_success,
-                self.mock_inv_discover_params,
-                self.get_have_initial_success,
-                self.import_switch_discover_success,
-                self.get_inventory_initial_switch_success,
-                self.get_inventory_initial_switch_success,
-                self.rediscover_switch_failure,
-            ]
+            self._set_send_routes(
+                self._inventory_route(self.get_inventory_initial_switch_success),
+                self._send_route(
+                    "POST",
+                    "/inventory/discover?setAndUseDiscoveryCredForLan=true",
+                    self.import_switch_discover_success,
+                ),
+                self._send_route(
+                    "POST", "/inventory/rediscover/", self.rediscover_switch_failure
+                ),
+            )
 
         elif "get_lan_switch_cred_failure" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_inventory_initial_switch_success,
-                self.mock_inv_discover_params,
-                self.get_have_initial_success,
-                self.import_switch_discover_success,
-                self.get_inventory_initial_switch_success,
-                self.get_inventory_initial_switch_success,
-                self.rediscover_switch_success,
-                self.get_inventory_initial_switch_success,
-                self.get_inventory_initial_switch_success,
-                self.get_lan_switch_cred_failure,
-            ]
+            self._set_send_routes(
+                self._inventory_route(self.get_inventory_initial_switch_success),
+                self._send_route(
+                    "POST",
+                    "/inventory/discover?setAndUseDiscoveryCredForLan=true",
+                    self.import_switch_discover_success,
+                ),
+                self._send_route(
+                    "POST", "/inventory/rediscover/", self.rediscover_switch_success
+                ),
+                self._send_route(
+                    "GET",
+                    "getLanSwitchCredentials",
+                    self.get_lan_switch_cred_failure,
+                ),
+            )
 
         elif "set_lan_switch_cred_failure" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_inventory_initial_switch_success,
-                self.mock_inv_discover_params,
-                self.get_have_initial_success,
-                self.import_switch_discover_success,
-                self.get_inventory_initial_switch_success,
-                self.get_inventory_initial_switch_success,
-                self.rediscover_switch_success,
-                self.get_inventory_initial_switch_success,
-                self.get_inventory_initial_switch_success,
-                self.get_lan_switch_cred_success,
-                self.set_lan_switch_cred_failure,
-            ]
+            self._set_send_routes(
+                self._inventory_route(self.get_inventory_initial_switch_success),
+                self._send_route(
+                    "POST",
+                    "/inventory/discover?setAndUseDiscoveryCredForLan=true",
+                    self.import_switch_discover_success,
+                ),
+                self._send_route(
+                    "POST", "/inventory/rediscover/", self.rediscover_switch_success
+                ),
+                self._send_route(
+                    "GET",
+                    "getLanSwitchCredentials",
+                    self.get_lan_switch_cred_success,
+                ),
+                self._send_route(
+                    "POST",
+                    "saveSwitchCredentials",
+                    self.set_lan_switch_cred_failure,
+                ),
+            )
 
         elif "set_assign_role_failure" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_inventory_initial_switch_success,
-                self.mock_inv_discover_params,
-                self.get_have_initial_success,
-                self.import_switch_discover_success,
-                self.get_inventory_initial_switch_success,
-                self.get_inventory_initial_switch_success,
-                self.rediscover_switch_success,
-                self.get_inventory_initial_switch_success,
-                self.get_inventory_initial_switch_success,
-                self.get_lan_switch_cred_success,
-                self.set_lan_switch_cred_success,
-                self.get_inventory_initial_switch_success,
-                self.set_assign_role_failure,
-            ]
+            self._set_send_routes(
+                self._inventory_route(self.get_inventory_initial_switch_success),
+                self._send_route(
+                    "POST",
+                    "/inventory/discover?setAndUseDiscoveryCredForLan=true",
+                    self.import_switch_discover_success,
+                ),
+                self._send_route(
+                    "POST", "/inventory/rediscover/", self.rediscover_switch_success
+                ),
+                self._send_route(
+                    "GET",
+                    "getLanSwitchCredentials",
+                    self.get_lan_switch_cred_success,
+                ),
+                self._send_route(
+                    "POST",
+                    "saveSwitchCredentials",
+                    self.set_lan_switch_cred_success,
+                ),
+                self._send_route("PUT", "/topology/role/", self.set_assign_role_failure),
+            )
 
         elif "get_fabric_id_failure" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.mock_inv_discover_params,
-                self.get_have_initial_success,
-                self.import_switch_discover_success,
-                self.get_inventory_initial_switch_success,
-                self.rediscover_switch_success,
-                self.get_inventory_initial_switch_success,
-                self.get_inventory_initial_switch_success,
-                self.get_lan_switch_cred_success,
-                self.set_lan_switch_cred_success,
-                self.get_inventory_initial_switch_success,
-                self.set_assign_role_success,
-                self.get_fabric_id_failure,
-            ]
+            self._set_send_routes(
+                self._inventory_route(self.get_inventory_initial_switch_success),
+                self._send_route(
+                    "POST",
+                    "/inventory/discover?setAndUseDiscoveryCredForLan=true",
+                    self.import_switch_discover_success,
+                ),
+                self._send_route(
+                    "POST", "/inventory/rediscover/", self.rediscover_switch_success
+                ),
+                self._send_route(
+                    "GET",
+                    "getLanSwitchCredentials",
+                    self.get_lan_switch_cred_success,
+                ),
+                self._send_route(
+                    "POST",
+                    "saveSwitchCredentials",
+                    self.set_lan_switch_cred_success,
+                ),
+                self._send_route("PUT", "/topology/role/", self.set_assign_role_success),
+                self._fabric_id_route(self.get_fabric_id_failure),
+            )
 
         elif "config_save_switch_failure" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_inventory_initial_switch_success,
-                self.mock_inv_discover_params,
-                self.get_have_initial_success,
-                self.import_switch_discover_success,
-                self.get_inventory_initial_switch_success,
-                self.get_inventory_initial_switch_success,
-                self.rediscover_switch_success,
-                self.get_inventory_initial_switch_success,
-                self.get_inventory_initial_switch_success,
-                self.get_lan_switch_cred_success,
-                self.set_lan_switch_cred_success,
-                self.get_inventory_initial_switch_success,
-                self.set_assign_role_success,
-                self.get_fabric_id_success,
-                self.config_save_switch_failure,
-            ]
+            self._set_send_routes(
+                self._inventory_route(self.get_inventory_initial_switch_success),
+                self._send_route(
+                    "POST",
+                    "/inventory/discover?setAndUseDiscoveryCredForLan=true",
+                    self.import_switch_discover_success,
+                ),
+                self._send_route(
+                    "POST", "/inventory/rediscover/", self.rediscover_switch_success
+                ),
+                self._send_route(
+                    "GET",
+                    "getLanSwitchCredentials",
+                    self.get_lan_switch_cred_success,
+                ),
+                self._send_route(
+                    "POST",
+                    "saveSwitchCredentials",
+                    self.set_lan_switch_cred_success,
+                ),
+                self._send_route("PUT", "/topology/role/", self.set_assign_role_success),
+                self._fabric_id_route(self.get_fabric_id_success),
+                self._send_route("POST", "/config-save", self.config_save_switch_failure),
+            )
 
         elif "config_deploy_switch_failure" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_inventory_initial_switch_success,
-                self.mock_inv_discover_params,
-                self.get_have_initial_success,
-                self.import_switch_discover_success,
-                self.get_inventory_initial_switch_success,
-                self.get_inventory_initial_switch_success,
-                self.rediscover_switch_success,
-                self.get_inventory_initial_switch_success,
-                self.get_inventory_initial_switch_success,
-                self.get_lan_switch_cred_success,
-                self.set_lan_switch_cred_success,
-                self.get_inventory_initial_switch_success,
-                self.set_assign_role_success,
-                self.get_fabric_id_success,
-                self.config_save_switch_success,
-                self.config_deploy_switch_failure,
-            ]
+            self._set_send_routes(
+                self._inventory_route(self.get_inventory_initial_switch_success),
+                self._send_route(
+                    "POST",
+                    "/inventory/discover?setAndUseDiscoveryCredForLan=true",
+                    self.import_switch_discover_success,
+                ),
+                self._send_route(
+                    "POST", "/inventory/rediscover/", self.rediscover_switch_success
+                ),
+                self._send_route(
+                    "GET",
+                    "getLanSwitchCredentials",
+                    self.get_lan_switch_cred_success,
+                ),
+                self._send_route(
+                    "POST",
+                    "saveSwitchCredentials",
+                    self.set_lan_switch_cred_success,
+                ),
+                self._send_route("PUT", "/topology/role/", self.set_assign_role_success),
+                self._fabric_id_route(self.get_fabric_id_success),
+                self._send_route("POST", "/config-save", self.config_save_switch_success),
+                self._send_route(
+                    "POST", "/config-deploy/", self.config_deploy_switch_failure
+                ),
+            )
 
         elif "invalid_remove_switch" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_have_one_switch_success,
-                self.invalid_remove_switch,
-            ]
+            self._set_send_routes(
+                self._inventory_route(self.get_have_one_switch_success, repeat_last=False),
+                self._send_route("DELETE", "/switches/", self.invalid_remove_switch),
+            )
 
         elif "blank_switch" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = []
 
         elif "already_created_switch" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_have_already_created_switch_success,
-                self.mock_inv_discover_params,
+            routes = [
+                self._inventory_route(
+                    self.get_have_already_created_switch_success, repeat_last=False
+                )
             ]
+            if "save_fast_path" in self._testMethodName:
+                routes.extend(
+                    [
+                        self._fabric_id_route(self.get_fabric_id_success),
+                        self._send_route(
+                            "POST", "/config-save", self.config_save_switch_success
+                        ),
+                    ]
+                )
+            self._set_send_routes(*routes)
 
         elif "already_deleted_switch" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = [self.get_inventory_blank_success]
+            self._set_send_routes(
+                self._inventory_route(self.get_inventory_blank_success, repeat_last=False)
+            )
 
         elif "query_poap_switch" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_have_one_switch_success,
-                self.get_inventory_query_poap_switch_success,
-                self.get_inventory_query_poap_success,
-            ]
+            self._set_send_routes(
+                self._inventory_route(
+                    [
+                        self.get_have_one_switch_success,
+                        self.get_inventory_query_poap_switch_success,
+                    ],
+                    repeat_last=False,
+                ),
+                self._poap_inventory_route(
+                    self.get_inventory_query_poap_success, repeat_last=False
+                ),
+            )
 
         elif "poap_dcnm12_switch" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_have_initial_success,
-                self.get_inventory_query_poap_success,
-                self.config_poap_switch_success,
-                self.get_inventory_poap_switch_success,
-                self.get_inventory_poap_switch_success,
-                self.rediscover_switch_success,
-                self.get_inventory_poap_switch_success,
-                self.get_inventory_poap_switch_success,
-                self.get_lan_switch_cred_success,
-                self.get_inventory_poap_switch_success,
-                self.set_assign_role_success,
-                self.get_fabric_id_success,
-                self.config_save_switch_success,
-                self.config_deploy_switch_success,
-            ]
-
-        elif "poap_switch" in self._testMethodName:
-            self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_have_initial_success,
-                self.get_inventory_query_poap_success,
-                self.config_poap_switch_success,
-                self.get_inventory_poap_switch_success,
-                self.get_inventory_poap_switch_success,
-                self.rediscover_switch_success,
-                self.get_inventory_poap_switch_success,
-                self.get_inventory_poap_switch_success,
-                self.get_lan_switch_cred_success,
-                self.get_inventory_poap_switch_success,
-                self.set_assign_role_success,
-                self.get_fabric_id_success,
-                self.config_save_switch_success,
-                self.config_deploy_switch_success,
-            ]
+            self._set_send_routes(
+                self._inventory_route(
+                    [self.get_have_initial_success, self.get_inventory_poap_switch_success]
+                ),
+                self._poap_inventory_route(
+                    self.get_inventory_query_poap_success, repeat_last=False
+                ),
+                self._send_route("POST", "/inventory/poap", self.config_poap_switch_success),
+                self._send_route(
+                    "POST", "/inventory/rediscover/", self.rediscover_switch_success
+                ),
+                self._send_route(
+                    "GET",
+                    "getLanSwitchCredentials",
+                    self.get_lan_switch_cred_success,
+                ),
+                self._send_route(
+                    "POST", "/rest/control/switches/roles", self.set_assign_role_success
+                ),
+                self._fabric_id_route(self.get_fabric_id_success),
+                self._send_route("POST", "/config-save", self.config_save_switch_success),
+                self._send_route(
+                    "POST", "/config-deploy/", self.config_deploy_switch_success
+                ),
+            )
 
         elif "poap_swap_switch" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_have_initial_success,
-                self.get_inventory_query_poap_success,
-                self.config_poap_switch_success,
-                self.get_inventory_query_poap_success,
-                self.config_poap_switch_success,
-                self.get_inventory_poap_switch_success,
-                self.get_inventory_poap_switch_success,
-                self.rediscover_switch_success,
-                self.get_inventory_poap_switch_success,
-                self.get_inventory_poap_switch_success,
-                self.get_lan_switch_cred_success,
-                self.get_inventory_poap_switch_success,
-                self.set_assign_role_success,
-                self.get_fabric_id_success,
-                self.config_save_switch_success,
-                self.config_deploy_switch_success,
-            ]
+            self._set_send_routes(
+                self._inventory_route(
+                    [self.get_have_initial_success, self.get_inventory_poap_switch_success]
+                ),
+                self._poap_inventory_route(
+                    [
+                        self.get_inventory_query_poap_success,
+                        self.get_inventory_query_poap_success,
+                    ],
+                    repeat_last=False,
+                ),
+                self._send_route("POST", "/swapSN/", self.config_poap_switch_success),
+                self._send_route("POST", "/inventory/poap", self.config_poap_switch_success),
+                self._send_route(
+                    "POST", "/inventory/rediscover/", self.rediscover_switch_success
+                ),
+                self._send_route(
+                    "GET",
+                    "getLanSwitchCredentials",
+                    self.get_lan_switch_cred_success,
+                ),
+                self._send_route(
+                    "POST", "/rest/control/switches/roles", self.set_assign_role_success
+                ),
+                self._fabric_id_route(self.get_fabric_id_success),
+                self._send_route("POST", "/config-save", self.config_save_switch_success),
+                self._send_route(
+                    "POST", "/config-deploy/", self.config_deploy_switch_success
+                ),
+            )
 
         elif "poap_role_switch" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_have_initial_success,
-                self.get_inventory_query_poap_success,
-                self.config_poap_switch_success,
-                self.get_inventory_poap_switch_success,
-                self.get_inventory_poap_switch_success,
-                self.rediscover_switch_success,
-                self.get_inventory_poap_switch_success,
-                self.get_inventory_poap_switch_success,
-                self.get_lan_switch_cred_success,
-                self.get_inventory_poap_switch_success,
-                self.set_assign_bg_role_success,
-                self.get_fabric_id_success,
-                self.config_save_switch_success,
-                self.config_deploy_switch_success,
-            ]
+            self._set_send_routes(
+                self._inventory_route(
+                    [self.get_have_initial_success, self.get_inventory_poap_switch_success]
+                ),
+                self._poap_inventory_route(
+                    self.get_inventory_query_poap_success, repeat_last=False
+                ),
+                self._send_route("POST", "/inventory/poap", self.config_poap_switch_success),
+                self._send_route(
+                    "POST", "/inventory/rediscover/", self.rediscover_switch_success
+                ),
+                self._send_route(
+                    "GET",
+                    "getLanSwitchCredentials",
+                    self.get_lan_switch_cred_success,
+                ),
+                self._send_route("PUT", "/topology/role/", self.set_assign_bg_role_success),
+                self._fabric_id_route(self.get_fabric_id_success),
+                self._send_route("POST", "/config-save", self.config_save_switch_success),
+                self._send_route(
+                    "POST", "/config-deploy/", self.config_deploy_switch_success
+                ),
+            )
 
-        elif "preprovision_switch" in self._testMethodName:
+        elif "poap_switch" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_have_initial_success,
-                self.config_poap_switch_success,
-                self.get_inventory_prepro_switch_success,
-                self.get_inventory_prepro_switch_success,
-                self.get_inventory_prepro_switch_success,
-                self.get_inventory_prepro_switch_success,
-                self.get_lan_switch_cred_success,
-                self.get_inventory_prepro_switch_success,
-                self.set_assign_role_success,
-                self.get_fabric_id_success,
-                self.config_save_switch_success,
-            ]
+            self._set_send_routes(
+                self._inventory_route(
+                    [self.get_have_initial_success, self.get_inventory_poap_switch_success]
+                ),
+                self._poap_inventory_route(
+                    self.get_inventory_query_poap_success, repeat_last=False
+                ),
+                self._send_route("POST", "/inventory/poap", self.config_poap_switch_success),
+                self._send_route(
+                    "POST", "/inventory/rediscover/", self.rediscover_switch_success
+                ),
+                self._send_route(
+                    "GET",
+                    "getLanSwitchCredentials",
+                    self.get_lan_switch_cred_success,
+                ),
+                self._send_route("PUT", "/topology/role/", self.set_assign_role_success),
+                self._fabric_id_route(self.get_fabric_id_success),
+                self._send_route("POST", "/config-save", self.config_save_switch_success),
+                self._send_route(
+                    "POST", "/config-deploy/", self.config_deploy_switch_success
+                ),
+            )
 
         elif "preprovision_role_switch" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_have_initial_success,
-                self.config_poap_switch_success,
-                self.get_inventory_prepro_switch_success,
-                self.get_inventory_prepro_switch_success,
-                self.get_inventory_prepro_switch_success,
-                self.get_inventory_prepro_switch_success,
-                self.get_lan_switch_cred_success,
-                self.get_inventory_prepro_switch_success,
-                self.set_assign_bg_role_success,
-                self.get_fabric_id_success,
-                self.config_save_switch_success,
-            ]
+            self._set_send_routes(
+                self._inventory_route(
+                    [self.get_have_initial_success, self.get_inventory_prepro_switch_success]
+                ),
+                self._send_route("POST", "/inventory/poap", self.config_poap_switch_success),
+                self._send_route(
+                    "GET",
+                    "getLanSwitchCredentials",
+                    self.get_lan_switch_cred_success,
+                ),
+                self._send_route("PUT", "/topology/role/", self.set_assign_bg_role_success),
+                self._fabric_id_route(self.get_fabric_id_success),
+                self._send_route("POST", "/config-save", self.config_save_switch_success),
+            )
+
+        elif "preprovision_switch" in self._testMethodName:
+            self.init_data()
+            self._set_send_routes(
+                self._inventory_route(
+                    [self.get_have_initial_success, self.get_inventory_prepro_switch_success]
+                ),
+                self._send_route("POST", "/inventory/poap", self.config_poap_switch_success),
+                self._send_route(
+                    "GET",
+                    "getLanSwitchCredentials",
+                    self.get_lan_switch_cred_success,
+                ),
+                self._send_route("PUT", "/topology/role/", self.set_assign_role_success),
+                self._fabric_id_route(self.get_fabric_id_success),
+                self._send_route("POST", "/config-save", self.config_save_switch_success),
+            )
 
         elif "poap_wrong_user_switch" in self._testMethodName:
             self.init_data()
@@ -814,40 +1148,66 @@ class TestDcnmInvModule(TestDcnmModule):
 
         elif "poap_idempotent_switch" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_inventory_merge_multi_type_switch_success,
-            ]
+            self._set_send_routes(
+                self._inventory_route(
+                    self.get_inventory_merge_multi_type_switch_success, repeat_last=False
+                )
+            )
 
         elif "prepro_idempotent_switch" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_inventory_merge_multi_type_switch_success,
-            ]
+            self._set_send_routes(
+                self._inventory_route(
+                    self.get_inventory_merge_multi_type_switch_success, repeat_last=False
+                )
+            )
 
         elif "merge_multi_type_switch" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_have_initial_success,
-                self.get_inventory_query_poap_success,
-                self.poap_inv_discover_params,
-                self.import_switch_discover_success,
-                self.config_poap_switch_success,
-                self.get_inventory_merge_multi_type_switch_success,
-                self.get_inventory_merge_multi_type_switch_success,
-                self.get_inventory_merge_multi_type_switch_success,
-                self.rediscover_switch_success,
-                self.rediscover_switch_success,
-                self.get_inventory_merge_multi_type_switch_success,
-                self.get_inventory_merge_multi_type_switch_success,
-                self.get_lan_switch_cred_success,
-                self.get_inventory_merge_multi_type_switch_success,
-                self.set_assign_bg_role_success,
-                self.set_assign_bg_role_success,
-                self.set_assign_bg_role_success,
-                self.get_fabric_id_success,
-                self.config_save_switch_success,
-                self.config_deploy_switch_success,
-            ]
+            self._set_send_routes(
+                self._inventory_route(
+                    [
+                        self.get_have_initial_success,
+                        self.get_inventory_merge_multi_type_switch_success,
+                    ]
+                ),
+                self._poap_inventory_route(
+                    self.get_inventory_query_poap_success, repeat_last=False
+                ),
+                self._send_route(
+                    "POST", "/inventory/test-reachability", self.poap_inv_discover_params
+                ),
+                self._send_route(
+                    "POST",
+                    "/inventory/discover?setAndUseDiscoveryCredForLan=true",
+                    self.import_switch_discover_success,
+                ),
+                self._send_route("POST", "/inventory/poap", self.config_poap_switch_success),
+                self._send_route(
+                    "POST",
+                    "/inventory/rediscover/",
+                    [self.rediscover_switch_success, self.rediscover_switch_success],
+                ),
+                self._send_route(
+                    "GET",
+                    "getLanSwitchCredentials",
+                    self.get_lan_switch_cred_success,
+                ),
+                self._send_route(
+                    "PUT",
+                    "/topology/role/",
+                    [
+                        self.set_assign_bg_role_success,
+                        self.set_assign_bg_role_success,
+                        self.set_assign_bg_role_success,
+                    ],
+                ),
+                self._fabric_id_route(self.get_fabric_id_success),
+                self._send_route("POST", "/config-save", self.config_save_switch_success),
+                self._send_route(
+                    "POST", "/config-deploy/", self.config_deploy_switch_success
+                ),
+            )
 
         elif "rma_no_ser_switch" in self._testMethodName:
             self.init_data()
@@ -857,24 +1217,28 @@ class TestDcnmInvModule(TestDcnmModule):
 
         elif "rma_switch" in self._testMethodName:
             self.init_data()
-            self.run_dcnm_send.side_effect = [
-                self.get_have_initial_success,
-                self.get_inventory_query_poap_success,
-                self.config_poap_switch_success,
-                self.get_inventory_poap_switch_success,
-                self.get_inventory_poap_switch_success,
-                self.rediscover_switch_success,
-                self.get_inventory_poap_switch_success,
-                self.get_inventory_poap_switch_success,
-                self.get_lan_switch_cred_success,
-                self.get_inventory_poap_switch_success,
-                self.get_fabric_id_success,
-                self.config_save_switch_success,
-                self.config_deploy_switch_success,
-            ]
-
-        else:
-            pass
+            self._set_send_routes(
+                self._inventory_route(
+                    [self.get_have_initial_success, self.get_inventory_poap_switch_success]
+                ),
+                self._poap_inventory_route(
+                    self.get_inventory_query_poap_success, repeat_last=False
+                ),
+                self._send_route("POST", "/rma", self.config_poap_switch_success),
+                self._send_route(
+                    "POST", "/inventory/rediscover/", self.rediscover_switch_success
+                ),
+                self._send_route(
+                    "GET",
+                    "getLanSwitchCredentials",
+                    self.get_lan_switch_cred_success,
+                ),
+                self._fabric_id_route(self.get_fabric_id_success),
+                self._send_route("POST", "/config-save", self.config_save_switch_success),
+                self._send_route(
+                    "POST", "/config-deploy/", self.config_deploy_switch_success
+                ),
+            )
 
     def test_dcnm_inv_merge_switch_fabric(self):
         set_module_args(
@@ -1222,6 +1586,8 @@ class TestDcnmInvModule(TestDcnmModule):
                 state="merged",
                 fabric="kharicha-fabric",
                 config=self.playbook_merge_switch_config,
+                save=False,
+                deploy=False,
             )
         )
         result = self.execute_module(changed=False, failed=False)
@@ -1229,6 +1595,19 @@ class TestDcnmInvModule(TestDcnmModule):
             result["response"],
             "The switch provided is already part of the fabric and cannot be created again",
         )
+
+    def test_dcnm_inv_already_created_switch_save_fast_path_fabric(self):
+        set_module_args(
+            dict(
+                state="merged",
+                fabric="kharicha-fabric",
+                config=self.playbook_merge_switch_config,
+            )
+        )
+        result = self.execute_module(changed=True, failed=False)
+        self.assertEqual(len(result["response"]), 1)
+        self.assertEqual(result["response"][0]["RETURN_CODE"], 200)
+        self.assertEqual(result["response"][0]["MESSAGE"], "OK")
 
     def test_dcnm_inv_already_deleted_switch_fabric(self):
         set_module_args(
@@ -1505,6 +1884,8 @@ class TestDcnmInvModule(TestDcnmModule):
                 state="merged",
                 fabric="kharicha-fabric",
                 config=self.playbook_poap_switch_config,
+                save=False,
+                deploy=False,
             )
         )
 
@@ -1521,6 +1902,8 @@ class TestDcnmInvModule(TestDcnmModule):
                 state="merged",
                 fabric="kharicha-fabric",
                 config=self.playbook_preprovision_switch_config,
+                save=False,
+                deploy=False,
             )
         )
 

--- a/tests/unit/modules/dcnm/test_dcnm_links.py
+++ b/tests/unit/modules/dcnm/test_dcnm_links.py
@@ -2503,7 +2503,7 @@ class TestDcnmLinksModule(TestDcnmModule):
         self.mock_hn_sn = self.payloads_data.get("mock_hn_sn")
         self.mock_fab_inv = self.payloads_data.get("mock_fab_inv_data")
         self.mock_unnum_fab_info = self.payloads_data.get(
-            "mock_umnum_fab_data"
+            "mock_unnum_fab_data"
         )
         self.mock_monitor_true_resp = self.payloads_data.get("mock_monitor_true_resp")
         self.mock_monitor_false_resp = self.payloads_data.get("mock_monitor_false_resp")

--- a/tests/unit/modules/dcnm/test_dcnm_network.py
+++ b/tests/unit/modules/dcnm/test_dcnm_network.py
@@ -914,7 +914,7 @@ class TestDcnmNetworkModule(TestDcnmModule):
 
         delete_paths = [
             args[2]
-            for args, _ in self.run_dcnm_send.call_args_list
+            for args, _kwargs in self.run_dcnm_send.call_args_list
             if len(args) >= 3 and args[1] == "DELETE"
         ]
         self.assertTrue(

--- a/tests/unit/modules/dcnm/test_dcnm_network.py
+++ b/tests/unit/modules/dcnm/test_dcnm_network.py
@@ -182,6 +182,37 @@ class TestDcnmNetworkModule(TestDcnmModule):
         dcnm_net.ip_sn = copy.deepcopy(ip_sn or self.mock_ip_sn)
         return dcnm_net
 
+    def test_dcnm_net_delete_switch_config_deploy_serials_are_dynamic(self):
+        dcnm_net = dcnm_network.DcnmNetwork.__new__(dcnm_network.DcnmNetwork)
+        dcnm_net.diff_detach = [
+            {
+                "networkName": "net-a",
+                "lanAttachList": [
+                    {"serialNumber": "SERIAL1"},
+                    {"serialNumber": "SERIAL2"},
+                ],
+            },
+            {
+                "networkName": "net-b",
+                "lanAttachList": [
+                    {"serialNumber": "SERIAL2"},
+                    {"serialNumber": "SERIAL3"},
+                ],
+            },
+            {
+                "networkName": "net-c",
+                "lanAttachList": [
+                    {"serialNumber": "SERIAL4"},
+                ],
+            },
+        ]
+
+        serials = dcnm_net.get_delete_deploy_switch_serials(
+            {"networkNames": "net-a,net-b"}
+        )
+
+        self.assertEqual(serials, ["SERIAL1", "SERIAL2", "SERIAL3"])
+
     def load_fixtures(self, response=None, device=""):
 
         if self.version == 12:
@@ -922,6 +953,27 @@ class TestDcnmNetworkModule(TestDcnmModule):
         self.assertTrue(
             any("/bulk-delete/networks?network-names=test_network" in path for path in delete_paths)
         )
+
+        config_deploy_calls = [
+            args
+            for args, _kwargs in self.run_dcnm_send.call_args_list
+            if len(args) >= 3 and args[1] == "POST" and "/config-deploy/" in args[2]
+        ]
+        self.assertEqual(len(config_deploy_calls), 1)
+        config_deploy_path = config_deploy_calls[0][2]
+        serial_segment = config_deploy_path.split("/config-deploy/")[1].split("?")[0]
+        self.assertEqual(
+            set(serial_segment.split(",")),
+            {"9NN7E41N16A", "9YO9A29F27U"},
+        )
+        self.assertEqual(len(config_deploy_calls[0]), 3)
+
+        switch_network_deploy_calls = [
+            args
+            for args, _kwargs in self.run_dcnm_send.call_args_list
+            if len(args) >= 3 and args[1] == "POST" and args[2].endswith("/networks/deploy")
+        ]
+        self.assertEqual(switch_network_deploy_calls, [])
 
     def test_dcnm_net_delete_without_config(self):
         set_module_args(dict(state="deleted", fabric="test_network", config=[]))

--- a/tests/unit/modules/dcnm/test_dcnm_network.py
+++ b/tests/unit/modules/dcnm/test_dcnm_network.py
@@ -241,6 +241,70 @@ class TestDcnmNetworkModule(TestDcnmModule):
             False,
         )
 
+    def test_dcnm_net_delete_attachment_wait_batches_pending_networks(self):
+        dcnm_net = dcnm_network.DcnmNetwork.__new__(dcnm_network.DcnmNetwork)
+        dcnm_net.log = self._build_test_logger()
+        dcnm_net.fabric = "test-fabric"
+        dcnm_net.fabric_type = "standalone"
+        dcnm_net.paths = {"GET_NET_ATTACH": "/attach/{}/{}"}
+        dcnm_net.module = Mock()
+        dcnm_net.WAIT_TIME_FOR_DELETE_LOOP = 5
+        dcnm_net.detach_and_deploy_for_del = Mock()
+
+        networks = [f"net-{index}" for index in range(31)]
+        dcnm_net.diff_delete = {network: "DEPLOYED" for network in networks}
+
+        self.run_dcnm_send.side_effect = [
+            {
+                "RETURN_CODE": 200,
+                "DATA": [
+                    {"networkName": network, "lanAttachList": []}
+                    for network in networks[:30]
+                ],
+            },
+            {
+                "RETURN_CODE": 200,
+                "DATA": [
+                    {"networkName": network, "lanAttachList": []}
+                    for network in networks[30:]
+                ],
+            },
+        ]
+
+        self.assertTrue(dcnm_net.wait_for_network_attachments_del_ready())
+
+        self.assertEqual(self.run_dcnm_send.call_count, 2)
+        paths = [call_args[0][2] for call_args in self.run_dcnm_send.call_args_list]
+        self.assertEqual(paths[0], "/attach/test-fabric/" + ",".join(networks[:30]))
+        self.assertEqual(paths[1], "/attach/test-fabric/" + networks[30])
+        self.assertEqual(set(dcnm_net.diff_delete.values()), {"NA"})
+        dcnm_net.detach_and_deploy_for_del.assert_not_called()
+
+    def test_dcnm_net_delete_attachment_wait_fails_on_unexpected_data(self):
+        dcnm_net = dcnm_network.DcnmNetwork.__new__(dcnm_network.DcnmNetwork)
+        dcnm_net.log = self._build_test_logger()
+        dcnm_net.fabric = "test-fabric"
+        dcnm_net.fabric_type = "standalone"
+        dcnm_net.paths = {"GET_NET_ATTACH": "/attach/{}/{}"}
+        dcnm_net.module = Mock()
+        dcnm_net.module.fail_json.side_effect = Exception("fail_json")
+        dcnm_net.WAIT_TIME_FOR_DELETE_LOOP = 5
+        dcnm_net.diff_delete = {"net-a": "DEPLOYED"}
+
+        self.run_dcnm_send.return_value = {
+            "RETURN_CODE": 414,
+            "DATA": "<html>URI Too Long</html>",
+        }
+
+        with self.assertRaises(Exception):
+            dcnm_net.wait_for_network_attachments_del_ready()
+
+        dcnm_net.module.fail_json.assert_called_once()
+        self.assertIn(
+            "Unexpected DATA while waiting for network attachments",
+            dcnm_net.module.fail_json.call_args[1]["msg"],
+        )
+
     def load_fixtures(self, response=None, device=""):
 
         if self.version == 12:

--- a/tests/unit/modules/dcnm/test_dcnm_network.py
+++ b/tests/unit/modules/dcnm/test_dcnm_network.py
@@ -67,7 +67,7 @@ class TestDcnmNetworkModule(TestDcnmModule):
         "mock_net_attach_object_del_not_ready"
     )
     mock_net_attach_object_del_ready = test_data.get("mock_net_attach_object_del_ready")
-
+    mock_net_del_ready = test_data.get("mock_net_del_ready")
     attach_success_resp = test_data.get("attach_success_resp")
     attach_success_resp2 = test_data.get("attach_success_resp2")
     deploy_success_resp = test_data.get("deploy_success_resp")
@@ -376,9 +376,10 @@ class TestDcnmNetworkModule(TestDcnmModule):
                 self.mock_net_object,
                 self.attach_success_resp,
                 self.deploy_success_resp,
-                self.mock_net_attach_object_del_not_ready,
-                self.mock_net_attach_object_del_ready,
-                self.delete_success_resp,
+                self.mock_net_attach_object_del_not_ready,  # wait_for_network_attachments_del_ready
+                self.mock_net_attach_object_del_ready,      # wait_for_network_attachments_del_ready
+                self.mock_net_del_ready,                     # wait_for_network_del_ready
+                self.delete_success_resp,                    # bulk_delete_networks_with_retry
                 self.blank_data,
                 self.attach_success_resp2,
                 self.deploy_success_resp,
@@ -392,9 +393,10 @@ class TestDcnmNetworkModule(TestDcnmModule):
                 self.mock_net_object,
                 self.attach_success_resp,
                 self.deploy_success_resp,
-                self.mock_net_attach_object_del_not_ready,
-                self.mock_net_attach_object_del_ready,
-                self.delete_success_resp,
+                self.mock_net_attach_object_del_not_ready,  # wait_for_network_attachments_del_ready
+                self.mock_net_attach_object_del_ready,      # wait_for_network_attachments_del_ready
+                self.mock_net_del_ready,                     # wait_for_network_del_ready
+                self.delete_success_resp,                    # bulk_delete_networks_with_retry
             ]
 
         elif "delete_without_config" in self._testMethodName:
@@ -406,10 +408,10 @@ class TestDcnmNetworkModule(TestDcnmModule):
                 self.blank_data,
                 self.attach_success_resp,
                 self.deploy_success_resp,
-                self.mock_net_attach_object_del_not_ready,
-                self.mock_net_attach_object_del_ready,
-                self.mock_net_attach_object_del_ready,
-                self.delete_success_resp,
+                self.mock_net_attach_object_del_not_ready,  # wait_for_network_attachments_del_ready
+                self.mock_net_attach_object_del_ready,      # wait_for_network_attachments_del_ready
+                self.mock_net_del_ready,                     # wait_for_network_del_ready
+                self.delete_success_resp,                    # bulk_delete_networks_with_retry
             ]
 
         elif "query_with_config" in self._testMethodName:

--- a/tests/unit/modules/dcnm/test_dcnm_network.py
+++ b/tests/unit/modules/dcnm/test_dcnm_network.py
@@ -21,6 +21,7 @@ from unittest.mock import Mock, patch
 
 # from units.compat.mock import patch
 
+from ansible_collections.cisco.dcnm.plugins.action import dcnm_network as dcnm_network_action
 from ansible_collections.cisco.dcnm.plugins.modules import dcnm_network
 from .dcnm_module import TestDcnmModule, set_module_args, loadPlaybookData
 
@@ -175,12 +176,249 @@ class TestDcnmNetworkModule(TestDcnmModule):
     def _build_test_logger():
         return type("Logger", (), {"debug": lambda *args, **kwargs: None})()
 
+    @staticmethod
+    def _build_secondary_ip_network_template(secondary_gw1="", secondary_gw2="", secondary_gw3="", secondary_gw4=""):
+        return {
+            "vlanId": 993,
+            "gatewayIpAddress": "10.250.93.1/24",
+            "isLayer2Only": False,
+            "tag": "",
+            "vlanName": "",
+            "intfDescription": "",
+            "mtu": "",
+            "suppressArp": False,
+            "dhcpServerAddr1": "",
+            "dhcpServerAddr2": "",
+            "dhcpServerAddr3": "",
+            "vrfDhcp": "",
+            "vrfDhcp2": "",
+            "vrfDhcp3": "",
+            "dhcpServers": "",
+            "loopbackId": "",
+            "mcastGroup": "",
+            "gatewayIpV6Address": "",
+            "secondaryGW1": secondary_gw1,
+            "secondaryGW2": secondary_gw2,
+            "secondaryGW3": secondary_gw3,
+            "secondaryGW4": secondary_gw4,
+            "trmEnabled": False,
+            "rtBothAuto": False,
+            "enableL3OnBorder": False,
+            "networkName": "sec-ip-test",
+        }
+
     def _build_diff_network(self, inventory_data, ip_sn=None):
         dcnm_net = dcnm_network.DcnmNetwork.__new__(dcnm_network.DcnmNetwork)
         dcnm_net.log = self._build_test_logger()
         dcnm_net.inventory_data = copy.deepcopy(inventory_data)
         dcnm_net.ip_sn = copy.deepcopy(ip_sn or self.mock_ip_sn)
         return dcnm_net
+
+    def _build_secondary_ip_update_network(self):
+        dcnm_net = dcnm_network.DcnmNetwork.__new__(dcnm_network.DcnmNetwork)
+        dcnm_net.module = Mock(params={"state": "merged"})
+        dcnm_net.is_ms_fabric = False
+        dcnm_net.fabric_type = "standalone"
+        dcnm_net.dcnm_version = 11
+        return dcnm_net
+
+    def _build_secondary_ip_update_payload(self, template_conf):
+        return {
+            "fabric": "test-fabric",
+            "vrf": "test-vrf",
+            "networkName": "sec-ip-test",
+            "displayName": "sec-ip-test",
+            "networkId": 50993,
+            "networkTemplate": "Default_Network_Universal",
+            "networkExtensionTemplate": "Default_Network_Extension_Universal",
+            "networkTemplateConfig": json.dumps(template_conf),
+        }
+
+    def test_dcnm_net_secondary_gws_template_config(self):
+        template_conf = self._build_secondary_ip_network_template(
+            secondary_gw1="192.166.88.1/24",
+            secondary_gw2="",
+            secondary_gw3=None,
+            secondary_gw4="192.169.88.1/24",
+        )
+
+        secondary_gws = json.loads(dcnm_network.DcnmNetwork.get_secondary_gws_template_config(template_conf))
+
+        self.assertEqual(
+            secondary_gws,
+            {
+                "secondaryGWs": [
+                    {"gatewayIpAddress": "192.166.88.1/24"},
+                    {"gatewayIpAddress": "192.169.88.1/24"},
+                ]
+            },
+        )
+
+    def test_dcnm_net_update_existing_network_adds_secondary_gws_payload(self):
+        dcnm_net = self._build_secondary_ip_update_network()
+        have = self._build_secondary_ip_update_payload(self._build_secondary_ip_network_template())
+        want = self._build_secondary_ip_update_payload(
+            self._build_secondary_ip_network_template(
+                secondary_gw1="192.166.88.1/24",
+                secondary_gw2="192.167.88.1/24",
+            )
+        )
+
+        dcnm_net.dcnm_update_network_information(
+            want,
+            have,
+            {
+                "secondary_ip_gw1": "192.166.88.1/24",
+                "secondary_ip_gw2": "192.167.88.1/24",
+            },
+        )
+
+        updated_template = json.loads(want["networkTemplateConfig"])
+        self.assertEqual(updated_template["secondaryGW1"], "192.166.88.1/24")
+        self.assertEqual(updated_template["secondaryGW2"], "192.167.88.1/24")
+        self.assertEqual(
+            json.loads(updated_template["secondaryGWs"]),
+            {
+                "secondaryGWs": [
+                    {"gatewayIpAddress": "192.166.88.1/24"},
+                    {"gatewayIpAddress": "192.167.88.1/24"},
+                ]
+            },
+        )
+
+    def test_dcnm_net_update_existing_network_clears_last_secondary_gw_payload(self):
+        dcnm_net = self._build_secondary_ip_update_network()
+        have = self._build_secondary_ip_update_payload(
+            self._build_secondary_ip_network_template(secondary_gw1="192.166.88.1/24")
+        )
+        want = self._build_secondary_ip_update_payload(self._build_secondary_ip_network_template())
+
+        dcnm_net.dcnm_update_network_information(want, have, {"secondary_ip_gw1": ""})
+
+        updated_template = json.loads(want["networkTemplateConfig"])
+        self.assertEqual(updated_template["secondaryGW1"], "")
+        self.assertEqual(json.loads(updated_template["secondaryGWs"]), {"secondaryGWs": []})
+
+    def test_dcnm_net_update_existing_network_clears_trailing_explicit_secondary_gw_payload(self):
+        dcnm_net = self._build_secondary_ip_update_network()
+        have = self._build_secondary_ip_update_payload(
+            self._build_secondary_ip_network_template(
+                secondary_gw1="192.166.88.1/24",
+                secondary_gw2="192.167.88.1/24",
+            )
+        )
+        want = self._build_secondary_ip_update_payload(self._build_secondary_ip_network_template())
+
+        dcnm_net.dcnm_update_network_information(want, have, {"secondary_ip_gw2": ""})
+
+        updated_template = json.loads(want["networkTemplateConfig"])
+        self.assertEqual(updated_template["secondaryGW1"], "192.166.88.1/24")
+        self.assertEqual(updated_template["secondaryGW2"], "")
+        self.assertEqual(
+            json.loads(updated_template["secondaryGWs"]),
+            {
+                "secondaryGWs": [
+                    {"gatewayIpAddress": "192.166.88.1/24"},
+                ]
+            },
+        )
+
+    def test_dcnm_net_update_existing_network_rejects_ambiguous_merged_secondary_gw_clear(self):
+        dcnm_net = self._build_secondary_ip_update_network()
+        dcnm_net.module.fail_json.side_effect = RuntimeError("fail_json called")
+        have = self._build_secondary_ip_update_payload(
+            self._build_secondary_ip_network_template(
+                secondary_gw1="192.166.88.1/24",
+                secondary_gw2="192.167.88.1/24",
+                secondary_gw3="192.168.88.1/24",
+            )
+        )
+        want = self._build_secondary_ip_update_payload(self._build_secondary_ip_network_template())
+
+        with self.assertRaises(RuntimeError):
+            dcnm_net.dcnm_update_network_information(want, have, {"secondary_ip_gw2": ""})
+
+        fail_msg = dcnm_net.module.fail_json.call_args[1]["msg"]
+        self.assertIn("cannot clear secondary_ip_gw2", fail_msg)
+        self.assertIn("compact list", fail_msg)
+
+    def test_dcnm_net_split_msd_merged_keeps_secondary_gws_parent_only(self):
+        action = dcnm_network_action.ActionModule.__new__(dcnm_network_action.ActionModule)
+        fabrics = {
+            "msd-parent": {
+                "type": "multisite_parent",
+                "fabricParent": "None",
+                "cluster_name": "",
+            },
+            "msd-child-1": {
+                "type": "multisite_child",
+                "fabricParent": "msd-parent",
+                "cluster_name": "",
+            },
+        }
+        config = [
+            {
+                "net_name": "ansible-msd-net1",
+                "vrf_name": "Tenant-1",
+                "is_l2only": False,
+                "secondary_ip_gw1": "192.166.88.1/24",
+                "secondary_ip_gw2": "",
+                "child_fabric_config": [
+                    {
+                        "fabric": "msd-child-1",
+                        "dhcp_loopback_id": 204,
+                    }
+                ],
+            }
+        ]
+
+        configs, error_msg = action._split_config(fabrics, "msd-parent", config, "merged", {}, 12)
+
+        self.assertIsNone(error_msg)
+        self.assertEqual(configs[0]["config"][0]["secondary_ip_gw1"], "192.166.88.1/24")
+        self.assertEqual(configs[0]["config"][0]["secondary_ip_gw2"], "")
+        child_config = configs[1]["config"][0]
+        self.assertNotIn("secondary_ip_gw1", child_config)
+        self.assertNotIn("secondary_ip_gw2", child_config)
+        self.assertEqual(child_config["dhcp_loopback_id"], 204)
+
+    def test_dcnm_net_split_msd_replaced_sends_full_secondary_gw_intent_to_child(self):
+        action = dcnm_network_action.ActionModule.__new__(dcnm_network_action.ActionModule)
+        fabrics = {
+            "msd-parent": {
+                "type": "multisite_parent",
+                "fabricParent": "None",
+                "cluster_name": "",
+            },
+            "msd-child-1": {
+                "type": "multisite_child",
+                "fabricParent": "msd-parent",
+                "cluster_name": "",
+            },
+        }
+        config = [
+            {
+                "net_name": "ansible-msd-net1",
+                "vrf_name": "Tenant-1",
+                "is_l2only": False,
+                "secondary_ip_gw1": "192.166.88.1/24",
+                "child_fabric_config": [
+                    {
+                        "fabric": "msd-child-1",
+                        "dhcp_loopback_id": 204,
+                    }
+                ],
+            }
+        ]
+
+        configs, error_msg = action._split_config(fabrics, "msd-parent", config, "replaced", {}, 12)
+
+        self.assertIsNone(error_msg)
+        child_config = configs[1]["config"][0]
+        self.assertEqual(child_config["secondary_ip_gw1"], "192.166.88.1/24")
+        self.assertEqual(child_config["secondary_ip_gw2"], "")
+        self.assertEqual(child_config["secondary_ip_gw3"], "")
+        self.assertEqual(child_config["secondary_ip_gw4"], "")
 
     def test_dcnm_net_delete_switch_config_deploy_serials_are_dynamic(self):
         dcnm_net = dcnm_network.DcnmNetwork.__new__(dcnm_network.DcnmNetwork)
@@ -228,6 +466,9 @@ class TestDcnmNetworkModule(TestDcnmModule):
         dcnm_net.diff_create = []
         dcnm_net.diff_attach = []
         dcnm_net.diff_deploy = {}
+        dcnm_net.network_sn_attach_map = {}
+        dcnm_net.network_sn_detach_map = {}
+        dcnm_net.have_attach_by_name = {}
         dcnm_net.wait_for_network_attachments_del_ready = Mock(return_value=True)
         dcnm_net.wait_for_network_del_ready = Mock(return_value=True)
         dcnm_net.bulk_delete_networks_with_retry = Mock()
@@ -647,12 +888,10 @@ class TestDcnmNetworkModule(TestDcnmModule):
                 self.empty_network_list,
                 self.mock_msd_net_create_response,
                 self.mock_msd_net_attach_response,
-                self.deploy_success_resp,
                 self.mock_msd_vrf_object,
                 self.mock_msd_child_net_object,
                 self.mock_msd_child_net_attach_object,
                 self.mock_msd_child_net_update_response,
-                self.deploy_success_resp,
             ]
 
         elif "_merged_msd_dhcp" in self._testMethodName:
@@ -671,12 +910,10 @@ class TestDcnmNetworkModule(TestDcnmModule):
                 self.empty_network_list,
                 self.mock_msd_dhcp_net_create_response,
                 self.mock_msd_dhcp_net_attach_response,
-                self.deploy_success_resp,
                 self.mock_msd_vrf_object,
                 self.mock_msd_dhcp_child_net_object,
                 self.mock_msd_dhcp_child_net_attach_object,
                 self.mock_msd_dhcp_child_net_update_response,
-                self.deploy_success_resp,
             ]
 
         elif "_msd_override_with_different_attachments" in self._testMethodName:
@@ -695,7 +932,6 @@ class TestDcnmNetworkModule(TestDcnmModule):
                 self.empty_network_list,
                 self.mock_msd_override_parent_net_object,
                 self.mock_msd_override_attach_response,
-                self.deploy_success_resp,
                 self.mock_msd_vrf_object,
                 self.mock_msd_override_child_net_object,
                 self.mock_msd_override_child_net_attach_object,
@@ -1594,9 +1830,9 @@ class TestDcnmNetworkModule(TestDcnmModule):
         self.assertTrue(parent_diff["attach"][0]["deploy"])
         self.assertTrue(parent_diff["attach"][1]["deploy"])
 
-        # Verify parent fabric response (create, attach, deploy)
+        # Verify parent fabric response (create, attach); deploy is aggregated separately
         parent_response = parent.get("response")
-        self.assertEqual(len(parent_response), 3)
+        self.assertEqual(len(parent_response), 2)
 
         # Verify create response
         self.assertEqual(parent_response[0]["RETURN_CODE"], 200)
@@ -1611,8 +1847,9 @@ class TestDcnmNetworkModule(TestDcnmModule):
         self.assertIn("ansible-msd-net1", str(parent_response[1]["DATA"]))
 
         # Verify deploy response
-        self.assertEqual(parent_response[2]["RETURN_CODE"], 200)
-        self.assertEqual(parent_response[2]["METHOD"], "POST")
+        self.assertIn("deployment", parent)
+        self.assertEqual(parent["deployment"]["RETURN_CODE"], 200)
+        self.assertEqual(parent["deployment"]["METHOD"], "POST")
 
         # Verify child fabrics section
         child_fabrics = result.get("child_fabrics")
@@ -1710,13 +1947,15 @@ class TestDcnmNetworkModule(TestDcnmModule):
         self.assertEqual(parent_diff["attach"][0]["ip_address"], "192.168.10.203")
         self.assertEqual(parent_diff["attach"][1]["ip_address"], "192.168.10.204")
 
-        # Verify parent fabric response
+        # Verify parent fabric response; deploy is aggregated separately
         parent_response = parent.get("response")
-        self.assertEqual(len(parent_response), 3)
+        self.assertEqual(len(parent_response), 2)
         self.assertEqual(parent_response[0]["DATA"]["Network Id"], 8004)
         self.assertEqual(parent_response[0]["DATA"]["Network Name"], "ansible-msd-dhcp-net")
         self.assertIn("9R518K2AT3R", str(parent_response[1]["DATA"]))
         self.assertIn("915KQ8P3NS8", str(parent_response[1]["DATA"]))
+        self.assertIn("deployment", parent)
+        self.assertEqual(parent["deployment"]["RETURN_CODE"], 200)
 
         # Verify child fabrics section
         child_fabrics = result.get("child_fabrics")
@@ -1817,9 +2056,9 @@ class TestDcnmNetworkModule(TestDcnmModule):
         self.assertEqual(attach2["ports"], "Ethernet1/16,Ethernet1/17")
         self.assertTrue(attach2["deploy"])
 
-        # Verify parent fabric response includes attachment update and deploy
+        # Verify parent fabric response includes attachment update; deploy is aggregated separately
         parent_response = parent.get("response")
-        self.assertEqual(len(parent_response), 3)
+        self.assertEqual(len(parent_response), 2)
 
         # Verify attachment update response (index 1)
         attach_resp = parent_response[1]
@@ -1830,8 +2069,9 @@ class TestDcnmNetworkModule(TestDcnmModule):
         self.assertIn("ansible-msd-dhcp-net-[915KQ8P3NS8/leaf4]", attach_resp["DATA"])
         self.assertEqual(attach_resp["DATA"]["ansible-msd-dhcp-net-[915KQ8P3NS8/leaf4]"], "SUCCESS")
 
-        # Verify deploy response (index 2)
-        deploy_resp = parent_response[2]
+        # Verify deploy response
+        self.assertIn("deployment", parent)
+        deploy_resp = parent["deployment"]
         self.assertEqual(deploy_resp["RETURN_CODE"], 200)
         self.assertEqual(deploy_resp["METHOD"], "POST")
         self.assertIn("status", deploy_resp["DATA"])

--- a/tests/unit/modules/dcnm/test_dcnm_network.py
+++ b/tests/unit/modules/dcnm/test_dcnm_network.py
@@ -378,7 +378,6 @@ class TestDcnmNetworkModule(TestDcnmModule):
                 self.deploy_success_resp,
                 self.mock_net_attach_object_del_not_ready,
                 self.mock_net_attach_object_del_ready,
-                self.mock_net_attach_object_del_ready,
                 self.delete_success_resp,
                 self.blank_data,
                 self.attach_success_resp2,
@@ -391,11 +390,9 @@ class TestDcnmNetworkModule(TestDcnmModule):
             self.run_dcnm_send.side_effect = [
                 self.mock_vrf_object,
                 self.mock_net_object,
-                self.blank_data,
                 self.attach_success_resp,
                 self.deploy_success_resp,
                 self.mock_net_attach_object_del_not_ready,
-                self.mock_net_attach_object_del_ready,
                 self.mock_net_attach_object_del_ready,
                 self.delete_success_resp,
             ]

--- a/tests/unit/modules/dcnm/test_dcnm_network.py
+++ b/tests/unit/modules/dcnm/test_dcnm_network.py
@@ -758,6 +758,29 @@ class TestDcnmNetworkModule(TestDcnmModule):
         self.assertEqual(result["response"][1]["DATA"]["status"], "")
         self.assertEqual(result["response"][1]["RETURN_CODE"], self.SUCCESS_RETURN_CODE)
 
+    def test_dcnm_net_replace_with_changes_bulk_inventory(self):
+        set_module_args(
+            dict(
+                state="replaced",
+                fabric="test_network",
+                config=self.playbook_config_replace,
+            )
+        )
+        with patch.object(dcnm_network.DcnmNetwork, "BULK_GET_HAVE_NETWORK_THRESHOLD", 1):
+            result = self.execute_module(changed=True, failed=False, use_action_plugin=True)
+
+        request_calls = [(call.args[1], call.args[2]) for call in self.run_dcnm_send.call_args_list]
+        get_net_path = dcnm_network.DcnmNetwork.dcnm_network_paths[self.version]["GET_NET"].format("test_network")
+        get_net_name_path = dcnm_network.DcnmNetwork.dcnm_network_paths[self.version]["GET_NET_NAME"].format(
+            "test_network", "test_network"
+        )
+
+        self.assertIn(("GET", get_net_path), request_calls)
+        self.assertNotIn(("GET", get_net_name_path), request_calls)
+        self.assertEqual(result.get("diff")[0]["vlan_id"], 203)
+        self.assertTrue(result.get("diff")[0]["attach"][0]["deploy"])
+        self.assertFalse(result.get("diff")[0]["attach"][1]["deploy"])
+
     def test_dcnm_net_replace_with_no_atch(self):
         set_module_args(
             dict(
@@ -888,6 +911,15 @@ class TestDcnmNetworkModule(TestDcnmModule):
         )
         self.assertEqual(result["response"][1]["DATA"]["status"], "")
         self.assertEqual(result["response"][1]["RETURN_CODE"], self.SUCCESS_RETURN_CODE)
+
+        delete_paths = [
+            args[2]
+            for args, _ in self.run_dcnm_send.call_args_list
+            if len(args) >= 3 and args[1] == "DELETE"
+        ]
+        self.assertTrue(
+            any("/bulk-delete/networks?network-names=test_network" in path for path in delete_paths)
+        )
 
     def test_dcnm_net_delete_without_config(self):
         set_module_args(dict(state="deleted", fabric="test_network", config=[]))

--- a/tests/unit/modules/dcnm/test_dcnm_network.py
+++ b/tests/unit/modules/dcnm/test_dcnm_network.py
@@ -42,6 +42,7 @@ class TestDcnmNetworkModule(TestDcnmModule):
     nd_version_11 = test_data.get("nd_version_11")
     mock_ip_sn = test_data.get("mock_ip_sn")
     net_inv_data = test_data.get("net_inv_data")
+    net_inv_data_vpc_tor = test_data.get("net_inv_data_vpc_tor")
     fabric_details = test_data.get("fabric_details")
     fabric_details_vxlan_fabric = test_data.get("fabric_details_vxlan_fabric")
     fabric_associations = test_data.get("fabric_associations")
@@ -56,6 +57,8 @@ class TestDcnmNetworkModule(TestDcnmModule):
     playbook_tor_roleerr_config = test_data.get("playbook_tor_roleerr_config")
     playbook_tor_config_update = test_data.get("playbook_tor_config_update")
     playbook_tor_only_config_update = test_data.get("playbook_tor_only_config_update")
+    playbook_tor_vpc_one_sided_config = test_data.get("playbook_tor_vpc_one_sided_config")
+    playbook_tor_vpc_one_sided_update = test_data.get("playbook_tor_vpc_one_sided_update")
 
     playbook_config_replace = test_data.get("playbook_config_replace")
     playbook_config_replace_no_atch = test_data.get("playbook_config_replace_no_atch")
@@ -121,6 +124,9 @@ class TestDcnmNetworkModule(TestDcnmModule):
         self.mock_net_attach_tor_only_object = copy.deepcopy(
             self.test_data.get("mock_net_attach_tor_only_object")
         )
+        self.mock_net_attach_tor_vpc_object = copy.deepcopy(
+            self.test_data.get("mock_net_attach_tor_vpc_object")
+        )
 
     def setUp(self):
         super(TestDcnmNetworkModule, self).setUp()
@@ -151,6 +157,30 @@ class TestDcnmNetworkModule(TestDcnmModule):
         self.mock_dcnm_ip_sn.stop()
         self.mock_dcnm_fabric_details.stop()
         self.mock_dcnm_get_url.stop()
+
+    @staticmethod
+    def _build_attach_state(serial, switch_ports, torports=None, vlan=202):
+        return {
+            "serialNumber": serial,
+            "networkName": "test_network",
+            "switchPorts": switch_ports,
+            "isAttached": True,
+            "deployment": True,
+            "is_deploy": True,
+            "vlan": vlan,
+            "torports": copy.deepcopy(torports or []),
+        }
+
+    @staticmethod
+    def _build_test_logger():
+        return type("Logger", (), {"debug": lambda *args, **kwargs: None})()
+
+    def _build_diff_network(self, inventory_data, ip_sn=None):
+        dcnm_net = dcnm_network.DcnmNetwork.__new__(dcnm_network.DcnmNetwork)
+        dcnm_net.log = self._build_test_logger()
+        dcnm_net.inventory_data = copy.deepcopy(inventory_data)
+        dcnm_net.ip_sn = copy.deepcopy(ip_sn or self.mock_ip_sn)
+        return dcnm_net
 
     def load_fixtures(self, response=None, device=""):
 
@@ -437,6 +467,18 @@ class TestDcnmNetworkModule(TestDcnmModule):
         elif "_merged_tor_only_with_update" in self._testMethodName:
             self.init_data()
             self.run_dcnm_get_url.side_effect = [self.mock_net_attach_tor_only_object]
+            self.run_dcnm_send.side_effect = [
+                self.mock_vrf_object,
+                self.mock_net_object,
+                self.blank_data,
+                self.attach_success_resp,
+                self.deploy_success_resp,
+            ]
+
+        elif "_merged_tor_vpc_one_sided_with_update" in self._testMethodName:
+            self.init_data()
+            self.run_dcnm_ip_sn.side_effect = [self.net_inv_data_vpc_tor]
+            self.run_dcnm_get_url.side_effect = [self.mock_net_attach_tor_vpc_object]
             self.run_dcnm_send.side_effect = [
                 self.mock_vrf_object,
                 self.mock_net_object,
@@ -989,6 +1031,297 @@ class TestDcnmNetworkModule(TestDcnmModule):
             attach_by_ip["10.10.10.217"]["tor_ports"],
         )
         self.assertEqual(result.get("diff")[0]["net_name"], "test_network")
+
+    def test_dcnm_net_merged_tor_vpc_idempotent(self):
+        dcnm_net = dcnm_network.DcnmNetwork.__new__(dcnm_network.DcnmNetwork)
+        dcnm_net.log = type("Logger", (), {"debug": lambda *args, **kwargs: None})()
+        dcnm_net.inventory_data = copy.deepcopy(self.net_inv_data_vpc_tor)
+        dcnm_net.ip_sn = copy.deepcopy(self.mock_ip_sn)
+
+        have_attach = [
+            {
+                "serialNumber": "9YO9A29F27U",
+                "networkName": "test_network",
+                "switchPorts": "Ethernet1/13,Ethernet1/14",
+                "isAttached": True,
+                "deployment": True,
+                "is_deploy": True,
+                "vlan": 202,
+                "torports": [
+                    {"switch": "dt-n9k6", "torPorts": "Ethernet1/12"},
+                    {"switch": "dt-n9k7", "torPorts": "Ethernet1/12"},
+                ],
+            },
+            {
+                "serialNumber": "9NN7E41N16A",
+                "networkName": "test_network",
+                "switchPorts": "Ethernet1/13,Ethernet1/14",
+                "isAttached": True,
+                "deployment": True,
+                "is_deploy": True,
+                "vlan": 202,
+                "torports": [
+                    {"switch": "dt-n9k6", "torPorts": "Ethernet1/12"},
+                    {"switch": "dt-n9k7", "torPorts": "Ethernet1/12"},
+                ],
+            },
+        ]
+        want_attach = copy.deepcopy(have_attach)
+
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach))
+
+        self.assertFalse(diff)
+        self.assertFalse(dep_net)
+
+    def test_dcnm_net_merged_tor_vpc_one_sided_with_update(self):
+        self.version = 12
+        set_module_args(
+            dict(
+                state="merged",
+                fabric="test_network",
+                config=self.playbook_tor_vpc_one_sided_update,
+            )
+        )
+        result = self.execute_module(changed=True, failed=False, use_action_plugin=True)
+        self.version = 11
+
+        attach_by_ip = {
+            attach["ip_address"]: attach for attach in result.get("diff")[0]["attach"]
+        }
+        self.assertIn("10.10.10.217", attach_by_ip)
+        self.assertIn("10.10.10.218", attach_by_ip)
+        self.assertIn("dt-n9k6(Ethernet1/13,Ethernet1/14,Ethernet1/12)", attach_by_ip["10.10.10.217"]["tor_ports"])
+        self.assertIn("dt-n9k7(Ethernet1/13,Ethernet1/14,Ethernet1/12)", attach_by_ip["10.10.10.217"]["tor_ports"])
+        self.assertIn("dt-n9k6(Ethernet1/13,Ethernet1/14,Ethernet1/12)", attach_by_ip["10.10.10.218"]["tor_ports"])
+        self.assertIn("dt-n9k7(Ethernet1/13,Ethernet1/14,Ethernet1/12)", attach_by_ip["10.10.10.218"]["tor_ports"])
+
+    def test_dcnm_net_replace_tor_vpc_one_sided_idempotent(self):
+        dcnm_net = dcnm_network.DcnmNetwork.__new__(dcnm_network.DcnmNetwork)
+        dcnm_net.log = type("Logger", (), {"debug": lambda *args, **kwargs: None})()
+        dcnm_net.inventory_data = copy.deepcopy(self.net_inv_data_vpc_tor)
+        dcnm_net.ip_sn = copy.deepcopy(self.mock_ip_sn)
+
+        want_attach = [
+            {
+                "serialNumber": "9NN7E41N16A",
+                "networkName": "test_network",
+                "switchPorts": "Ethernet1/13,Ethernet1/14",
+                "isAttached": True,
+                "deployment": True,
+                "is_deploy": True,
+                "torports": [],
+            },
+            {
+                "serialNumber": "9YO9A29F27U",
+                "networkName": "test_network",
+                "switchPorts": "Ethernet1/13,Ethernet1/14",
+                "isAttached": True,
+                "deployment": True,
+                "is_deploy": True,
+                "torports": [
+                    {"switch": "dt-n9k6", "torPorts": "Ethernet1/12"},
+                    {"switch": "dt-n9k7", "torPorts": "Ethernet1/12"},
+                ],
+            },
+        ]
+        have_attach = [
+            {
+                "serialNumber": "9NN7E41N16A",
+                "networkName": "test_network",
+                "switchPorts": "Ethernet1/13,Ethernet1/14",
+                "isAttached": True,
+                "deployment": True,
+                "is_deploy": True,
+                "vlan": 202,
+                "torports": [
+                    {"switch": "dt-n9k6", "torPorts": "Ethernet1/12"},
+                    {"switch": "dt-n9k7", "torPorts": "Ethernet1/12"},
+                ],
+            },
+            {
+                "serialNumber": "9YO9A29F27U",
+                "networkName": "test_network",
+                "switchPorts": "Ethernet1/13,Ethernet1/14",
+                "isAttached": True,
+                "deployment": True,
+                "is_deploy": True,
+                "vlan": 202,
+                "torports": [
+                    {"switch": "dt-n9k6", "torPorts": "Ethernet1/12"},
+                    {"switch": "dt-n9k7", "torPorts": "Ethernet1/12"},
+                ],
+            },
+        ]
+
+        dcnm_net.normalize_vpc_torports(want_attach)
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach), replace=True)
+
+        self.assertFalse(diff)
+        self.assertFalse(dep_net)
+
+    def test_dcnm_net_merged_tor_vpc_single_tor_with_update(self):
+        dcnm_net = self._build_diff_network(self.net_inv_data_vpc_tor)
+
+        have_attach = [
+            self._build_attach_state(
+                "9NN7E41N16A",
+                "Ethernet1/13,Ethernet1/14",
+                [{"switch": "dt-n9k6", "torPorts": "Ethernet1/12"}],
+            ),
+            self._build_attach_state(
+                "9YO9A29F27U",
+                "Ethernet1/13,Ethernet1/14",
+                [{"switch": "dt-n9k6", "torPorts": "Ethernet1/12"}],
+            ),
+        ]
+        want_attach = [
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14"),
+            self._build_attach_state(
+                "9YO9A29F27U",
+                "Ethernet1/13,Ethernet1/14",
+                [{"switch": "dt-n9k6", "torPorts": "Ethernet1/13,Ethernet1/14"}],
+            ),
+        ]
+
+        dcnm_net.normalize_vpc_torports(want_attach)
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(
+            copy.deepcopy(want_attach), copy.deepcopy(have_attach)
+        )
+
+        attach_by_serial = {attach["serialNumber"]: attach for attach in diff}
+        self.assertTrue(dep_net)
+        self.assertEqual(len(diff), 2)
+        self.assertEqual(
+            attach_by_serial["9NN7E41N16A"]["torPorts"],
+            "dt-n9k6(Ethernet1/13,Ethernet1/14,Ethernet1/12)",
+        )
+        self.assertEqual(
+            attach_by_serial["9YO9A29F27U"]["torPorts"],
+            "dt-n9k6(Ethernet1/13,Ethernet1/14,Ethernet1/12)",
+        )
+
+    def test_dcnm_net_replace_tor_vpc_single_tor_idempotent(self):
+        dcnm_net = self._build_diff_network(self.net_inv_data_vpc_tor)
+
+        want_attach = [
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14"),
+            self._build_attach_state(
+                "9YO9A29F27U",
+                "Ethernet1/13,Ethernet1/14",
+                [{"switch": "dt-n9k6", "torPorts": "Ethernet1/13,Ethernet1/14"}],
+            ),
+        ]
+        have_attach = [
+            self._build_attach_state(
+                "9NN7E41N16A",
+                "Ethernet1/13,Ethernet1/14",
+                [{"switch": "dt-n9k6", "torPorts": "Ethernet1/13,Ethernet1/14"}],
+            ),
+            self._build_attach_state(
+                "9YO9A29F27U",
+                "Ethernet1/13,Ethernet1/14",
+                [{"switch": "dt-n9k6", "torPorts": "Ethernet1/13,Ethernet1/14"}],
+            ),
+        ]
+
+        dcnm_net.normalize_vpc_torports(want_attach)
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(
+            copy.deepcopy(want_attach), copy.deepcopy(have_attach), replace=True
+        )
+
+        self.assertFalse(diff)
+        self.assertFalse(dep_net)
+
+    def test_dcnm_net_merged_tor_single_leaf_single_tor_with_update(self):
+        inventory_data = {
+            "10.10.10.217": {
+                "ipAddress": "10.10.10.217",
+                "logicalName": "dt-n9k1",
+                "serialNumber": "9NN7E41N16A",
+                "switchRole": "leaf",
+                "isVpcConfigured": False,
+            },
+            "10.10.10.219": {
+                "ipAddress": "10.10.10.219",
+                "logicalName": "dt-n9k6",
+                "serialNumber": "9YO9A29F28C",
+                "switchRole": "tor",
+            },
+        }
+        ip_sn = {
+            "10.10.10.217": "9NN7E41N16A",
+            "10.10.10.219": "9YO9A29F28C",
+        }
+        dcnm_net = self._build_diff_network(inventory_data, ip_sn)
+
+        have_attach = [
+            self._build_attach_state(
+                "9NN7E41N16A",
+                "Ethernet1/13",
+                [{"switch": "dt-n9k6", "torPorts": "Ethernet1/12"}],
+            )
+        ]
+        want_attach = [
+            self._build_attach_state(
+                "9NN7E41N16A",
+                "Ethernet1/13",
+                [{"switch": "dt-n9k6", "torPorts": "Ethernet1/13,Ethernet1/14"}],
+            )
+        ]
+
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(
+            copy.deepcopy(want_attach), copy.deepcopy(have_attach)
+        )
+
+        self.assertTrue(dep_net)
+        self.assertEqual(len(diff), 1)
+        self.assertEqual(
+            diff[0]["torPorts"], "dt-n9k6(Ethernet1/13,Ethernet1/14,Ethernet1/12)"
+        )
+
+    def test_dcnm_net_replace_tor_single_leaf_single_tor_idempotent(self):
+        inventory_data = {
+            "10.10.10.217": {
+                "ipAddress": "10.10.10.217",
+                "logicalName": "dt-n9k1",
+                "serialNumber": "9NN7E41N16A",
+                "switchRole": "leaf",
+                "isVpcConfigured": False,
+            },
+            "10.10.10.219": {
+                "ipAddress": "10.10.10.219",
+                "logicalName": "dt-n9k6",
+                "serialNumber": "9YO9A29F28C",
+                "switchRole": "tor",
+            },
+        }
+        ip_sn = {
+            "10.10.10.217": "9NN7E41N16A",
+            "10.10.10.219": "9YO9A29F28C",
+        }
+        dcnm_net = self._build_diff_network(inventory_data, ip_sn)
+
+        want_attach = [
+            self._build_attach_state(
+                "9NN7E41N16A",
+                "Ethernet1/13",
+                [{"switch": "dt-n9k6", "torPorts": "Ethernet1/13,Ethernet1/14"}],
+            )
+        ]
+        have_attach = [
+            self._build_attach_state(
+                "9NN7E41N16A",
+                "Ethernet1/13",
+                [{"switch": "dt-n9k6", "torPorts": "Ethernet1/13,Ethernet1/14"}],
+            )
+        ]
+
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(
+            copy.deepcopy(want_attach), copy.deepcopy(have_attach), replace=True
+        )
+
+        self.assertFalse(diff)
+        self.assertFalse(dep_net)
 
     def test_dcnm_net_replace_tor_ports(self):
         self.version = 12

--- a/tests/unit/modules/dcnm/test_dcnm_network.py
+++ b/tests/unit/modules/dcnm/test_dcnm_network.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 # from units.compat.mock import patch
 
@@ -212,6 +212,34 @@ class TestDcnmNetworkModule(TestDcnmModule):
         )
 
         self.assertEqual(serials, ["SERIAL1", "SERIAL2", "SERIAL3"])
+
+    def test_dcnm_net_delete_out_of_sync_networks_are_bulk_deleted(self):
+        dcnm_net = dcnm_network.DcnmNetwork.__new__(dcnm_network.DcnmNetwork)
+        dcnm_net.log = self._build_test_logger()
+        dcnm_net.fabric = "test-fabric"
+        dcnm_net.fabric_type = "standalone"
+        dcnm_net.paths = {"GET_NET": "/networks/{}"}
+        dcnm_net.module = Mock(check_mode=False)
+        dcnm_net.result = {"changed": False, "response": []}
+        dcnm_net.diff_create_update = []
+        dcnm_net.diff_detach = []
+        dcnm_net.diff_undeploy = {}
+        dcnm_net.diff_delete = {"net-a": "OUT-OF-SYNC"}
+        dcnm_net.diff_create = []
+        dcnm_net.diff_attach = []
+        dcnm_net.diff_deploy = {}
+        dcnm_net.wait_for_network_attachments_del_ready = Mock(return_value=True)
+        dcnm_net.wait_for_network_del_ready = Mock(return_value=True)
+        dcnm_net.bulk_delete_networks_with_retry = Mock()
+
+        dcnm_net.push_to_remote()
+
+        dcnm_net.bulk_delete_networks_with_retry.assert_called_once_with(
+            ["net-a"],
+            "/networks/test-fabric",
+            "DELETE",
+            False,
+        )
 
     def load_fixtures(self, response=None, device=""):
 

--- a/tests/unit/modules/dcnm/test_dcnm_network.py
+++ b/tests/unit/modules/dcnm/test_dcnm_network.py
@@ -55,6 +55,7 @@ class TestDcnmNetworkModule(TestDcnmModule):
     playbook_tor_config = test_data.get("playbook_tor_config")
     playbook_tor_roleerr_config = test_data.get("playbook_tor_roleerr_config")
     playbook_tor_config_update = test_data.get("playbook_tor_config_update")
+    playbook_tor_only_config_update = test_data.get("playbook_tor_only_config_update")
 
     playbook_config_replace = test_data.get("playbook_config_replace")
     playbook_config_replace_no_atch = test_data.get("playbook_config_replace_no_atch")
@@ -117,6 +118,9 @@ class TestDcnmNetworkModule(TestDcnmModule):
         self.mock_net_query_object = copy.deepcopy(self.test_data.get("mock_net_query_object"))
         self.mock_vlan_get = copy.deepcopy(self.test_data.get("mock_vlan_get"))
         self.mock_net_attach_tor_object = copy.deepcopy(self.test_data.get("mock_net_attach_tor_object"))
+        self.mock_net_attach_tor_only_object = copy.deepcopy(
+            self.test_data.get("mock_net_attach_tor_only_object")
+        )
 
     def setUp(self):
         super(TestDcnmNetworkModule, self).setUp()
@@ -422,6 +426,17 @@ class TestDcnmNetworkModule(TestDcnmModule):
         elif "_merged_tor_with_update" in self._testMethodName:
             self.init_data()
             self.run_dcnm_get_url.side_effect = [self.mock_net_attach_tor_object]
+            self.run_dcnm_send.side_effect = [
+                self.mock_vrf_object,
+                self.mock_net_object,
+                self.blank_data,
+                self.attach_success_resp,
+                self.deploy_success_resp,
+            ]
+
+        elif "_merged_tor_only_with_update" in self._testMethodName:
+            self.init_data()
+            self.run_dcnm_get_url.side_effect = [self.mock_net_attach_tor_only_object]
             self.run_dcnm_send.side_effect = [
                 self.mock_vrf_object,
                 self.mock_net_object,
@@ -951,6 +966,29 @@ class TestDcnmNetworkModule(TestDcnmModule):
             result.get("diff")[0]["attach"][1]["ip_address"], "10.10.10.217"
         )
         self.assertEqual(result.get("diff")[0]["vrf_name"], "ansible-vrf-int1")
+
+    def test_dcnm_net_merged_tor_only_with_update(self):
+        self.version = 12
+        set_module_args(
+            dict(
+                state="merged",
+                fabric="test_network",
+                config=self.playbook_tor_only_config_update,
+            )
+        )
+        result = self.execute_module(changed=True, failed=False, use_action_plugin=True)
+        self.version = 11
+
+        attach_by_ip = {
+            attach["ip_address"]: attach for attach in result.get("diff")[0]["attach"]
+        }
+        self.assertIn("10.10.10.217", attach_by_ip)
+        self.assertEqual(attach_by_ip["10.10.10.217"]["ports"], "")
+        self.assertIn(
+            "dt-n9k7(Ethernet1/13,Ethernet1/12)",
+            attach_by_ip["10.10.10.217"]["tor_ports"],
+        )
+        self.assertEqual(result.get("diff")[0]["net_name"], "test_network")
 
     def test_dcnm_net_replace_tor_ports(self):
         self.version = 12

--- a/tests/unit/modules/dcnm/test_dcnm_network.py
+++ b/tests/unit/modules/dcnm/test_dcnm_network.py
@@ -378,47 +378,7 @@ class TestDcnmNetworkModule(TestDcnmModule):
         self.assertEqual(configs[0]["config"][0]["secondary_ip_gw1"], "192.166.88.1/24")
         self.assertEqual(configs[0]["config"][0]["secondary_ip_gw2"], "")
         child_config = configs[1]["config"][0]
-        self.assertNotIn("secondary_ip_gw1", child_config)
-        self.assertNotIn("secondary_ip_gw2", child_config)
         self.assertEqual(child_config["dhcp_loopback_id"], 204)
-
-    def test_dcnm_net_split_msd_replaced_sends_full_secondary_gw_intent_to_child(self):
-        action = dcnm_network_action.ActionModule.__new__(dcnm_network_action.ActionModule)
-        fabrics = {
-            "msd-parent": {
-                "type": "multisite_parent",
-                "fabricParent": "None",
-                "cluster_name": "",
-            },
-            "msd-child-1": {
-                "type": "multisite_child",
-                "fabricParent": "msd-parent",
-                "cluster_name": "",
-            },
-        }
-        config = [
-            {
-                "net_name": "ansible-msd-net1",
-                "vrf_name": "Tenant-1",
-                "is_l2only": False,
-                "secondary_ip_gw1": "192.166.88.1/24",
-                "child_fabric_config": [
-                    {
-                        "fabric": "msd-child-1",
-                        "dhcp_loopback_id": 204,
-                    }
-                ],
-            }
-        ]
-
-        configs, error_msg = action._split_config(fabrics, "msd-parent", config, "replaced", {}, 12)
-
-        self.assertIsNone(error_msg)
-        child_config = configs[1]["config"][0]
-        self.assertEqual(child_config["secondary_ip_gw1"], "192.166.88.1/24")
-        self.assertEqual(child_config["secondary_ip_gw2"], "")
-        self.assertEqual(child_config["secondary_ip_gw3"], "")
-        self.assertEqual(child_config["secondary_ip_gw4"], "")
 
     def test_dcnm_net_delete_switch_config_deploy_serials_are_dynamic(self):
         dcnm_net = dcnm_network.DcnmNetwork.__new__(dcnm_network.DcnmNetwork)

--- a/tests/unit/modules/dcnm/test_dcnm_vpc_pair.py
+++ b/tests/unit/modules/dcnm/test_dcnm_vpc_pair.py
@@ -1739,9 +1739,6 @@ class TestDcnmVpcPairModule(TestDcnmModule):
         dcnm_send_side_effect.append(data.get("vpc_pair_null_have"))
         dcnm_send_side_effect.append(data.get("vpc_pair_null_have"))
         dcnm_send_side_effect.append(data.get("vpc_pair_null_have"))
-        dcnm_send_side_effect.append(resp.get("vpc_pair_sync_status_in_sync"))
-        dcnm_send_side_effect.append(resp.get("vpc_pair_sync_status_in_sync"))
-        dcnm_send_side_effect.append(resp.get("vpc_pair_sync_status_in_sync"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_create_succ_resp"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_create_succ_resp"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_create_succ_resp"))
@@ -2168,22 +2165,18 @@ class TestDcnmVpcPairModule(TestDcnmModule):
         dcnm_send_side_effect_3 = []
 
         # dcnm_send() invoked from module_utils/dcnm_vpc_pair_utils.py
-        dcnm_send_side_effect.append(resp.get("vpc_pair_null_have"))
-        dcnm_send_side_effect.append(resp.get("vpc_pair_null_have"))
-        dcnm_send_side_effect.append(resp.get("vpc_pair_null_have"))
+        dcnm_send_side_effect.append(data.get("vpc_pair_null_have"))
+        dcnm_send_side_effect.append(data.get("vpc_pair_null_have"))
+        dcnm_send_side_effect.append(data.get("vpc_pair_null_have"))
 
-        dcnm_send_side_effect.append(resp.get("vpc_pair_null_have"))
-        dcnm_send_side_effect.append(resp.get("vpc_pair_null_have"))
-        dcnm_send_side_effect.append(resp.get("vpc_pair_null_have"))
-        dcnm_send_side_effect.append(resp.get("vpc_pair_null_have"))
-        dcnm_send_side_effect.append(resp.get("vpc_pair_null_have"))
-        dcnm_send_side_effect.append(resp.get("vpc_pair_null_have"))
-        dcnm_send_side_effect.append(resp.get("vpc_pair_null_have"))
-        dcnm_send_side_effect.append(resp.get("vpc_pair_null_have"))
-
-        dcnm_send_side_effect.append(resp.get("vpc_pair_sync_status_in_sync"))
-        dcnm_send_side_effect.append(resp.get("vpc_pair_sync_status_in_sync"))
-        dcnm_send_side_effect.append(resp.get("vpc_pair_sync_status_in_sync"))
+        dcnm_send_side_effect.append(data.get("vpc_pair_null_have"))
+        dcnm_send_side_effect.append(data.get("vpc_pair_null_have"))
+        dcnm_send_side_effect.append(data.get("vpc_pair_null_have"))
+        dcnm_send_side_effect.append(data.get("vpc_pair_null_have"))
+        dcnm_send_side_effect.append(data.get("vpc_pair_null_have"))
+        dcnm_send_side_effect.append(data.get("vpc_pair_null_have"))
+        dcnm_send_side_effect.append(data.get("vpc_pair_null_have"))
+        dcnm_send_side_effect.append(data.get("vpc_pair_null_have"))
 
         dcnm_send_side_effect.append(resp.get("vpc_pair_create_succ_resp"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_create_succ_resp"))
@@ -2287,30 +2280,17 @@ class TestDcnmVpcPairModule(TestDcnmModule):
         dcnm_send_side_effect_3 = []
 
         # dcnm_send() invoked from module_utils/dcnm_vpc_pair_utils.py
-        dcnm_send_side_effect.append(resp.get("vpc_pair_null_have"))
+        dcnm_send_side_effect.append(data.get("vpc_pair_null_have"))
+        dcnm_send_side_effect.append(data.get("vpc_pair_null_have"))
+        dcnm_send_side_effect.append(data.get("vpc_pair_null_have"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_85"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_policy_resp_85"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_86"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_policy_resp_86"))
-
-        dcnm_send_side_effect.append(resp.get("vpc_pair_null_have"))
-        dcnm_send_side_effect.append(resp.get("vpc_pair_null_have"))
-        dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_85"))
-        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
-        dcnm_send_side_effect.append(
-            copy.deepcopy(resp.get("vpc_pair_policy_resp_85"))
-        )
-        dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_86"))
-        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
-        dcnm_send_side_effect.append(
-            copy.deepcopy(resp.get("vpc_pair_policy_resp_86"))
-        )
-        dcnm_send_side_effect.append(resp.get("vpc_pair_null_have"))
-        dcnm_send_side_effect.append(resp.get("vpc_pair_null_have"))
-
-        dcnm_send_side_effect.append(resp.get("vpc_pair_sync_status_in_sync"))
+        dcnm_send_side_effect.append(data.get("vpc_pair_null_have"))
+        dcnm_send_side_effect.append(data.get("vpc_pair_null_have"))
 
         dcnm_send_side_effect.append(resp.get("vpc_pair_delete_succ_resp"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_delete_succ_resp"))
@@ -2430,24 +2410,6 @@ class TestDcnmVpcPairModule(TestDcnmModule):
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_86"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_policy_resp_86"))
-
-        dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_84"))
-        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
-        dcnm_send_side_effect.append(
-            copy.deepcopy(resp.get("vpc_pair_policy_resp_84"))
-        )
-        dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_85"))
-        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
-        dcnm_send_side_effect.append(
-            copy.deepcopy(resp.get("vpc_pair_policy_resp_85"))
-        )
-        dcnm_send_side_effect.append(resp.get("vpc_pair_info_resp_86"))
-        dcnm_send_side_effect.append(resp.get("vpc_pair_info_virtual_peer_link_resp"))
-        dcnm_send_side_effect.append(
-            copy.deepcopy(resp.get("vpc_pair_policy_resp_86"))
-        )
-        dcnm_send_side_effect.append(resp.get("vpc_pair_null_have"))
-        dcnm_send_side_effect.append(resp.get("vpc_pair_null_have"))
 
         dcnm_send_side_effect.append(resp.get("vpc_pair_delete_succ_resp"))
         dcnm_send_side_effect.append(resp.get("vpc_pair_delete_succ_resp"))

--- a/tests/unit/modules/dcnm/test_dcnm_vrf.py
+++ b/tests/unit/modules/dcnm/test_dcnm_vrf.py
@@ -57,6 +57,8 @@ class TestDcnmVrfModule(TestDcnmModule):
     mock_vrf_attach_object_del_ready = test_data.get("mock_vrf_attach_object_del_ready")
     mock_msd_vrf_attach_object_del_not_ready = test_data.get("mock_msd_vrf_attach_object_del_not_ready")
     mock_msd_vrf_attach_object_del_ready = test_data.get("mock_msd_vrf_attach_object_del_ready")
+    mock_vrf_object_na = test_data.get("mock_vrf_object_na")
+    mock_vrf_object_dcnm_only_na = test_data.get("mock_vrf_object_dcnm_only_na")
 
     msd_attach_success_resp = test_data.get("msd_attach_success_resp")
     msd_attach_success_resp_2 = test_data.get("msd_attach_success_resp_2")
@@ -70,6 +72,7 @@ class TestDcnmVrfModule(TestDcnmModule):
     error2 = test_data.get("error2")
     error3 = test_data.get("error3")
     delete_success_resp = test_data.get("delete_success_resp")
+    delete_failure_resp = test_data.get("delete_failure_resp")
     blank_data = test_data.get("blank_data")
     blank_data_with_empty_data = {
         "DATA": [],
@@ -523,9 +526,10 @@ class TestDcnmVrfModule(TestDcnmModule):
                 self.mock_net_from_vrf_empty,
                 self.attach_success_resp,
                 self.deploy_success_resp,
-                self.mock_vrf_attach_object_del_not_ready,
-                self.mock_vrf_attach_object_del_ready,
-                self.delete_success_resp,
+                self.mock_vrf_attach_object_del_not_ready,  # wait_for_vrf_attachments_del_ready
+                self.mock_vrf_attach_object_del_ready,      # wait_for_vrf_attachments_del_ready
+                self.mock_vrf_object_na,                     # wait_for_vrf_del_ready
+                self.delete_success_resp,                    # bulk_delete_with_retry
                 self.mock_pools_top_down_vrf_vlan,
                 self.mock_pools_top_down_dot1q,
                 self.blank_data,
@@ -564,9 +568,10 @@ class TestDcnmVrfModule(TestDcnmModule):
                 self.mock_net_from_vrf_empty,  # Check for network attachments before delete
                 self.attach_success_resp,
                 self.deploy_success_resp,
-                self.mock_vrf_attach_object_del_not_ready,
-                self.mock_vrf_attach_object_del_ready,
-                self.delete_success_resp,
+                self.mock_vrf_attach_object_del_not_ready,  # wait_for_vrf_attachments_del_ready
+                self.mock_vrf_attach_object_del_ready,      # wait_for_vrf_attachments_del_ready
+                self.mock_vrf_object_na,                     # wait_for_vrf_del_ready
+                self.delete_success_resp,                    # bulk_delete_with_retry
                 self.mock_pools_top_down_vrf_vlan,
                 self.mock_pools_top_down_dot1q,
             ]
@@ -582,9 +587,10 @@ class TestDcnmVrfModule(TestDcnmModule):
                 self.mock_net_from_vrf_empty,
                 self.attach_success_resp,
                 # deploy_success_resp removed - deploy now handled by action plugin
-                self.mock_vrf_attach_object_del_not_ready,
-                self.mock_vrf_attach_object_del_ready,
-                self.delete_success_resp,
+                self.mock_vrf_attach_object_del_not_ready,  # wait_for_vrf_attachments_del_ready
+                self.mock_vrf_attach_object_del_ready,      # wait_for_vrf_attachments_del_ready
+                self.mock_vrf_object_na,                     # wait_for_vrf_del_ready
+                self.delete_success_resp,                    # bulk_delete_with_retry
                 self.mock_pools_top_down_vrf_vlan,
                 self.mock_pools_top_down_dot1q,
             ]
@@ -599,8 +605,12 @@ class TestDcnmVrfModule(TestDcnmModule):
                 self.mock_net_from_vrf_empty,
                 self.attach_success_resp,
                 self.deploy_success_resp,
-                self.mock_vrf_attach_object_del_not_ready,
-                self.mock_vrf_attach_object_del_oos,
+                self.mock_vrf_attach_object_del_not_ready,  # wait_for_vrf_attachments_del_ready
+                self.mock_vrf_attach_object_del_oos,        # wait_for_vrf_attachments_del_ready (OUT-OF-SYNC)
+                self.mock_vrf_object_na,                     # wait_for_vrf_del_ready
+                self.delete_failure_resp,                    # bulk_delete_with_retry attempt 1
+                self.delete_failure_resp,                    # bulk_delete_with_retry attempt 2
+                self.delete_failure_resp,                    # bulk_delete_with_retry attempt 3 (final)
             ]
 
         elif "delete_dcnm_only" in self._testMethodName:
@@ -619,9 +629,10 @@ class TestDcnmVrfModule(TestDcnmModule):
                 self.mock_net_from_vrf_empty,
                 self.attach_success_resp,
                 self.deploy_success_resp,
-                obj1,
-                obj2,
-                self.delete_success_resp,
+                obj1,                          # wait_for_vrf_attachments_del_ready
+                obj2,                          # wait_for_vrf_attachments_del_ready
+                self.mock_vrf_object_dcnm_only_na,  # wait_for_vrf_del_ready
+                self.delete_success_resp,      # bulk_delete_with_retry
                 self.mock_pools_top_down_vrf_vlan,
                 self.mock_pools_top_down_dot1q,
             ]
@@ -771,6 +782,7 @@ class TestDcnmVrfModule(TestDcnmModule):
                 self.msd_attach_success_resp,               # detach
                 self.mock_msd_vrf_attach_object_del_not_ready,
                 self.mock_msd_vrf_attach_object_del_ready,
+                self.mock_vrf_object_na,                     # wait_for_vrf_del_ready
                 self.delete_success_resp,
                 self.mock_pools_top_down_vrf_vlan,
                 self.mock_pools_top_down_dot1q,
@@ -787,6 +799,7 @@ class TestDcnmVrfModule(TestDcnmModule):
                 self.msd_attach_success_resp,               # detach
                 self.mock_msd_vrf_attach_object_del_not_ready,
                 self.mock_msd_vrf_attach_object_del_ready,
+                self.mock_vrf_object_na,                     # wait_for_vrf_del_ready
                 self.delete_success_resp,
                 self.mock_pools_top_down_vrf_vlan,
                 self.mock_pools_top_down_dot1q,
@@ -832,6 +845,7 @@ class TestDcnmVrfModule(TestDcnmModule):
                 self.msd_attach_success_resp,               # detach
                 self.mock_msd_vrf_attach_object_del_not_ready,
                 self.mock_msd_vrf_attach_object_del_ready,
+                self.mock_vrf_object_na,                     # wait_for_vrf_del_ready
                 self.delete_success_resp,
                 self.mock_pools_top_down_vrf_vlan,
                 self.mock_pools_top_down_dot1q,
@@ -848,6 +862,7 @@ class TestDcnmVrfModule(TestDcnmModule):
                 self.msd_attach_success_resp,               # detach
                 self.mock_msd_vrf_attach_object_del_not_ready,
                 self.mock_msd_vrf_attach_object_del_ready,
+                self.mock_vrf_object_na,                     # wait_for_vrf_del_ready
                 self.delete_success_resp,
                 self.mock_pools_top_down_vrf_vlan,
                 self.mock_pools_top_down_dot1q,
@@ -1454,8 +1469,12 @@ class TestDcnmVrfModule(TestDcnmModule):
         playbook = self.test_data.get("playbook_config")
         set_module_args(dict(state="deleted", fabric="standalone_fabric", config=playbook))
         result = self.execute_module(changed=False, failed=True, use_action_plugin=True)
-        msg = "DcnmVrf.push_diff_delete: Deletion of vrfs test_vrf_1 has failed"
-        self.assertEqual(result["msg"]["response"][2], msg)
+        # With retry logic, bulk delete failure appends responses and can return them
+        # Check if the failure is detected (either in msg string or in response list)
+        self.assertTrue(result.get("failed"))
+        # The result should reference the test_vrf_1 VRF that failed
+        result_str = str(result)
+        self.assertIn("test_vrf_1", result_str)
 
     def test_dcnm_vrf_query(self):
         playbook = self.test_data.get("playbook_config")

--- a/tests/unit/modules/dcnm/test_dcnm_vrf.py
+++ b/tests/unit/modules/dcnm/test_dcnm_vrf.py
@@ -586,7 +586,7 @@ class TestDcnmVrfModule(TestDcnmModule):
                 # and get_have() skips get_vrf_lite_objects() calls for optimization
                 self.mock_net_from_vrf_empty,
                 self.attach_success_resp,
-                # deploy_success_resp removed - deploy now handled by action plugin
+                self.deploy_success_resp,
                 self.mock_vrf_attach_object_del_not_ready,  # wait_for_vrf_attachments_del_ready
                 self.mock_vrf_attach_object_del_ready,      # wait_for_vrf_attachments_del_ready
                 self.mock_vrf_object_na,                     # wait_for_vrf_del_ready
@@ -780,6 +780,7 @@ class TestDcnmVrfModule(TestDcnmModule):
                 self.mock_msd_parent_vrf_object,            # get_vrf_objects
                 self.mock_net_from_vrf_empty,               # Check for network attachments before delete
                 self.msd_attach_success_resp,               # detach
+                self.deploy_success_resp,                   # undeploy
                 self.mock_msd_vrf_attach_object_del_not_ready,
                 self.mock_msd_vrf_attach_object_del_ready,
                 self.mock_vrf_object_na,                     # wait_for_vrf_del_ready
@@ -797,6 +798,7 @@ class TestDcnmVrfModule(TestDcnmModule):
                 self.mock_msd_parent_vrf_object,            # Parent: get_vrf_objects
                 self.mock_net_from_vrf_empty,               # Check for network attachments before delete
                 self.msd_attach_success_resp,               # detach
+                self.deploy_success_resp,                   # undeploy
                 self.mock_msd_vrf_attach_object_del_not_ready,
                 self.mock_msd_vrf_attach_object_del_ready,
                 self.mock_vrf_object_na,                     # wait_for_vrf_del_ready
@@ -843,6 +845,7 @@ class TestDcnmVrfModule(TestDcnmModule):
                 self.mock_msd_parent_vrf_object,            # get_vrf_objects
                 self.mock_net_from_vrf_empty,               # Check for network attachments before delete
                 self.msd_attach_success_resp,               # detach
+                self.deploy_success_resp,                   # undeploy
                 self.mock_msd_vrf_attach_object_del_not_ready,
                 self.mock_msd_vrf_attach_object_del_ready,
                 self.mock_vrf_object_na,                     # wait_for_vrf_del_ready
@@ -860,6 +863,7 @@ class TestDcnmVrfModule(TestDcnmModule):
                 self.mock_msd_parent_vrf_object,            # Parent: get_vrf_objects
                 self.mock_net_from_vrf_empty,               # Check for network attachments before delete
                 self.msd_attach_success_resp,               # detach
+                self.deploy_success_resp,                   # undeploy
                 self.mock_msd_vrf_attach_object_del_not_ready,
                 self.mock_msd_vrf_attach_object_del_ready,
                 self.mock_vrf_object_na,                     # wait_for_vrf_del_ready

--- a/tests/unit/modules/dcnm/test_dcnm_vrf.py
+++ b/tests/unit/modules/dcnm/test_dcnm_vrf.py
@@ -155,6 +155,13 @@ class TestDcnmVrfModule(TestDcnmModule):
         self.mock_vrf_attach_get_ext_object_merge_att4_only = copy.deepcopy(
             self.test_data.get("mock_vrf_attach_get_ext_object_merge_att4_only")
         )
+        # Combined (batched) VRF-Lite switch fixtures for PENDING-05 batch GET_VRF_SWITCH
+        self.mock_vrf_attach_get_ext_object_combined_sn1_sn2 = copy.deepcopy(
+            self.test_data.get("mock_vrf_attach_get_ext_object_combined_sn1_sn2")
+        )
+        self.mock_vrf_attach_get_ext_object_combined_sn1_sn4 = copy.deepcopy(
+            self.test_data.get("mock_vrf_attach_get_ext_object_combined_sn1_sn4")
+        )
         self.mock_vrf_msd_attach_get_ext_object_dcnm_att1_only = copy.deepcopy(
             self.test_data.get("mock_vrf_msd_attach_get_ext_object_dcnm_att1_only")
         )
@@ -315,8 +322,8 @@ class TestDcnmVrfModule(TestDcnmModule):
             self.run_dcnm_get_url.side_effect = [self.mock_vrf_attach_object2]
             self.run_dcnm_send.side_effect = [
                 self.mock_vrf_object,
-                self.mock_vrf_attach_get_ext_object_merge_att1_only,
-                self.mock_vrf_attach_get_ext_object_merge_att4_only,
+                # Batch GET_VRF_SWITCH: one call for both switches (PENDING-05)
+                self.mock_vrf_attach_get_ext_object_combined_sn1_sn4,
             ]
 
         elif "_merged_with_incorrect" in self._testMethodName:
@@ -347,8 +354,8 @@ class TestDcnmVrfModule(TestDcnmModule):
             self.run_dcnm_get_url.side_effect = [self.mock_vrf_attach_object]
             self.run_dcnm_send.side_effect = [
                 self.mock_vrf_object,
-                self.mock_vrf_attach_get_ext_object_merge_att1_only,
-                self.mock_vrf_attach_get_ext_object_merge_att2_only,
+                # Batch GET_VRF_SWITCH: one call for both switches (PENDING-05)
+                self.mock_vrf_attach_get_ext_object_combined_sn1_sn2,
                 self.mock_vrf_lite_obj,
                 self.attach_success_resp,
                 self.deploy_success_resp,
@@ -360,8 +367,8 @@ class TestDcnmVrfModule(TestDcnmModule):
             self.run_dcnm_get_url.side_effect = [self.mock_vrf_attach_object]
             self.run_dcnm_send.side_effect = [
                 self.mock_vrf_object,
-                self.mock_vrf_attach_get_ext_object_merge_att1_only,
-                self.mock_vrf_attach_get_ext_object_merge_att2_only,
+                # Batch GET_VRF_SWITCH: one call for both switches (PENDING-05)
+                self.mock_vrf_attach_get_ext_object_combined_sn1_sn2,
                 self.blank_data,
                 self.mock_vrf_lite_obj,
                 self.attach_success_resp,
@@ -387,8 +394,8 @@ class TestDcnmVrfModule(TestDcnmModule):
                 self.mock_vrf_lite_obj,
                 self.mock_vrf_attach_object_pending,
                 self.blank_data,
-                self.mock_vrf_attach_get_ext_object_merge_att1_only,
-                self.mock_vrf_attach_get_ext_object_merge_att4_only,
+                # Batch GET_VRF_SWITCH: one call for both switches (PENDING-05)
+                self.mock_vrf_attach_get_ext_object_combined_sn1_sn4,
                 self.deploy_success_resp,
             ]
 
@@ -440,8 +447,8 @@ class TestDcnmVrfModule(TestDcnmModule):
             self.run_dcnm_get_url.side_effect = [self.mock_vrf_attach_object2]
             self.run_dcnm_send.side_effect = [
                 self.mock_vrf_object,
-                self.mock_vrf_attach_get_ext_object_merge_att1_only,
-                self.mock_vrf_attach_get_ext_object_merge_att4_only,
+                # Batch GET_VRF_SWITCH: one call for both switches (PENDING-05)
+                self.mock_vrf_attach_get_ext_object_combined_sn1_sn4,
                 self.mock_vrf_lite_obj,
                 self.attach_success_resp,
                 self.deploy_success_resp,
@@ -462,8 +469,8 @@ class TestDcnmVrfModule(TestDcnmModule):
             self.run_dcnm_get_url.side_effect = [self.mock_vrf_attach_object2]
             self.run_dcnm_send.side_effect = [
                 self.mock_vrf_object,
-                self.mock_vrf_attach_get_ext_object_merge_att1_only,
-                self.mock_vrf_attach_get_ext_object_merge_att4_only,
+                # Batch GET_VRF_SWITCH: one call for both switches (PENDING-05)
+                self.mock_vrf_attach_get_ext_object_combined_sn1_sn4,
             ]
 
         elif "lite_override_with_additions" in self._testMethodName:
@@ -492,8 +499,8 @@ class TestDcnmVrfModule(TestDcnmModule):
             self.run_dcnm_get_url.side_effect = [self.mock_vrf_attach_object2]
             self.run_dcnm_send.side_effect = [
                 self.mock_vrf_object,
-                self.mock_vrf_attach_get_ext_object_merge_att1_only,
-                self.mock_vrf_attach_get_ext_object_merge_att4_only,
+                # Batch GET_VRF_SWITCH: one call for both switches (PENDING-05)
+                self.mock_vrf_attach_get_ext_object_combined_sn1_sn4,
                 self.mock_vrf_lite_obj,
                 self.attach_success_resp,
                 self.deploy_success_resp,
@@ -540,8 +547,9 @@ class TestDcnmVrfModule(TestDcnmModule):
             self.run_dcnm_get_url.side_effect = [self.mock_vrf_attach_object2]
             self.run_dcnm_send.side_effect = [
                 self.mock_vrf_object,
-                self.mock_vrf_attach_get_ext_object_merge_att3_only,
-                self.mock_vrf_attach_get_ext_object_merge_att4_only,
+                # Batch GET_VRF_SWITCH: one call for both switches (PENDING-05)
+                # att3 has the same serialNumber as att1 (XYZKSJHSMK1), so combined_sn1_sn4 applies
+                self.mock_vrf_attach_get_ext_object_combined_sn1_sn4,
             ]
 
         elif "delete_std_lite" in self._testMethodName:
@@ -551,8 +559,8 @@ class TestDcnmVrfModule(TestDcnmModule):
             self.run_dcnm_get_url.side_effect = [self.mock_vrf_attach_object2]
             self.run_dcnm_send.side_effect = [
                 self.mock_vrf_object,
-                self.mock_vrf_attach_get_ext_object_merge_att1_only,
-                self.mock_vrf_attach_get_ext_object_merge_att4_only,
+                # Batch GET_VRF_SWITCH: one call for both switches (PENDING-05)
+                self.mock_vrf_attach_get_ext_object_combined_sn1_sn4,
                 self.mock_net_from_vrf_empty,  # Check for network attachments before delete
                 self.attach_success_resp,
                 self.deploy_success_resp,
@@ -629,8 +637,8 @@ class TestDcnmVrfModule(TestDcnmModule):
                 self.mock_vrf_object,  # get_have: GET /vrfs (NO get_vrf_lite calls because config=[])
                 self.mock_vrf_object,  # get_diff_query: GET /vrfs
                 self.mock_vrf_attach_object2_query,  # get_diff_query: dcnm_send() GET /vrfs/attachments
-                self.mock_vrf_attach_get_ext_object_merge_att1_only,  # get_diff_query: get_vrf_lite_objects(att1)
-                self.mock_vrf_attach_get_ext_object_merge_att4_only,  # get_diff_query: get_vrf_lite_objects(att4)
+                # Batch GET_VRF_SWITCH: one call for both switches of test_vrf_1 (PENDING-05)
+                self.mock_vrf_attach_get_ext_object_combined_sn1_sn4,
             ]
 
         elif "query_vrf_lite" in self._testMethodName:
@@ -638,12 +646,12 @@ class TestDcnmVrfModule(TestDcnmModule):
             self.run_dcnm_get_url.side_effect = [self.mock_vrf_attach_object2]
             self.run_dcnm_send.side_effect = [
                 self.mock_vrf_object,  # get_have: GET /vrfs
-                self.mock_vrf_attach_get_ext_object_merge_att1_only,  # get_have: extension att1
-                self.mock_vrf_attach_get_ext_object_merge_att4_only,  # get_have: extension att4
+                # Batch GET_VRF_SWITCH: one call for both switches in get_have() (PENDING-05)
+                self.mock_vrf_attach_get_ext_object_combined_sn1_sn4,
                 self.mock_vrf_object,  # get_diff_query: GET /vrfs
                 self.mock_vrf_attach_object2_query,  # get_diff_query: GET /vrfs/attachments
-                self.mock_vrf_attach_get_ext_object_merge_att1_only,  # get_diff_query: extension att1
-                self.mock_vrf_attach_get_ext_object_merge_att4_only,  # get_diff_query: extension att4
+                # Batch GET_VRF_SWITCH: one call for both switches in get_diff_query() (PENDING-05)
+                self.mock_vrf_attach_get_ext_object_combined_sn1_sn4,
             ]
 
         elif "nochild_msd_query" in self._testMethodName:


### PR DESCRIPTION
## Summary

This PR delivers a broad set of performance improvements and bug fixes across the NDFC/DCNM collection, with a focus on reducing controller API volume, improving large-scale fabric workflows, and fixing several idempotence and deployment edge cases.

The main improvements introduce bulk API usage where supported, batched polling and delete workflows, cached controller lookups, and O(1) in-memory lookup maps for frequently accessed inventory, interface, VRF, network, link, resource manager, and vPC pair data. These changes significantly reduce repeated API calls and repeated list scans during merged, replaced, overridden, deleted, and query operations.

The PR also improves deployment accuracy for VRF and Network resources by tracking affected switch serials and supporting both switch-level and resource-level deploy modes. Network and VRF delete workflows now use batched readiness checks and bulk delete retry handling, making large-scale cleanup operations more reliable.

Several correctness fixes are included as well, including improved TOR attachment handling for networks, secondary gateway handling for MSD workflows, VRF VLAN and BGP password idempotence fixes, Resource Manager scope comparison fixes, interface native VLAN and defaulting fixes, and safer vPC pair caching/deploy behavior.

Overall, these changes make the modules faster, more scalable, and more predictable when operating against larger fabrics or repeated idempotent runs.

## Changes

| Module | Updates / Performance Improvements | Bug Fixes / Behavior Fixes |
|---|---|---|
| `dcnm_interface` | - Added bulk interface retrieval using `IF_WITH_SNO`.<br>- Added per-switch/per-interface interface detail caching.<br>- Prefetches interface policy details for all switches referenced in intent before diffing.<br>- Splits grouped bulk interface responses into individual cache entries.<br>- Optimized overridden, deleted, and replaced workflows with lookup maps instead of repeated scans.<br>- Uses bulk interface modify endpoint when supported, including `207 Multi-Status` handling.<br>- Flattens interface deploy payloads to reduce repeated deploy calls.<br>- Limits safety deploy checks to `check_deploy=true` cases. | - Fixed merged diff behavior when controller payloads omit optional `nvPairs` keys.<br>- Fixed native VLAN-related idempotence gaps.<br>- Fixed stale/default handling for port-channel and vPC member interfaces after parent operations.<br>- Added TOR uplink awareness so TOR uplink ports are not incorrectly defaulted during overridden/default operations. |
| `dcnm_inventory` | - Added O(1) inventory lookup by management IP.<br>- Added cached POAP inventory lookup by serial number.<br>- Reuses existing inventory data for known switches and skips unnecessary reachability checks for idempotent runs.<br>- Groups create/import payloads by common role/configuration to reduce duplicate discover/import calls.<br>- Optimized rediscovery, health polling, credential matching, and role assignment using dictionaries/sets.<br>- Batches NDFC role assignments into a single roles API call.<br>- Reduced polling windows for all-switch readiness and config-save retries. | - Improved idempotent bootstrap/preprovision handling.<br>- Added fast-path handling for merged reruns with no new switches while still honoring save/deploy flows.<br>- Updated diff formatting to reflect grouped switch create/import payloads. |
| `dcnm_links` | - Added bulk API support detection.<br>- Added bulk link update endpoint support.<br>- Sends all link modifications through a single bulk PUT when supported.<br>- Preserves existing per-link update behavior when bulk APIs are unavailable.<br>- Accepts both `200 OK` and `207 Multi-Status` for bulk link updates. | - Added clearer failure handling when the source fabric cannot be found.<br>- Minor unit test expectation cleanup. |
| `dcnm_network` | - Added `deploy_mode` support for switch-level versus resource-level deploy flows.<br>- Added bulk network update support using `/top-down/v2/bulk-update/networks` where available.<br>- Added switch-level deploy helpers and serial-to-network deploy mapping.<br>- Added optimized network inventory retrieval using targeted GETs for small requests and bulk GETs for large/overridden requests.<br>- Added O(1) attachment lookup by network name.<br>- Added batched attachment readiness checks, detach/deploy handling, and network delete polling.<br>- Added bulk network delete with retry and partial-failure handling.<br>- Optimized attachment/deploy payload generation using serial attach/detach maps. | - Fixed secondary gateway handling for MSD parent workflows.<br>- Fixed merged TOR port handling so new TOR ports are appended without dropping existing TOR attachments.<br>- Fixed replaced/overridden TOR behavior so TOR ports are removed only when required.<br>- Improved parsing for mixed leaf/TOR `portNames`, residual ports, and TOR-only attachment strings.<br>- Added normalization for one-sided TOR intent on vPC peers.<br>- Fixed config-only deployment detection so network configuration changes deploy even without attachment deltas.<br>- Improved named-network not-found handling across NDFC and OneManage response variants.<br>- Removed direct `/tmp/dcnm.log` debug writes from the action plugin. |
| `dcnm_resource_manager` | - Added bulk API support detection.<br>- Added bulk resource creation endpoint support.<br>- Added bulk payload builder for `Fabric`, `Device`, `DeviceInterface`, `DevicePair`, and `Link` scopes.<br>- Uses bulk resource create when supported and falls back to individual create otherwise.<br>- Accepts both `200 OK` and `207 Multi-Status` for bulk create/delete operations. | - Fixed resource manager idempotence by making `entityType` / `scopeType` comparisons case-insensitive.<br>- Preserves optional `resourceValue` and `vrfName` in generated bulk payloads. |
| `dcnm_vpc_pair` | - Added VPC pair info caching by switch DB ID.<br>- Caches pair info under both peer DB IDs when available.<br>- Added sync status caching for repeated deploy checks.<br>- Returns deep copies from cache to prevent mutation side effects.<br>- Reuses cached pair info across delete/query/override flows.<br>- Reduces unnecessary recommendation, peer-link, and sync-status API calls. | - Skips peer-link/recommendation calls when a switch has no peer.<br>- Invalidates sync cache around deploy/save retry points so retry checks use fresh controller state.<br>- Refined deploy decision logic so create/merge paths go directly to deploy payload while no-change existing pairs use sync checks. |
| `dcnm_vrf` | - Added `deploy_mode` support for switch-level versus resource-level deploy flows.<br>- Added bulk VRF update support using `/top-down/v2/bulk-update/vrfs` where available.<br>- Added switch-level deploy helpers and serial-to-VRF deploy mapping.<br>- Added O(1) lookup maps for VRF create, attach, and desired state.<br>- Optimized VRF-lite data retrieval by batching `GET_VRF_SWITCH` by VRF and serials.<br>- Filters VRF processing to playbook-targeted VRFs before attachment/switch lookups.<br>- Added batched VRF attachment delete readiness checks.<br>- Added bulk VRF delete with retry and partial-failure handling. | - Fixed VRF VLAN propagation when `enableL3VniNoVlan` is enabled or desired VLAN is `0`.<br>- Fixed BGP password clear handling by skipping key-type comparison when desired password is empty.<br>- Fixed no-attach deploy accumulation to avoid duplicating VRFs already in deploy diffs.<br>- Allows `OUT-OF-SYNC`, `FAILED`, and `NA` terminal states during delete readiness checks.<br>- Rebuilds lookup maps during failure/rollback paths to keep retry state consistent.<br>- Action plugin now validates wrapped deploy payloads and calls shared parent deploy logic. |


## Test Coverage

| Module | Coverage Added / Updated |
|---|---|
| `dcnm_interface` | <ul><li>Added regression coverage for merged Ethernet interfaces when native VLAN fields are missing from controller data.</li><li>Updated unit fixtures to exercise bulk `IF_WITH_SNO` prefetch/cache behavior across Ethernet, SVI, loopback, port-channel, vPC, multi-interface, bunched-interface, and overridden flows.</li><li>Added grouped bulk response coverage to verify that multiple interfaces returned under one policy are split into individual cache entries.</li></ul> |
| `dcnm_inventory` | <ul><li>Added route-based mock handling to validate optimized API call patterns.</li><li>Updated merge/import tests for grouped switch create flows and batched role assignment.</li><li>Added coverage for the already-created switch save/deploy fast path.</li><li>Updated POAP, preprovision, multi-switch, brownfield/greenfield, RMA, save, and deploy test flows to match cached and batched inventory behavior.</li></ul> |
| `dcnm_links` | <ul><li>Corrected the unnumbered fabric fixture reference used by existing link tests.</li><li>Existing link merge, modify, replace, delete, query, numbered, unnumbered, IPv6, vPC, and XE integration coverage remains in place.</li></ul> |
| `dcnm_network` | <ul><li>Added unit coverage for secondary gateway template generation, add/update behavior, clear behavior, and ambiguous merged clear rejection.</li><li>Added MSD split coverage to verify secondary gateways stay parent-only for merged and are sent to children for replaced workflows.</li><li>Added unit coverage for dynamic delete deploy serial selection, OUT-OF-SYNC bulk delete, batched attachment delete readiness checks, and unexpected delete readiness data.</li><li>Added bulk inventory coverage for replace workflows.</li><li>Added TOR attachment coverage for TOR-only updates, vPC-to-TOR pair updates, one-sided vPC TOR intent normalization, single TOR peer updates, single-leaf/single-TOR updates, and replace/idempotence scenarios.</li><li>Added standalone integration test cases TC13-TC15 for TOR port preservation and idempotence across vPC leaf pair to single TOR, vPC leaf pair to TOR pair, and single leaf to single TOR topologies.</li></ul> |
| `dcnm_resource_manager` | <ul><li>Existing Resource Manager merge, delete, query, invalid-parameter, and sanity coverage remains in place.</li><li>No dedicated test file was changed for the new bulk create path in this PR.</li></ul> |
| `dcnm_vpc_pair` | <ul><li>Updated unit expectations to match reduced API calls from VPC pair info caching and sync-status caching.</li><li>Adjusted create, delete, replaced, and overridden test flows so they validate the optimized call sequence while preserving existing behavior checks.</li></ul> |
| `dcnm_vrf` | <ul><li>Added fixture coverage for batched VRF-lite `GET_VRF_SWITCH` responses across multiple switches.</li><li>Updated merged, replaced, overridden, deleted, query, MSD, and MCFG unit flows to validate batched VRF-lite lookups.</li><li>Added coverage for delete readiness polling, `NA` terminal VRF delete state, bulk delete retry behavior, and delete failure reporting.</li><li>Updated MSD/MCFG delete and override tests to include undeploy, readiness polling, and bulk delete behavior.</li></ul> |
