### PR TITLE
Fix dcnm_interface overridden handling for fabric peering vPC peer-links with null alias

### DIFF
--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -5473,6 +5473,22 @@ class DcnmIntf:
             }
         )
 
+    def dcnm_intf_is_vpc_peer_link_port_channel(self, intf):
+
+        if intf.get("ifType") != "INTERFACE_PORT_CHANNEL":
+            return False
+
+        alias = intf.get("alias")
+        if alias is not None and "vpc-peer-link" in alias:
+            return True
+
+        underlay_policies = intf.get("underlayPolicies") or []
+        for policy in underlay_policies:
+            if (policy or {}).get("templateName") == "int_vpc_peer_link_po":
+                return True
+
+        return False
+
     def dcnm_intf_process_config(self, cfg):
 
         processed = []
@@ -5736,10 +5752,7 @@ class DcnmIntf:
                 ):
                     # Port-channel which are created as part of VPC peer link should not be deleted
                     if have["ifType"] == "INTERFACE_PORT_CHANNEL":
-                        if (
-                            have["alias"] is not None
-                            and "vpc-peer-link" in have["alias"]
-                        ):
+                        if self.dcnm_intf_is_vpc_peer_link_port_channel(have):
                             self.changed_dict[0]["skipped"].append(
                                 {
                                     "Name": name,

--- a/tests/unit/modules/dcnm/test_dcnm_intf.py
+++ b/tests/unit/modules/dcnm/test_dcnm_intf.py
@@ -54,6 +54,89 @@ class TestDcnmIntfModule(TestDcnmModule):
             "DATA": data,
         }
 
+    def test_dcnm_intf_is_vpc_peer_link_port_channel_null_alias_template(self):
+
+        dcnm_intf = object.__new__(dcnm_interface.DcnmIntf)
+        intf = {
+            "ifType": "INTERFACE_PORT_CHANNEL",
+            "alias": None,
+            "underlayPolicies": [
+                {
+                    "templateName": "int_vpc_peer_link_po",
+                }
+            ],
+        }
+
+        self.assertEqual(
+            dcnm_intf.dcnm_intf_is_vpc_peer_link_port_channel(intf),
+            True,
+        )
+
+    def test_dcnm_intf_is_vpc_peer_link_port_channel_alias(self):
+
+        dcnm_intf = object.__new__(dcnm_interface.DcnmIntf)
+        intf = {
+            "ifType": "INTERFACE_PORT_CHANNEL",
+            "alias": "vpc-peer-link leaf1--leaf2",
+            "underlayPolicies": [],
+        }
+
+        self.assertEqual(
+            dcnm_intf.dcnm_intf_is_vpc_peer_link_port_channel(intf),
+            True,
+        )
+
+    def test_dcnm_intf_is_vpc_peer_link_port_channel_regular_pc(self):
+
+        dcnm_intf = object.__new__(dcnm_interface.DcnmIntf)
+        intf = {
+            "ifType": "INTERFACE_PORT_CHANNEL",
+            "alias": None,
+            "underlayPolicies": [
+                {
+                    "templateName": "int_port_channel_trunk",
+                }
+            ],
+        }
+
+        self.assertEqual(
+            dcnm_intf.dcnm_intf_is_vpc_peer_link_port_channel(intf),
+            False,
+        )
+
+    def test_dcnm_intf_is_vpc_peer_link_port_channel_none_policies(self):
+
+        dcnm_intf = object.__new__(dcnm_interface.DcnmIntf)
+        intf = {
+            "ifType": "INTERFACE_PORT_CHANNEL",
+            "alias": None,
+            "underlayPolicies": None,
+        }
+
+        self.assertEqual(
+            dcnm_intf.dcnm_intf_is_vpc_peer_link_port_channel(intf),
+            False,
+        )
+
+    def test_dcnm_intf_is_vpc_peer_link_port_channel_none_policy_item(self):
+
+        dcnm_intf = object.__new__(dcnm_interface.DcnmIntf)
+        intf = {
+            "ifType": "INTERFACE_PORT_CHANNEL",
+            "alias": None,
+            "underlayPolicies": [
+                None,
+                {
+                    "templateName": "int_vpc_peer_link_po",
+                },
+            ],
+        }
+
+        self.assertEqual(
+            dcnm_intf.dcnm_intf_is_vpc_peer_link_port_channel(intf),
+            True,
+        )
+
     def setUp(self):
 
         super(TestDcnmIntfModule, self).setUp()


### PR DESCRIPTION
## Summary

Fixes #698.

`dcnm_interface` with `state: overridden` already skips NDFC-generated vPC peer-link port-channels so they are not deleted during interface cleanup. However, the current detection depends on the interface `alias` containing `vpc-peer-link`.

In some NDFC responses, the fabric peering vPC peer-link `Port-channel` can have `alias: null`. When that happens, the module does not recognize it as an NDFC-generated peer-link and may mark it for deletion.

This change makes the detection more robust by also checking the NDFC underlay policy template:

- keep the existing alias-based detection
- also treat `templateName: int_vpc_peer_link_po` as a fabric peering vPC peer-link
- safely handle `underlayPolicies: null` and unexpected `None` entries

## Changes

- Added a helper to identify NDFC-generated vPC peer-link port-channels.
- Updated the `state: overridden` diff logic to use that helper.
- Added unit tests for:
  - peer-link port-channel with `alias: null`
  - existing alias-based peer-link detection
  - regular port-channel safety
  - `underlayPolicies: null`
  - `None` entries inside `underlayPolicies`

## Debug evidence

During interactive debugging in `dcnm_intf_get_diff_overridden()`, the problematic interface was an NDFC-generated fabric peering vPC peer-link port-channel.

Before this fix, the skip logic only checked the interface alias:

```python
have["alias"] is not None and "vpc-peer-link" in have["alias"]
```

For the failing case, the relevant values were:

```text
ifType: INTERFACE_PORT_CHANNEL
alias: None
underlayPolicies[0].templateName: int_vpc_peer_link_po
```

Because `alias` was `None`, the old condition evaluated to `False`. The module did not recognize the interface as a protected vPC peer-link, so `state: overridden` could continue processing it as a removable unmanaged interface.

After this fix, the same interface is identified by the NDFC-generated underlay policy template:

```text
ifType: INTERFACE_PORT_CHANNEL
alias: None
underlayPolicies[0].templateName: int_vpc_peer_link_po
helper result: True
```

With this fix, the peer-link port-channel is protected and added to `skipped`. Before the fix, the alias-only check could miss that same interface and allow it to become a deletion candidate in `deleted` / `delete_deploy`.

The post-fix manual run confirmed the behavior in the remove stage:

```text
REMOVE [nac-fabric2-ca] Step 3/10: interface_all (dcnm_interface)
REMOVE [nac-fabric2-ca] interface_all -> ok (changed=False)

deleted: []
delete_deploy: []
Port-channel1: skipped
templateName: int_vpc_peer_link_po
```

## Validation

- Ran targeted unit tests for the new helper.
- Ran existing overridden interface regression tests:
  - `test_dcnm_intf_pc_overridden_existing`
  - `test_dcnm_intf_vpc_overridden_existing`
- Ran a manual VXLAN fabric workflow in a lab environment:
  - create completed successfully
  - deploy completed successfully
  - remove reached `dcnm_interface state=overridden`
  - `interface_all` completed with `changed=False`
  - `deleted=[]` and `delete_deploy=[]`
  - fabric peering `Port-channel1` entries were skipped, not deleted
  - playbook completed with `failed=0`

## Notes

The manual lab run validates the full create/deploy/remove flow. The exact `alias: null` case is covered by the new unit test because that value depends on the NDFC response returned for the peer-link.
