### PR TITLE
Adding support for svi enabled at network attachment level (supported on >= 4.1

### DIFF
--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -1686,9 +1686,13 @@ class DcnmNetwork:
         # NDFC expects lowercase-string booleans inside the instanceValues JSON payload.
         # NDFC-managed keys already present in have (isVPC, isActive, ...) are merged
         # back in later by diff_for_attach_deploy.
-        svi_enabled = bool(attach.pop("svi_enabled", True))
-        inst_values = {"sviEnabled": "true" if svi_enabled else "false"}
-        attach.update({"instanceValues": json.dumps(inst_values)})
+        nd_version = get_nd_version(self._action_module, self._task_vars, self._tmp)
+        if nd_version >= 12.4:
+            svi_enabled = bool(attach.pop("svi_enabled", True))
+            inst_values = {"sviEnabled": "true" if svi_enabled else "false"}
+            attach.update({"instanceValues": json.dumps(inst_values)})
+        else:
+            attach.update({"instanceValues": ""})
         attach.update({"freeformConfig": ""})
         attach.update({"is_deploy": deploy})
 

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -343,6 +343,12 @@ options:
               There will not be any functional impact if specified in playbook.
             type: bool
             default: true
+          svi_enabled:
+            description:
+            - Per switch knob to control whether the Switched Virtual Interface (SVI) is enabled
+            type: bool
+            required: false
+            default: true
           tor_ports:
             description:
             - List of interfaces in the paired TOR switch for this leaf where the network will be attached
@@ -1347,6 +1353,23 @@ class DcnmNetwork:
                     if want["serialNumber"] == have["serialNumber"] and want["networkName"] == have["networkName"]:
                         found = True
 
+                        # Merge instanceValues so playbook-driven keys (sviEnabled) override
+                        # while NDFC-managed keys (isVPC, isActive) are preserved from have.
+                        want_inst_raw = want.get("instanceValues") or ""
+                        have_inst_raw = have.get("instanceValues") or ""
+                        want_inst = json.loads(want_inst_raw) if want_inst_raw else {}
+                        have_inst = json.loads(have_inst_raw) if have_inst_raw else {}
+                        merged_inst = dict(have_inst)
+                        merged_inst.update(want_inst)
+                        want["instanceValues"] = json.dumps(merged_inst) if merged_inst else ""
+                        # Only diff on sviEnabled when NDFC actually returned it.
+                        # Absence in have means "no opinion" - avoids spurious re-deploys
+                        # driven purely by the playbook default.
+                        svi_changed = (
+                            "sviEnabled" in have_inst
+                            and have_inst["sviEnabled"] != want_inst.get("sviEnabled", "false")
+                        )
+
                         if want.get("isAttached") is not None:
                             if bool(have["isAttached"]) and bool(want["isAttached"]):
                                 torports_configured = False
@@ -1464,7 +1487,7 @@ class DcnmNetwork:
                                         dep_net = True
                                     continue
 
-                                elif torports_configured:
+                                elif torports_configured or svi_changed:
                                     del want["isAttached"]
                                     attach_list.append(want)
                                     if bool(want["is_deploy"]):
@@ -1586,7 +1609,12 @@ class DcnmNetwork:
         attach.update({"deployment": True})
         attach.update({"isAttached": True})
         attach.update({"extensionValues": ""})
-        attach.update({"instanceValues": ""})
+        # NDFC expects lowercase-string booleans inside the instanceValues JSON payload.
+        # NDFC-managed keys already present in have (isVPC, isActive, ...) are merged
+        # back in later by diff_for_attach_deploy.
+        svi_enabled = bool(attach.pop("svi_enabled", True))
+        inst_values = {"sviEnabled": "true" if svi_enabled else "false"}
+        attach.update({"instanceValues": json.dumps(inst_values)})
         attach.update({"freeformConfig": ""})
         attach.update({"is_deploy": deploy})
 
@@ -2706,7 +2734,10 @@ class DcnmNetwork:
                 attach.update({"serialNumber": sn})
                 attach.update({"deployment": deploy})
                 attach.update({"extensionValues": ""})
-                attach.update({"instanceValues": ""})
+                # Preserve instanceValues from NDFC so diff can honor sviEnabled.
+                # NDFC returns null for unattached switches; normalize to "".
+                raw_inst = attach.get("instanceValues")
+                attach.update({"instanceValues": raw_inst if raw_inst else ""})
                 attach.update({"freeformConfig": ""})
                 attach.update({"isAttached": attach_state})
                 attach.update({"dot1QVlan": 0})
@@ -5041,6 +5072,7 @@ class DcnmNetwork:
                 ip_address=dict(required=True, type="str"),
                 ports=dict(type="list", default=[]),
                 deploy=dict(type="bool", default=True),
+                svi_enabled=dict(type="bool", default=True),
             )
 
             if self.config:
