### PR TITLE
Adding support for vlan_id override at network attachment level

### DIFF
--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -1612,7 +1612,6 @@ class DcnmNetwork:
         # Clean up vlan_id from attach dict before sending to API
         if "vlan_id" in attach:
             del attach["vlan_id"]
-    
 
         if "deploy" in attach:
             del attach["deploy"]

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -336,6 +336,13 @@ options:
             type: list
             elements: str
             required: true
+          vlan_id:
+            description:
+            - VLAN ID override for this specific switch attachment
+            - If not specified, uses the network-level vlan_id
+            - If neither is specified, NDFC will auto-select an available VLAN
+            type: int
+            required: false
           deploy:
             description:
             - Per switch knob to control whether to deploy the attachment
@@ -1418,7 +1425,7 @@ class DcnmNetwork:
                                 # This is needed to handle cases where vlan is updated after deploying the network
                                 # and attachments. This ensures that the attachments before vlan update will use previous
                                 # vlan id. All the active attachments on ND will have a vlan-id.
-                                if have.get("vlan"):
+                                if want.get("vlan") == 0 and have.get("vlan"):
                                     want["vlan"] = have.get("vlan")
 
                                 if sorted(h_sw_ports) != sorted(w_sw_ports):
@@ -1577,7 +1584,7 @@ class DcnmNetwork:
         attach.update({"serialNumber": serial})
         attach.update({"switchPorts": ",".join(attach["ports"])})
         attach.update({"detachSwitchPorts": ""})  # Is this supported??Need to handle correct
-        attach.update({"vlan": 0})
+        attach.update({"vlan": attach.get("vlan_id", 0)})     # Use attachment vlan_id if provided
         attach.update({"dot1QVlan": 0})
         attach.update({"untagged": False})
         # This flag is not to be confused for deploy of attachment.
@@ -1601,6 +1608,11 @@ class DcnmNetwork:
                 torlist.append(torports)
             del attach["tor_ports"]
         attach.update({"torports": torlist})
+
+        # Clean up vlan_id from attach dict before sending to API
+        if "vlan_id" in attach:
+            del attach["vlan_id"]
+    
 
         if "deploy" in attach:
             del attach["deploy"]
@@ -5041,6 +5053,7 @@ class DcnmNetwork:
                 ip_address=dict(required=True, type="str"),
                 ports=dict(type="list", default=[]),
                 deploy=dict(type="bool", default=True),
+                vlan_id=dict(type="int", required=False),
             )
 
             if self.config:
@@ -5079,6 +5092,7 @@ class DcnmNetwork:
                 ports=dict(type="list", default=[]),
                 deploy=dict(type="bool", default=True),
                 tor_ports=dict(required=False, type="list", elements="dict"),
+                vlan_id=dict(type="int", required=False),
             )
             tor_att_spec = dict(
                 ip_address=dict(required=True, type="str"),

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -336,13 +336,6 @@ options:
             type: list
             elements: str
             required: true
-          vlan_id:
-            description:
-            - VLAN ID override for this specific switch attachment
-            - If not specified, uses the network-level vlan_id
-            - If neither is specified, NDFC will auto-select an available VLAN
-            type: int
-            required: false
           deploy:
             description:
             - Per switch knob to control whether to deploy the attachment

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -5230,7 +5230,7 @@ class DcnmNetwork:
                 ip_address=dict(required=True, type="str"),
                 ports=dict(type="list", default=[]),
                 deploy=dict(type="bool", default=True),
-                vlan_id=dict(type="int", required=False),
+                vlan_id=dict(type="int", range_max=4094, required=False),
             )
 
             if self.config:
@@ -5269,7 +5269,7 @@ class DcnmNetwork:
                 ports=dict(type="list", default=[]),
                 deploy=dict(type="bool", default=True),
                 tor_ports=dict(required=False, type="list", elements="dict"),
-                vlan_id=dict(type="int", required=False),
+                vlan_id=dict(type="int", range_max=4094, required=False),
             )
             tor_att_spec = dict(
                 ip_address=dict(required=True, type="str"),

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -1403,7 +1403,7 @@ class DcnmNetwork:
                 )
         return serials
 
-    def diff_for_attach_deploy(self, want_a, have_a, replace=False):
+    def diff_for_attach_deploy(self, want_a, have_a, replace=False, network_vlan=0):
         caller = inspect.stack()[1][3]
 
         msg = "ENTERED. "
