### PR TITLE
Fix ND 4.1/4.2 fabric updates with empty boolean _PREV values

### DIFF
--- a/plugins/module_utils/fabric/update.py
+++ b/plugins/module_utils/fabric/update.py
@@ -65,6 +65,9 @@ class FabricUpdateCommon(FabricCommon):
         -   Initialize STP_BRIDGE_PRIORITY to empty string if:
             - STP_ROOT_OPTION is "unmanaged"
             - STP_BRIDGE_PRIORITY is not already present in payload
+        -   Normalize boolean previous-value fields to "false" if empty:
+            - INBAND_MGMT_PREV
+            - securityGroupTagMacSegmentation_PREV
 
         Args:
             payload: Dictionary containing fabric parameters
@@ -77,6 +80,14 @@ class FabricUpdateCommon(FabricCommon):
         if "STP_ROOT_OPTION" in payload and payload["STP_ROOT_OPTION"] == "unmanaged":
             if "STP_BRIDGE_PRIORITY" not in payload:
                 payload["STP_BRIDGE_PRIORITY"] = ""
+
+        boolean_previous_value_keys = [
+            "INBAND_MGMT_PREV",
+            "securityGroupTagMacSegmentation_PREV",
+        ]
+        for key in boolean_previous_value_keys:
+            if payload.get(key) == "":
+                payload[key] = "false"
 
         problematic_keys = [
             "dcnmUser",

--- a/tests/unit/modules/dcnm/dcnm_fabric/test_fabric_update_bulk.py
+++ b/tests/unit/modules/dcnm/dcnm_fabric/test_fabric_update_bulk.py
@@ -77,6 +77,141 @@ def test_fabric_update_bulk_00000(fabric_update_bulk) -> None:
     assert instance.fabric_types.class_name == "FabricTypes"
 
 
+@pytest.mark.parametrize(
+    "input_value, expected_value",
+    [
+        ("", "false"),
+        ("false", "false"),
+        ("true", "true"),
+    ],
+)
+def test_remove_nd4x_problematic_keys_normalizes_boolean_previous_values(fabric_update_bulk, input_value, expected_value) -> None:
+    """
+    ND 4.2 can return empty previous boolean values, but rejects those values
+    when dcnm_fabric sends the complete nvPairs payload on update.
+    """
+    payload = {
+        "INBAND_MGMT": "",
+        "INBAND_MGMT_PREV": input_value,
+        "MPLS_ISIS_AREA_NUM_PREV": "",
+        "securityGroupTagMacSegmentation": "",
+        "securityGroupTagMacSegmentation_PREV": input_value,
+    }
+
+    fabric_update_bulk._remove_nd4x_problematic_keys(payload)
+
+    assert payload["INBAND_MGMT"] == ""
+    assert payload["INBAND_MGMT_PREV"] == expected_value
+    assert payload["MPLS_ISIS_AREA_NUM_PREV"] == ""
+    assert payload["securityGroupTagMacSegmentation"] == ""
+    assert payload["securityGroupTagMacSegmentation_PREV"] == expected_value
+
+
+def test_remove_nd4x_problematic_keys_does_not_add_absent_previous_values(fabric_update_bulk) -> None:
+    payload = {"SYSLOG_SEV": "4,4"}
+
+    fabric_update_bulk._remove_nd4x_problematic_keys(payload)
+
+    assert payload == {"SYSLOG_SEV": "4,4"}
+
+
+@pytest.mark.parametrize(
+    "is_controller_version_4x, expected_payload",
+    [
+        (
+            True,
+            {
+                "BGP_AS": "65001",
+                "DEPLOY": False,
+                "FABRIC_NAME": "f1",
+                "FABRIC_TYPE": "VXLAN_EVPN",
+                "INBAND_MGMT": "",
+                "INBAND_MGMT_PREV": "false",
+                "SYSLOG_SEV": "4,4",
+                "securityGroupTagMacSegmentation": "",
+                "securityGroupTagMacSegmentation_PREV": "false",
+            },
+        ),
+        (
+            False,
+            {
+                "DEPLOY": False,
+                "FABRIC_NAME": "f1",
+                "FABRIC_TYPE": "VXLAN_EVPN",
+                "SYSLOG_SEV": "4,4",
+            },
+        ),
+    ],
+)
+def test_fabric_update_payload_normalizes_nd4x_boolean_previous_values(
+    fabric_update_bulk,
+    is_controller_version_4x,
+    expected_payload,
+) -> None:
+    """Normalize controller nvPairs only in the ND 4.x full-payload path."""
+    controller_version = MockControllerVersion()
+    controller_version.is_controller_version_4x = is_controller_version_4x
+
+    fabric_update_bulk.controller_version = controller_version
+    fabric_update_bulk.fabric_details = FabricDetailsByName()
+    fabric_update_bulk.fabric_details.data = {
+        "f1": {
+            "nvPairs": {
+                "BGP_AS": "65001",
+                "FABRIC_NAME": "f1",
+                "INBAND_MGMT": "",
+                "INBAND_MGMT_PREV": "",
+                "SYSLOG_SEV": "3,3",
+                "securityGroupTagMacSegmentation": "",
+                "securityGroupTagMacSegmentation_PREV": "",
+            }
+        }
+    }
+    payload = {
+        "BGP_AS": "65001",
+        "DEPLOY": False,
+        "FABRIC_NAME": "f1",
+        "FABRIC_TYPE": "VXLAN_EVPN",
+        "SYSLOG_SEV": "4,4",
+    }
+
+    fabric_update_bulk._fabric_needs_update_for_merged_state(payload)
+
+    assert fabric_update_bulk._fabric_changes_payload["f1"] == expected_payload
+
+
+def test_fabric_update_idempotent_payload_does_not_trigger_nd4x_normalization(fabric_update_bulk) -> None:
+    """No full payload or update is built when the requested settings already match."""
+    controller_version = MockControllerVersion()
+    controller_version.is_controller_version_4x = True
+
+    fabric_update_bulk.controller_version = controller_version
+    fabric_update_bulk.fabric_details = FabricDetailsByName()
+    fabric_update_bulk.fabric_details.data = {
+        "f1": {
+            "nvPairs": {
+                "BGP_AS": "65001",
+                "FABRIC_NAME": "f1",
+                "INBAND_MGMT_PREV": "",
+                "SYSLOG_SEV": "4,4",
+                "securityGroupTagMacSegmentation_PREV": "",
+            }
+        }
+    }
+    payload = {
+        "BGP_AS": "65001",
+        "DEPLOY": False,
+        "FABRIC_NAME": "f1",
+        "FABRIC_TYPE": "VXLAN_EVPN",
+        "SYSLOG_SEV": "4,4",
+    }
+
+    fabric_update_bulk._fabric_needs_update_for_merged_state(payload)
+
+    assert True not in fabric_update_bulk._fabric_update_required
+    assert fabric_update_bulk._fabric_changes_payload["f1"] == payload
+
+
 def test_fabric_update_bulk_00020(fabric_update_bulk) -> None:
     """
     ### Classes and Methods


### PR DESCRIPTION
## Summary

Fixes #703.

ND 4.1 and 4.2 rejects updates to existing VXLAN EVPN fabrics when the full payload contains these empty boolean previous-value fields:

```json
{
  "INBAND_MGMT_PREV": "",
  "securityGroupTagMacSegmentation_PREV": ""
}
```

This change normalizes those values to `"false"` before `dcnm_fabric` sends the update.

## Problem

ND 4.x requires all fabric `nvPairs` to be included in a fabric update.

When an existing fabric requires an update, `dcnm_fabric`:

1. Copies the current `nvPairs` returned by NDFC.
2. Applies the requested changes.
3. Sends the complete payload through PUT.

ND 4.2 can return these values:

```json
{
  "INBAND_MGMT": "",
  "INBAND_MGMT_PREV": "",
  "securityGroupTagMacSegmentation": "",
  "securityGroupTagMacSegmentation_PREV": ""
}
```

However, the ND 4.1 and 4.2 PUT endpoint rejects the two empty boolean `_PREV` values and requires:

```json
{
  "INBAND_MGMT_PREV": "false",
  "securityGroupTagMacSegmentation_PREV": "false"
}
```

As a result, changing an unrelated fabric setting can fail.

## Reproduction

The issue was reproduced on:

```text
Nexus Dashboard 4.2.1 / 4.1.1g
NDFC 12.5.0.475 / 12.4.1.321

cisco.dcnm 3.12.1-dev
```

The only requested change was:

```text
SYSLOG_SEV: "3,3" -> "4,4"
```

No SGT or in-band management setting was changed.

The failed PUT contained:

```json
{
  "INBAND_MGMT": "",
  "INBAND_MGMT_PREV": "",
  "securityGroupTagMacSegmentation": "",
  "securityGroupTagMacSegmentation_PREV": "",
  "SYSLOG_SEV": "4,4"
}
```

NDFC rejected it:

```text
METHOD: PUT
REQUEST_PATH: .../rest/control/fabrics/nac-fabric2/Easy_Fabric
RETURN_CODE: 500
```

```text
Failed to update the fabric, due to invalid fields
[{securityGroupTagMacSegmentation_PREV=, INBAND_MGMT_PREV=}],
please provide valid fields
[{securityGroupTagMacSegmentation_PREV=false, INBAND_MGMT_PREV=false}]
```

## Root Cause

The initial greenfield create is not affected because the create payload is built from the user configuration. No existing controller `nvPairs` are copied.

After creation, ND 4.1 and 4.2 may store the boolean `_PREV` fields as empty strings. A later fabric-settings update copies those values into the required ND 4.x full payload, and the controller rejects them.

A fabric created successfully as greenfield can therefore fail during a later update.

## Fix

Update `FabricUpdateCommon._remove_nd4x_problematic_keys()` to normalize only the two confirmed boolean previous-value fields when they are empty:

```python
boolean_previous_value_keys = [
    "INBAND_MGMT_PREV",
    "securityGroupTagMacSegmentation_PREV",
]

for key in boolean_previous_value_keys:
    if payload.get(key) == "":
        payload[key] = "false"
```

These are NDFC-controlled internal/previous-value fields. They are normalized rather than removed because ND 4.1, 4.2 explicitly requires both fields with value `"false"`.

The fix intentionally:

* Changes only the ND 4.x full-update path.
* Changes only empty values.
* Preserves existing `"true"` and `"false"` values.
* Does not add keys that are absent.
* Does not normalize unrelated `_PREV` fields.
* Leaves the current fields unchanged:

  ```json
  {
    "INBAND_MGMT": "",
    "securityGroupTagMacSegmentation": ""
  }
  ```

## Affected Scenarios

The failure can occur when an existing fabric requires a fabric-settings PUT:

* Brownfield reconciliation.
* A second deployment containing a fabric-setting change.
* Drift remediation.
* Updates after an ND upgrade.
* Changes introduced by collection defaults.
* Standalone VXLAN EVPN fabric updates.
* VXLAN EVPN child-fabric updates under MSD or MCFG.

The initial create and idempotent runs without fabric-setting changes are not affected.

## Unit Tests

Added coverage for:

* Empty values are normalized to `"false"`.
* Existing `"false"` values are preserved.
* Existing `"true"` values are preserved.
* Absent keys are not added.
* Unrelated `_PREV` fields remain unchanged.
* ND 4.x full-payload updates are normalized.
* ND 3.x continues to use the unchanged delta payload.
* Idempotent ND 4.x runs do not build an update payload.

```text
41 passed
```

Additional checks:

```text
black: passed
compileall: passed
git diff --check: passed
```

## Related Work

* #609 introduced the ND 4.x full-payload update behavior.
* #615 / #616 and #622 added sanitation for other problematic ND 4.x fields.
* #696 tracks the broader handling of empty feature-dependent `nvPairs`.
* netascode/ansible-dc-vxlan#826 prevents invalid SGT fields during fabric creation.

The earlier sanitation fixes handle different controller-returned fields, including `INBAND_ENABLE_PREV`, but do not handle the distinct `INBAND_MGMT_PREV` or `securityGroupTagMacSegmentation_PREV` fields rejected by ND 4.1 and 4.2.

The `ansible-dc-vxlan` change prevents an invalid create payload. This fix addresses the separate `dcnm_fabric` update path and also handles `INBAND_MGMT_PREV`, which is unrelated to the SGT template.