@@ -5079,6 +5111,7 @@ class DcnmNetwork:
                 ports=dict(type="list", default=[]),
                 deploy=dict(type="bool", default=True),
                 tor_ports=dict(required=False, type="list", elements="dict"),
+                svi_enabled=dict(type="bool", default=True),
             )
             tor_att_spec = dict(
                 ip_address=dict(required=True, type="str"),

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -343,12 +343,6 @@ options:
               There will not be any functional impact if specified in playbook.
             type: bool
             default: true
-          svi_enabled:
-            description:
-            - Per switch knob to control whether the Switched Virtual Interface (SVI) is enabled
-            type: bool
-            required: false
-            default: true
           tor_ports:
             description:
             - List of interfaces in the paired TOR switch for this leaf where the network will be attached

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -1686,8 +1686,7 @@ class DcnmNetwork:
         # NDFC expects lowercase-string booleans inside the instanceValues JSON payload.
         # NDFC-managed keys already present in have (isVPC, isActive, ...) are merged
         # back in later by diff_for_attach_deploy.
-        nd_version = get_nd_version(self._action_module, self._task_vars, self._tmp)
-        if nd_version >= 12.4:
+        if self.dcnm_version >= 12.4:
             svi_enabled = bool(attach.pop("svi_enabled", True))
             inst_values = {"sviEnabled": "true" if svi_enabled else "false"}
             attach.update({"instanceValues": json.dumps(inst_values)})

--- a/tests/unit/modules/dcnm/test_dcnm_network.py
+++ b/tests/unit/modules/dcnm/test_dcnm_network.py
@@ -2328,9 +2328,10 @@ class TestDcnmNetworkModule(TestDcnmModule):
     def _make_bare_dcnm_net(self):
         dcnm_net = dcnm_network.DcnmNetwork.__new__(dcnm_network.DcnmNetwork)
         dcnm_net.log = type("Logger", (), {"debug": lambda *a, **k: None})()
-        dcnm_net.fabric = "juarocha-nac-fabric1"
-        dcnm_net.ip_sn = {"10.6.20.109": "9W28HEH9T5J"}
-        dcnm_net.inventory_data = {"10.6.20.109": {"switchRole": "leaf"}}
+        dcnm_net.fabric = "test-fabric"
+        dcnm_net.ip_sn = {"10.10.10.217": "9NN7E41N16A"}
+        dcnm_net.inventory_data = {"10.10.10.217": {"switchRole": "leaf"}}
+        dcnm_net.dcnm_version = 12.4
 
         class _Module:
             def fail_json(self, **kwargs):
@@ -2343,7 +2344,7 @@ class TestDcnmNetworkModule(TestDcnmModule):
         dcnm_net = self._make_bare_dcnm_net()
         with patch.object(dcnm_network, "dcnm_get_ip_addr_info", lambda module, ip, a, b: ip):
             attach = {
-                "ip_address": "10.6.20.109",
+                "ip_address": "10.10.10.217",
                 "ports": ["Ethernet1/3"],
                 "svi_enabled": True,
             }
@@ -2353,13 +2354,13 @@ class TestDcnmNetworkModule(TestDcnmModule):
         self.assertIn("instanceValues", out)
         inst = json.loads(out["instanceValues"])
         self.assertEqual(inst["sviEnabled"], "true")
-        self.assertEqual(out["serialNumber"], "9W28HEH9T5J")
+        self.assertEqual(out["serialNumber"], "9NN7E41N16A")
         self.assertEqual(out["networkName"], "Test_Network1")
 
     def test_dcnm_net_update_attach_params_defaults_svi_enabled_to_true_when_omitted(self):
         dcnm_net = self._make_bare_dcnm_net()
         with patch.object(dcnm_network, "dcnm_get_ip_addr_info", lambda module, ip, a, b: ip):
-            attach = {"ip_address": "10.6.20.109", "ports": ["Ethernet1/3"]}
+            attach = {"ip_address": "10.10.10.217", "ports": ["Ethernet1/3"]}
             out = dcnm_net.update_attach_params(attach, "Test_Network1", deploy=True)
 
         self.assertEqual(json.loads(out["instanceValues"])["sviEnabled"], "true")
@@ -2368,7 +2369,7 @@ class TestDcnmNetworkModule(TestDcnmModule):
         dcnm_net = self._make_bare_dcnm_net()
         with patch.object(dcnm_network, "dcnm_get_ip_addr_info", lambda module, ip, a, b: ip):
             attach = {
-                "ip_address": "10.6.20.109",
+                "ip_address": "10.10.10.217",
                 "ports": ["Ethernet1/3"],
                 "svi_enabled": False,
             }
@@ -2380,7 +2381,7 @@ class TestDcnmNetworkModule(TestDcnmModule):
         dcnm_net = self._make_bare_dcnm_net()
 
         have_attach = [{
-            "serialNumber": "9W28HEH9T5J",
+            "serialNumber": "9NN7E41N16A",
             "networkName": "Test_Network1",
             "switchPorts": "Ethernet1/3",
             "isAttached": True,
@@ -2405,7 +2406,7 @@ class TestDcnmNetworkModule(TestDcnmModule):
         dcnm_net = self._make_bare_dcnm_net()
 
         have_attach = [{
-            "serialNumber": "9W28HEH9T5J",
+            "serialNumber": "9NN7E41N16A",
             "networkName": "Test_Network1",
             "switchPorts": "Ethernet1/3",
             "isAttached": True,

--- a/tests/unit/modules/dcnm/test_dcnm_network.py
+++ b/tests/unit/modules/dcnm/test_dcnm_network.py
@@ -2104,3 +2104,100 @@ class TestDcnmNetworkModule(TestDcnmModule):
         self.assertEqual(leaf4_attach["portNames"], "Ethernet1/16,Ethernet1/17")
         self.assertEqual(leaf4_attach["lanAttachState"], "IN PROGRESS")
         self.assertTrue(leaf4_attach["isLanAttached"])
+
+    def _make_bare_dcnm_net(self):
+        dcnm_net = dcnm_network.DcnmNetwork.__new__(dcnm_network.DcnmNetwork)
+        dcnm_net.log = type("Logger", (), {"debug": lambda *a, **k: None})()
+        dcnm_net.fabric = "juarocha-nac-fabric1"
+        dcnm_net.ip_sn = {"10.6.20.109": "9W28HEH9T5J"}
+        dcnm_net.inventory_data = {"10.6.20.109": {"switchRole": "leaf"}}
+
+        class _Module:
+            def fail_json(self, **kwargs):
+                raise AssertionError(kwargs)
+
+        dcnm_net.module = _Module()
+        return dcnm_net
+
+    def test_dcnm_net_update_attach_params_serializes_svi_enabled_true(self):
+        dcnm_net = self._make_bare_dcnm_net()
+        with patch.object(dcnm_network, "dcnm_get_ip_addr_info", lambda module, ip, a, b: ip):
+            attach = {
+                "ip_address": "10.6.20.109",
+                "ports": ["Ethernet1/3"],
+                "svi_enabled": True,
+            }
+            out = dcnm_net.update_attach_params(attach, "Test_Network1", deploy=True)
+
+        self.assertNotIn("svi_enabled", out)
+        self.assertIn("instanceValues", out)
+        inst = json.loads(out["instanceValues"])
+        self.assertEqual(inst["sviEnabled"], "true")
+        self.assertEqual(out["serialNumber"], "9W28HEH9T5J")
+        self.assertEqual(out["networkName"], "Test_Network1")
+
+    def test_dcnm_net_update_attach_params_defaults_svi_enabled_to_true_when_omitted(self):
+        dcnm_net = self._make_bare_dcnm_net()
+        with patch.object(dcnm_network, "dcnm_get_ip_addr_info", lambda module, ip, a, b: ip):
+            attach = {"ip_address": "10.6.20.109", "ports": ["Ethernet1/3"]}
+            out = dcnm_net.update_attach_params(attach, "Test_Network1", deploy=True)
+
+        self.assertEqual(json.loads(out["instanceValues"])["sviEnabled"], "true")
+
+    def test_dcnm_net_update_attach_params_serializes_svi_enabled_false_when_explicit(self):
+        dcnm_net = self._make_bare_dcnm_net()
+        with patch.object(dcnm_network, "dcnm_get_ip_addr_info", lambda module, ip, a, b: ip):
+            attach = {
+                "ip_address": "10.6.20.109",
+                "ports": ["Ethernet1/3"],
+                "svi_enabled": False,
+            }
+            out = dcnm_net.update_attach_params(attach, "Test_Network1", deploy=True)
+
+        self.assertEqual(json.loads(out["instanceValues"])["sviEnabled"], "false")
+
+    def test_dcnm_net_diff_for_attach_deploy_svi_enabled_flip_triggers_change(self):
+        dcnm_net = self._make_bare_dcnm_net()
+
+        have_attach = [{
+            "serialNumber": "9W28HEH9T5J",
+            "networkName": "Test_Network1",
+            "switchPorts": "Ethernet1/3",
+            "isAttached": True,
+            "deployment": True,
+            "is_deploy": True,
+            "vlan": 1111,
+            "instanceValues": json.dumps({"isVPC": "false", "sviEnabled": "false", "isActive": "false"}),
+        }]
+        want_attach = copy.deepcopy(have_attach)
+        want_attach[0]["instanceValues"] = json.dumps({"sviEnabled": "true"})
+
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach))
+
+        self.assertTrue(diff)
+        self.assertTrue(dep_net)
+        merged = json.loads(diff[0]["instanceValues"])
+        self.assertEqual(merged["sviEnabled"], "true")
+        self.assertEqual(merged["isVPC"], "false")
+        self.assertEqual(merged["isActive"], "false")
+
+    def test_dcnm_net_diff_for_attach_deploy_svi_enabled_idempotent(self):
+        dcnm_net = self._make_bare_dcnm_net()
+
+        have_attach = [{
+            "serialNumber": "9W28HEH9T5J",
+            "networkName": "Test_Network1",
+            "switchPorts": "Ethernet1/3",
+            "isAttached": True,
+            "deployment": True,
+            "is_deploy": True,
+            "vlan": 1111,
+            "instanceValues": json.dumps({"isVPC": "false", "sviEnabled": "true", "isActive": "false"}),
+        }]
+        want_attach = copy.deepcopy(have_attach)
+        want_attach[0]["instanceValues"] = json.dumps({"sviEnabled": "true"})
+
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach))
+
+        self.assertFalse(diff)
+        self.assertFalse(dep_net)


### PR DESCRIPTION
Fixes #690 

Note:
This feature is only supported on ND v4.1 newer. 

I didn't see any version knob on the repo for this type of features