@@ -1495,11 +1495,17 @@ class DcnmNetwork:
                                 h_sw_ports = have["switchPorts"].split(",") if have["switchPorts"] else []
                                 w_sw_ports = want["switchPorts"].split(",") if want["switchPorts"] else []
 
-                                # This is needed to handle cases where vlan is updated after deploying the network
-                                # and attachments. This ensures that the attachments before vlan update will use previous
-                                # vlan id. All the active attachments on ND will have a vlan-id.
-                                if want.get("vlan") == 0 and have.get("vlan"):
-                                    want["vlan"] = have.get("vlan")
+                                want_vlan = int(want.get("vlan") or 0)
+                                have_vlan = int(have.get("vlan") or 0)
+
+                                if not replace and want_vlan == 0 and have_vlan:
+                                    want_vlan = have_vlan
+                                    want["vlan"] = have_vlan
+                                elif replace and want_vlan == 0 and network_vlan:
+                                    want_vlan = int(network_vlan)
+                                    want["vlan"] = int(network_vlan)
+
+                                vlan_changed = want_vlan != have_vlan
 
                                 if sorted(h_sw_ports) != sorted(w_sw_ports):
                                     atch_sw_ports = list(set(w_sw_ports) - set(h_sw_ports))
@@ -1509,7 +1515,7 @@ class DcnmNetwork:
                                         dtach_sw_ports = list(set(h_sw_ports) - set(w_sw_ports))
 
                                         if not atch_sw_ports and not dtach_sw_ports:
-                                            if torports_configured:
+                                            if torports_configured or vlan_changed:
                                                 del want["isAttached"]
                                                 attach_list.append(want)
                                                 if bool(want["is_deploy"]):
@@ -1528,7 +1534,7 @@ class DcnmNetwork:
 
                                     if not atch_sw_ports:
                                         # The attachments in the have consist of attachments in want and more.
-                                        if torports_configured:
+                                        if torports_configured or vlan_changed:
                                             del want["isAttached"]
                                             attach_list.append(want)
                                             if bool(want["is_deploy"]):
@@ -1545,6 +1551,13 @@ class DcnmNetwork:
                                     continue
 
                                 elif torports_configured:
+                                    del want["isAttached"]
+                                    attach_list.append(want)
+                                    if bool(want["is_deploy"]):
+                                        dep_net = True
+                                    continue
+
+                                elif vlan_changed:
                                     del want["isAttached"]
                                     attach_list.append(want)
                                     if bool(want["is_deploy"]):
@@ -1657,7 +1670,7 @@ class DcnmNetwork:
         attach.update({"serialNumber": serial})
         attach.update({"switchPorts": ",".join(attach["ports"])})
         attach.update({"detachSwitchPorts": ""})  # Is this supported??Need to handle correct
-        attach.update({"vlan": attach.get("vlan_id", 0)})     # Use attachment vlan_id if provided
+        attach.update({"vlan": attach.get("vlan_id") or 0})     # Use attachment vlan_id if provided; None/omitted -> 0
         attach.update({"dot1QVlan": 0})
         attach.update({"untagged": False})
         # This flag is not to be confused for deploy of attachment.
@@ -2965,6 +2978,7 @@ class DcnmNetwork:
                             # )
                 net_attach.update({"networkName": net["net_name"]})
                 net_attach.update({"lanAttachList": networks})
+                net_attach.update({"vlan_id": net.get("vlan_id") or 0})
                 want_attach.append(net_attach)
 
             all_networks += net["net_name"] + ","
@@ -3418,11 +3432,17 @@ class DcnmNetwork:
                 if want_a["networkName"] == have_a["networkName"]:
 
                     found = True
-                    diff, net = self.diff_for_attach_deploy(want_a["lanAttachList"], have_a["lanAttachList"], replace)
+                    diff, net = self.diff_for_attach_deploy(
+                        want_a["lanAttachList"],
+                        have_a["lanAttachList"],
+                        replace,
+                        network_vlan=want_a.get("vlan_id") or 0,
+                    )
 
                     if diff:
                         base = want_a.copy()
                         del base["lanAttachList"]
+                        base.pop("vlan_id", None)
                         base.update({"lanAttachList": diff})
                         diff_attach.append(base)
                         if net:
@@ -3474,6 +3494,7 @@ class DcnmNetwork:
                 if atch_list:
                     base = want_a.copy()
                     del base["lanAttachList"]
+                    base.pop("vlan_id", None)
                     base.update({"lanAttachList": atch_list})
                     diff_attach.append(base)
                     if bool(attach["is_deploy"]):

--- a/tests/integration/targets/dcnm_network/tests/dcnm/standalone/merged.yaml
+++ b/tests/integration/targets/dcnm_network/tests/dcnm/standalone/merged.yaml
@@ -1435,6 +1435,33 @@
       - result.response | length == 0
   tags: merged
 
+- name: MERGED - TC16 - Create Network with invalid attachment vlan id
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ test_data_common.fabric }}"
+    state: merged
+    config:
+      - net_name: ansible-net13
+        vrf_name: Tenant-1
+        net_id: 7005
+        net_template: Default_Network_Universal
+        net_extension_template: Default_Network_Extension_Universal
+        vlan_id: 1500
+        gw_ip_subnet: '192.168.30.1/24'
+        attach:
+          - ip_address: "{{ test_data_common.sw1 }}"
+            vlan_id: 15000
+        deploy: true
+  register: result
+  ignore_errors: true
+  tags: merged
+
+- name: MERGED - TC16 - ASSERT - Check invalid attachment vlan id
+  ansible.builtin.assert:
+    that:
+      - '"Invalid parameters in playbook: vlan_id:15000 : The item exceeds the allowed range of max 4094" in result.msg'
+      - result.changed == false
+  tags: merged
+
 ##############################################
 ##                 CLEAN-UP                 ##
 ##############################################

--- a/tests/unit/modules/dcnm/fixtures/dcnm_network.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_network.json
@@ -2022,5 +2022,80 @@
                 ]
             }
         ]
+    },
+    "playbook_config_attach_vlan_override": [
+        {
+            "net_name": "test_network",
+            "vrf_name": "ansible-vrf-int1",
+            "net_id": "9008011",
+            "net_template": "Default_Network_Universal",
+            "net_extension_template": "Default_Network_Extension_Universal",
+            "vlan_id": "202",
+            "gw_ip_subnet": "192.168.30.1/24",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.217",
+                    "ports": [
+                        "Ethernet1/13",
+                        "Ethernet1/14"
+                    ],
+                    "vlan_id": 300,
+                    "deploy": true
+                },
+                {
+                    "ip_address": "10.10.10.218",
+                    "ports": [
+                        "Ethernet1/13",
+                        "Ethernet1/14"
+                    ],
+                    "deploy": true
+                }
+            ],
+            "deploy": true
+        }
+    ],
+    "mock_net_attach_object_vlan_override": {
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200,
+        "DATA": [
+            {
+                "networkName": "test_network",
+                "lanAttachList": [
+                    {
+                        "networkName": "test_network",
+                        "displayName": "test_network",
+                        "switchName": "n9kv-218",
+                        "switchRole": "leaf",
+                        "fabricName": "test_net",
+                        "lanAttachState": "DEPLOYED",
+                        "isLanAttached": true,
+                        "portNames": "Ethernet1/13,Ethernet1/14",
+                        "switchSerialNo": "9YO9A29F27U",
+                        "switchDbId": 4191270,
+                        "ipAddress": "10.10.10.218",
+                        "networkId": 9008011,
+                        "vlanId": 202,
+                        "interfaceGroups": null
+                    },
+                    {
+                        "networkName": "test_network",
+                        "displayName": "test_network",
+                        "switchName": "n9kv-217",
+                        "switchRole": "leaf",
+                        "fabricName": "test_net",
+                        "lanAttachState": "DEPLOYED",
+                        "isLanAttached": true,
+                        "portNames": "Ethernet1/13,Ethernet1/14",
+                        "switchSerialNo": "9NN7E41N16A",
+                        "switchDbId": 4195850,
+                        "ipAddress": "10.10.10.217",
+                        "networkId": 9008011,
+                        "vlanId": 300,
+                        "interfaceGroups": null
+                    }
+                ]
+            }
+        ]
     }
 }

--- a/tests/unit/modules/dcnm/test_dcnm_network.py
+++ b/tests/unit/modules/dcnm/test_dcnm_network.py
@@ -64,6 +64,8 @@ class TestDcnmNetworkModule(TestDcnmModule):
     playbook_config_replace = test_data.get("playbook_config_replace")
     playbook_config_replace_no_atch = test_data.get("playbook_config_replace_no_atch")
     playbook_config_override = test_data.get("playbook_config_override")
+    playbook_config_attach_vlan_override = test_data.get("playbook_config_attach_vlan_override")
+    mock_net_attach_object_vlan_override = test_data.get("mock_net_attach_object_vlan_override")
     mock_net_attach_object_del_not_ready = test_data.get(
         "mock_net_attach_object_del_not_ready"
     )
@@ -632,6 +634,25 @@ class TestDcnmNetworkModule(TestDcnmModule):
                 self.blank_data,
                 self.attach_success_resp,
                 self.deploy_success_resp,
+            ]
+
+        elif "_merged_attach_vlan_override_new" in self._testMethodName:
+            self.init_data()
+            self.run_dcnm_send.side_effect = [
+                self.mock_vrf_object,
+                self.blank_data,
+                self.blank_data,
+                self.attach_success_resp,
+                self.deploy_success_resp,
+            ]
+
+        elif "_merged_attach_vlan_override_idempotent" in self._testMethodName:
+            self.init_data()
+            self.run_dcnm_get_url.side_effect = [self.mock_net_attach_object_vlan_override]
+            self.run_dcnm_fabric_details.side_effect = [self.fabric_details_vxlan_fabric]
+            self.run_dcnm_send.side_effect = [
+                self.mock_vrf_object,
+                self.mock_net_object,
             ]
 
         elif "replace_with_no_atch" in self._testMethodName:
@@ -2104,3 +2125,48 @@ class TestDcnmNetworkModule(TestDcnmModule):
         self.assertEqual(leaf4_attach["portNames"], "Ethernet1/16,Ethernet1/17")
         self.assertEqual(leaf4_attach["lanAttachState"], "IN PROGRESS")
         self.assertTrue(leaf4_attach["isLanAttached"])
+
+    # ==================== Attachment-level VLAN Override Tests ====================
+
+    def test_dcnm_net_merged_attach_vlan_override_new(self):
+        """Test creating a new network with attachment-level vlan_id override.
+
+        First attachment (10.10.10.217) specifies vlan_id=300 to override network-level vlan_id=202.
+        Second attachment (10.10.10.218) uses network-level vlan_id (no override).
+        """
+        set_module_args(
+            dict(state="merged", fabric="test_network", config=self.playbook_config_attach_vlan_override)
+        )
+        result = self.execute_module(changed=True, failed=False, use_action_plugin=True)
+        self.assertTrue(result.get("diff")[0]["attach"][0]["deploy"])
+        self.assertTrue(result.get("diff")[0]["attach"][1]["deploy"])
+
+    def test_dcnm_net_merged_attach_vlan_override_idempotent(self):
+        """Test idempotency when attachment-level vlan_id matches existing state.
+
+        Network already deployed with first switch having vlan 300 (override) and
+        second switch having vlan 202 (network default). Re-running with same config
+        should produce no changes.
+        """
+        set_module_args(
+            dict(state="merged", fabric="test_network", config=self.playbook_config_attach_vlan_override)
+        )
+        result = self.execute_module(changed=False, failed=False, use_action_plugin=True)
+        self.assertFalse(result.get("diff"))
+
+    def test_dcnm_net_diff_for_attach_deploy_vlan_inherit(self):
+        """Test that vlan=0 in want inherits vlan from have (no change detected)."""
+        dcnm_net = self._build_diff_network(self.net_inv_data)
+
+        have_attach = [
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", vlan=300),
+        ]
+        want_attach = [
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", vlan=0),
+        ]
+
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach))
+
+        # No diff - vlan=0 inherits existing vlan 300
+        self.assertFalse(diff)
+        self.assertFalse(dep_net)

--- a/tests/unit/modules/dcnm/test_dcnm_network.py
+++ b/tests/unit/modules/dcnm/test_dcnm_network.py
@@ -1089,8 +1089,10 @@ class TestDcnmNetworkModule(TestDcnmModule):
         )
         result = self.execute_module(changed=True, failed=False, use_action_plugin=True)
         self.assertEqual(result.get("diff")[0]["vlan_id"], 203)
-        self.assertTrue(result.get("diff")[0]["attach"][0]["deploy"])
-        self.assertFalse(result.get("diff")[0]["attach"][1]["deploy"])
+        deploy_by_ip = {a["ip_address"]: a["deploy"] for a in result.get("diff")[0]["attach"]}
+        self.assertTrue(deploy_by_ip["10.10.10.218"])
+        self.assertTrue(deploy_by_ip["10.10.10.226"])
+        self.assertFalse(deploy_by_ip["10.10.10.217"])
         self.assertEqual(
             result["response"][0]["DATA"]["test-network--9NN7E41N16A(leaf1)"], "SUCCESS"
         )
@@ -1120,8 +1122,10 @@ class TestDcnmNetworkModule(TestDcnmModule):
         self.assertIn(("GET", get_net_path), request_calls)
         self.assertNotIn(("GET", get_net_name_path), request_calls)
         self.assertEqual(result.get("diff")[0]["vlan_id"], 203)
-        self.assertTrue(result.get("diff")[0]["attach"][0]["deploy"])
-        self.assertFalse(result.get("diff")[0]["attach"][1]["deploy"])
+        deploy_by_ip = {a["ip_address"]: a["deploy"] for a in result.get("diff")[0]["attach"]}
+        self.assertTrue(deploy_by_ip["10.10.10.218"])
+        self.assertTrue(deploy_by_ip["10.10.10.226"])
+        self.assertFalse(deploy_by_ip["10.10.10.217"])
 
     def test_dcnm_net_replace_with_no_atch(self):
         set_module_args(
@@ -1501,6 +1505,7 @@ class TestDcnmNetworkModule(TestDcnmModule):
                 "isAttached": True,
                 "deployment": True,
                 "is_deploy": True,
+                "vlan": 0,
                 "torports": [],
             },
             {
@@ -1510,6 +1515,7 @@ class TestDcnmNetworkModule(TestDcnmModule):
                 "isAttached": True,
                 "deployment": True,
                 "is_deploy": True,
+                "vlan": 0,
                 "torports": [
                     {"switch": "dt-n9k6", "torPorts": "Ethernet1/12"},
                     {"switch": "dt-n9k7", "torPorts": "Ethernet1/12"},
@@ -1546,7 +1552,7 @@ class TestDcnmNetworkModule(TestDcnmModule):
         ]
 
         dcnm_net.normalize_vpc_torports(want_attach)
-        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach), replace=True)
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach), replace=True, network_vlan=202)
 
         self.assertFalse(diff)
         self.assertFalse(dep_net)
@@ -2390,3 +2396,55 @@ class TestDcnmNetworkModule(TestDcnmModule):
         # No diff - vlan=0 inherits existing vlan 300
         self.assertFalse(diff)
         self.assertFalse(dep_net)
+
+    def test_dcnm_net_diff_for_attach_deploy_vlan_only_change_merged(self):
+        """Vlan-only change under merged must produce a diff with the new vlan."""
+        dcnm_net = self._build_diff_network(self.net_inv_data)
+
+        have_attach = [
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", vlan=300),
+        ]
+        want_attach = [
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", vlan=301),
+        ]
+
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach))
+
+        self.assertEqual(len(diff), 1)
+        self.assertEqual(diff[0]["vlan"], 301)
+        self.assertEqual(diff[0]["switchPorts"], "Ethernet1/13,Ethernet1/14")
+        self.assertTrue(dep_net)
+
+    def test_dcnm_net_diff_for_attach_deploy_vlan_only_change_replaced(self):
+        """Vlan-only change under replaced must produce a diff with the new vlan."""
+        dcnm_net = self._build_diff_network(self.net_inv_data)
+
+        have_attach = [
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", vlan=300),
+        ]
+        want_attach = [
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", vlan=301),
+        ]
+
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach), replace=True)
+
+        self.assertEqual(len(diff), 1)
+        self.assertEqual(diff[0]["vlan"], 301)
+        self.assertTrue(dep_net)
+
+    def test_dcnm_net_diff_for_attach_deploy_vlan_reset_replaced(self):
+        """Replaced with omitted attach vlan_id must send vlan=0 to reset the override."""
+        dcnm_net = self._build_diff_network(self.net_inv_data)
+
+        have_attach = [
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", vlan=300),
+        ]
+        want_attach = [
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", vlan=0),
+        ]
+
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach), replace=True)
+
+        self.assertEqual(len(diff), 1)
+        self.assertEqual(diff[0]["vlan"], 0)
+        self.assertTrue(dep_net)


### PR DESCRIPTION
Fixes #686 
Tested on ND 3.1, 3.2 and 4.1