### PR TITLE
Fix physical Ethernet state=deleted reset on ND 4.2

### DIFF
--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -5467,6 +5467,10 @@ class DcnmIntf:
 
         return None
 
+    def dcnm_intf_capability_enabled(self, intf, capability):
+
+        return str(intf.get(capability)).strip().lower() == "true"
+
     def dcnm_intf_skip_non_resolvable_deferred(self, intf):
 
         self.changed_dict[0]["skipped"].append(
@@ -5476,6 +5480,37 @@ class DcnmIntf:
                 "Deletable": intf.get("deletable"),
                 "Underlay Policies": intf.get("underlayPolicies"),
                 "Reason": "Non-deletable interface without resolvable underlay policy source",
+            }
+        )
+
+    def dcnm_intf_skip_physical_default_not_allowed(self, intf):
+
+        self.changed_dict[0]["skipped"].append(
+            {
+                "Name": intf["ifName"],
+                "Alias": intf.get("alias"),
+                "Deletable": intf.get("deletable"),
+                "Edit Allowed": intf.get("editAllowed"),
+                "Reason": (
+                    "Physical interface reset is not allowed because neither "
+                    "deletable nor editAllowed is true"
+                ),
+            }
+        )
+
+    def dcnm_intf_skip_edit_allowed_underlay_dependency(self, intf):
+
+        self.changed_dict[0]["skipped"].append(
+            {
+                "Name": intf["ifName"],
+                "Alias": intf.get("alias"),
+                "Deletable": intf.get("deletable"),
+                "Edit Allowed": intf.get("editAllowed"),
+                "Underlay Policies": intf.get("underlayPolicies"),
+                "Reason": (
+                    "Physical interface reset through editAllowed was skipped "
+                    "because its underlay policy source is not being deleted"
+                ),
             }
         )
 
@@ -5644,24 +5679,34 @@ class DcnmIntf:
                         )
                         continue
 
-                if str(have["deletable"]).lower() == "false":
+                if (
+                    str(have.get("deletable")).strip().lower()
+                    == "false"
+                ):
                     source = self.dcnm_intf_get_underlay_policy_source(have)
 
-                    if source is None:
+                    if source is not None:
+                        # Add this 'have to a deferred list. We will process this list once we have processed all the 'haves'
+                        defer_list.append(have)
+                        self.changed_dict[0]["deferred"].append(
+                            {
+                                "Name": name,
+                                "Deletable": have["deletable"],
+                                "Underlay Policies": have["underlayPolicies"],
+                                "Source": source,
+                            }
+                        )
+                        continue
+
+                    if self.module.params["state"] != "deleted":
                         self.dcnm_intf_skip_non_resolvable_deferred(have)
                         continue
 
-                    # Add this 'have to a deferred list. We will process this list once we have processed all the 'haves'
-                    defer_list.append(have)
-                    self.changed_dict[0]["deferred"].append(
-                        {
-                            "Name": name,
-                            "Deletable": have["deletable"],
-                            "Underlay Policies": have["underlayPolicies"],
-                            "Source": source,
-                        }
-                    )
-                    continue
+                    if not self.dcnm_intf_capability_enabled(
+                        have, "editAllowed"
+                    ):
+                        self.dcnm_intf_skip_physical_default_not_allowed(have)
+                        continue
 
                 uelem = self.dcnm_intf_get_default_eth_payload(
                     name, sno, fabric
@@ -6089,12 +6134,21 @@ class DcnmIntf:
                                 )
                             ):
 
-                                if (
-                                    str(match_have["deletable"]).lower()
-                                    == "false"
-                                ):
+                                deletable = self.dcnm_intf_capability_enabled(
+                                    match_have, "deletable"
+                                )
+                                edit_allowed = self.dcnm_intf_capability_enabled(
+                                    match_have, "editAllowed"
+                                )
+                                if not deletable and not edit_allowed:
+                                    self.dcnm_intf_skip_physical_default_not_allowed(
+                                        match_have
+                                    )
                                     continue
 
+                                using_edit_allowed = (
+                                    not deletable and edit_allowed
+                                )
                                 uelem = self.dcnm_intf_get_default_eth_payload(
                                     intf["ifName"],
                                     intf["serialNumber"],
@@ -6124,9 +6178,26 @@ class DcnmIntf:
                                         match_have
                                     )
                                     if rc is True:
-                                        if self.dcnm_intf_should_defer_deleted_member_default(
-                                            match_have, iface
+                                        defer_member_default = (
+                                            self.dcnm_intf_should_defer_deleted_member_default(
+                                                match_have, iface
+                                            )
+                                        )
+                                        source = (
+                                            self.dcnm_intf_get_underlay_policy_source(
+                                                match_have
+                                            )
+                                        )
+                                        if (
+                                            using_edit_allowed
+                                            and source is not None
+                                            and not defer_member_default
                                         ):
+                                            self.dcnm_intf_skip_edit_allowed_underlay_dependency(
+                                                match_have
+                                            )
+                                            continue
+                                        if defer_member_default:
                                             self.dcnm_intf_defer_deleted_member_default(
                                                 intf["ifName"],
                                                 intf["serialNumber"],

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -5679,10 +5679,32 @@ class DcnmIntf:
                         )
                         continue
 
-                if (
-                    str(have.get("deletable")).strip().lower()
-                    == "false"
-                ):
+                is_deleted = self.module.params["state"] == "deleted"
+                deletable = self.dcnm_intf_capability_enabled(
+                    have, "deletable"
+                )
+                edit_allowed = self.dcnm_intf_capability_enabled(
+                    have, "editAllowed"
+                )
+
+                # A bulk deleted request must make the same fail-closed
+                # capability decision as a named deleted request. Missing or
+                # unrecognized controller metadata is not authorization to
+                # reset a physical interface.
+                if is_deleted and not deletable and not edit_allowed:
+                    self.dcnm_intf_skip_physical_default_not_allowed(have)
+                    continue
+
+                raw_deletable_is_false = (
+                    str(have.get("deletable")).strip().lower() == "false"
+                )
+                needs_dependency_handling = (
+                    not deletable
+                    if is_deleted
+                    else raw_deletable_is_false
+                )
+
+                if needs_dependency_handling:
                     source = self.dcnm_intf_get_underlay_policy_source(have)
 
                     if source is not None:
@@ -5691,21 +5713,15 @@ class DcnmIntf:
                         self.changed_dict[0]["deferred"].append(
                             {
                                 "Name": name,
-                                "Deletable": have["deletable"],
+                                "Deletable": have.get("deletable"),
                                 "Underlay Policies": have["underlayPolicies"],
                                 "Source": source,
                             }
                         )
                         continue
 
-                    if self.module.params["state"] != "deleted":
+                    if not is_deleted:
                         self.dcnm_intf_skip_non_resolvable_deferred(have)
-                        continue
-
-                    if not self.dcnm_intf_capability_enabled(
-                        have, "editAllowed"
-                    ):
-                        self.dcnm_intf_skip_physical_default_not_allowed(have)
                         continue
 
                 uelem = self.dcnm_intf_get_default_eth_payload(
@@ -7106,14 +7122,15 @@ def main():
         or dcnm_intf.diff_delete[dcnm_intf.int_index["INTERFACE_VLAN"]]
         or dcnm_intf.diff_delete[dcnm_intf.int_index["STRAIGHT_TROUGH_FEX"]]
         or dcnm_intf.diff_delete[dcnm_intf.int_index["AA_FEX"]]
-        or dcnm_intf.diff_delete_deploy
+        or any(dcnm_intf.diff_delete_deploy)
+        or dcnm_intf.diff_create_breakout
+        or dcnm_intf.diff_delete_breakout
     ):
         dcnm_intf.result["changed"] = True
     else:
         module.exit_json(**dcnm_intf.result)
 
     if module.check_mode:
-        dcnm_intf.result["changed"] = False
         module.exit_json(**dcnm_intf.result)
 
     dcnm_intf.dcnm_intf_send_message_to_dcnm()

--- a/tests/unit/modules/dcnm/test_dcnm_intf.py
+++ b/tests/unit/modules/dcnm/test_dcnm_intf.py
@@ -54,6 +54,17 @@ class TestDcnmIntfModule(TestDcnmModule):
             "DATA": data,
         }
 
+    def assert_no_mutating_dcnm_calls(self):
+
+        mutating_methods = {"POST", "PUT", "DELETE"}
+        self.assertFalse(
+            any(
+                call.args[1] in mutating_methods
+                for call in self.run_dcnm_send.call_args_list
+                if len(call.args) > 1
+            )
+        )
+
     def test_dcnm_intf_is_vpc_peer_link_port_channel_null_alias_template(self):
 
         dcnm_intf = object.__new__(dcnm_interface.DcnmIntf)
@@ -3323,10 +3334,11 @@ class TestDcnmIntfModule(TestDcnmModule):
                 config=self.playbook_config,
             )
         )
-        result = self.execute_module(changed=False, failed=False)
+        result = self.execute_module(changed=True, failed=False)
 
         self.assertEqual(len(result["diff"][0]["merged"]), 5)
         self.assertFalse(result.get("response"))
+        self.assert_no_mutating_dcnm_calls()
         for d in result["diff"][0]["merged"]:
             for intf in d["interfaces"]:
                 self.assertEqual(
@@ -4005,7 +4017,13 @@ class TestDcnmIntfModule(TestDcnmModule):
             else:
                 intf["editAllowed"] = edit_allowed
 
-    def prepare_nd42_deleted_all_eth_test(self):
+    def prepare_nd42_deleted_all_eth_test(
+        self,
+        deletable=False,
+        edit_allowed=True,
+        omit_deletable=False,
+        omit_edit_allowed=False,
+    ):
 
         self.config_data = loadPlaybookData("dcnm_intf_common_configs")
         self.have_all_payloads_data = copy.deepcopy(
@@ -4017,8 +4035,14 @@ class TestDcnmIntfModule(TestDcnmModule):
                 intf["ifType"] == "INTERFACE_ETHERNET"
                 and str(intf["isPhysical"]).lower() == "true"
             ):
-                intf["deletable"] = False
-                intf["editAllowed"] = True
+                if omit_deletable:
+                    intf.pop("deletable", None)
+                else:
+                    intf["deletable"] = deletable
+                if omit_edit_allowed:
+                    intf.pop("editAllowed", None)
+                else:
+                    intf["editAllowed"] = edit_allowed
 
         self.playbook_config = self.config_data.get("override_eth_only_config")
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
@@ -4031,6 +4055,32 @@ class TestDcnmIntfModule(TestDcnmModule):
             "mock_monitor_false_resp"
         )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
+
+    def set_eth_deleted_payloads_to_role_default(self):
+
+        payload_names = [
+            "eth_merged_trunk_payloads",
+            "eth_merged_access_payloads",
+            "eth_merged_routed_payloads",
+            "eth_merged_epl_routed_payloads",
+            "eth_merged_monitor_payloads",
+        ]
+        for payload_name in payload_names:
+            payload = self.payloads_data[payload_name]["DATA"][0]
+            ifname = payload["interfaces"][0]["ifName"]
+            payload["policy"] = "int_routed_host_11_1"
+            payload["interfaces"][0]["nvPairs"] = {
+                "MTU": 9216,
+                "SPEED": "Auto",
+                "DESC": "",
+                "CONF": "no shutdown",
+                "ADMIN_STATE": True,
+                "INTF_NAME": ifname,
+                "INTF_VRF": "",
+                "IP": "",
+                "PREFIX": "",
+                "ROUTING_TAG": "",
+            }
 
     def test_dcnm_intf_eth_deleted_existing(self):
 
@@ -4103,39 +4153,17 @@ class TestDcnmIntfModule(TestDcnmModule):
                 config=self.playbook_config,
             )
         )
-        result = self.execute_module(changed=False, failed=False)
+        result = self.execute_module(changed=True, failed=False)
 
         self.assertEqual(len(result["diff"][0]["replaced"]), 5)
         self.assertFalse(result.get("response"))
+        self.assert_no_mutating_dcnm_calls()
 
     def test_dcnm_intf_eth_deleted_existing_nd42_idempotent(self):
 
         self.prepare_eth_deleted_existing_test()
         self.set_eth_deleted_capabilities(False, True)
-
-        payload_names = [
-            "eth_merged_trunk_payloads",
-            "eth_merged_access_payloads",
-            "eth_merged_routed_payloads",
-            "eth_merged_epl_routed_payloads",
-            "eth_merged_monitor_payloads",
-        ]
-        for payload_name in payload_names:
-            payload = self.payloads_data[payload_name]["DATA"][0]
-            ifname = payload["interfaces"][0]["ifName"]
-            payload["policy"] = "int_routed_host_11_1"
-            payload["interfaces"][0]["nvPairs"] = {
-                "MTU": 9216,
-                "SPEED": "Auto",
-                "DESC": "",
-                "CONF": "no shutdown",
-                "ADMIN_STATE": True,
-                "INTF_NAME": ifname,
-                "INTF_VRF": "",
-                "IP": "",
-                "PREFIX": "",
-                "ROUTING_TAG": "",
-            }
+        self.set_eth_deleted_payloads_to_role_default()
 
         set_module_args(
             dict(
@@ -4149,6 +4177,27 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.assertEqual(len(result["diff"][0]["replaced"]), 0)
         self.assertEqual(len(result["diff"][0]["skipped"]), 0)
         self.assertFalse(result.get("response"))
+
+    def test_dcnm_intf_eth_deleted_existing_nd42_check_mode_idempotent(self):
+
+        self.prepare_eth_deleted_existing_test()
+        self.set_eth_deleted_capabilities(False, True)
+        self.set_eth_deleted_payloads_to_role_default()
+
+        set_module_args(
+            dict(
+                state="deleted",
+                _ansible_check_mode=True,
+                fabric="test_fabric",
+                config=self.playbook_config,
+            )
+        )
+        result = self.execute_module(changed=False, failed=False)
+
+        self.assertEqual(len(result["diff"][0]["replaced"]), 0)
+        self.assertEqual(len(result["diff"][0]["skipped"]), 0)
+        self.assertFalse(result.get("response"))
+        self.assert_no_mutating_dcnm_calls()
 
     def test_dcnm_intf_eth_deleted_existing_nd42_underlay_dependency(self):
 
@@ -4202,6 +4251,25 @@ class TestDcnmIntfModule(TestDcnmModule):
 
         self.prepare_eth_deleted_existing_test()
         self.set_eth_deleted_capabilities(False)
+
+        set_module_args(
+            dict(
+                state="deleted",
+                fabric="test_fabric",
+                config=self.playbook_config,
+            )
+        )
+        result = self.execute_module(changed=False, failed=False)
+
+        self.assertEqual(len(result["diff"][0]["replaced"]), 0)
+        self.assertEqual(len(result["diff"][0]["skipped"]), 5)
+
+    def test_dcnm_intf_eth_deleted_existing_unknown_deletable_not_editable(
+        self,
+    ):
+
+        self.prepare_eth_deleted_existing_test()
+        self.set_eth_deleted_capabilities(None, False)
 
         set_module_args(
             dict(
@@ -6640,6 +6708,125 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.assertEqual(len(result["diff"][0]["replaced"]), 3)
         self.assertEqual(len(result["diff"][0]["skipped"]), 0)
 
+    def test_dcnm_intf_override_eth_intf_types_only_deleted_nd42_fail_closed(
+        self,
+    ):
+
+        invalid_capabilities = [
+            ("missing deletable", None, False, True, False),
+            ("null deletable", None, False, False, False),
+            ("blank deletable", "", False, False, False),
+            ("numeric zero deletable", 0, False, False, False),
+            ("unknown deletable", "unknown", False, False, False),
+            ("both false", False, False, False, False),
+            ("both missing", None, None, True, True),
+        ]
+
+        for (
+            description,
+            deletable,
+            edit_allowed,
+            omit_deletable,
+            omit_edit_allowed,
+        ) in invalid_capabilities:
+            with self.subTest(description):
+                self.prepare_nd42_deleted_all_eth_test(
+                    deletable=deletable,
+                    edit_allowed=edit_allowed,
+                    omit_deletable=omit_deletable,
+                    omit_edit_allowed=omit_edit_allowed,
+                )
+
+                set_module_args(
+                    dict(
+                        state="deleted",
+                        fabric="test_fabric",
+                        override_intf_types=["eth"],
+                        deploy=False,
+                        config=[],
+                    )
+                )
+                result = self.execute_module(changed=False, failed=False)
+
+                self.assertEqual(len(result["diff"][0]["deleted"]), 0)
+                self.assertEqual(len(result["diff"][0]["replaced"]), 0)
+                self.assertEqual(len(result["diff"][0]["deploy"]), 0)
+                self.assertEqual(len(result["diff"][0]["skipped"]), 3)
+                self.assertTrue(
+                    all(
+                        skipped["Reason"]
+                        == (
+                            "Physical interface reset is not allowed because "
+                            "neither deletable nor editAllowed is true"
+                        )
+                        for skipped in result["diff"][0]["skipped"]
+                    )
+                )
+                self.assertFalse(result.get("response"))
+                self.assert_no_mutating_dcnm_calls()
+
+    def test_dcnm_intf_override_eth_intf_types_only_deleted_nd42_capability_true(
+        self,
+    ):
+
+        valid_capabilities = [
+            ("boolean deletable", True, False, False, False),
+            ("string deletable", " TRUE ", None, False, True),
+            ("boolean edit allowed", False, True, False, False),
+            ("string edit allowed", None, " TRUE ", True, False),
+        ]
+
+        for (
+            description,
+            deletable,
+            edit_allowed,
+            omit_deletable,
+            omit_edit_allowed,
+        ) in valid_capabilities:
+            with self.subTest(description):
+                self.prepare_nd42_deleted_all_eth_test(
+                    deletable=deletable,
+                    edit_allowed=edit_allowed,
+                    omit_deletable=omit_deletable,
+                    omit_edit_allowed=omit_edit_allowed,
+                )
+
+                set_module_args(
+                    dict(
+                        state="deleted",
+                        fabric="test_fabric",
+                        override_intf_types=["eth"],
+                        deploy=False,
+                        config=[],
+                    )
+                )
+                result = self.execute_module(changed=True, failed=False)
+
+                self.assertEqual(len(result["diff"][0]["replaced"]), 3)
+                self.assertEqual(len(result["diff"][0]["skipped"]), 0)
+
+    def test_dcnm_intf_override_eth_intf_types_only_deleted_nd42_check_mode(
+        self,
+    ):
+
+        self.prepare_nd42_deleted_all_eth_test()
+
+        set_module_args(
+            dict(
+                state="deleted",
+                _ansible_check_mode=True,
+                fabric="test_fabric",
+                override_intf_types=["eth"],
+                deploy=False,
+                config=[],
+            )
+        )
+        result = self.execute_module(changed=True, failed=False)
+
+        self.assertEqual(len(result["diff"][0]["replaced"]), 3)
+        self.assertFalse(result.get("response"))
+        self.assert_no_mutating_dcnm_calls()
+
     def test_dcnm_intf_override_eth_intf_types_only_deleted_nd42_switch_only(
         self,
     ):
@@ -6673,6 +6860,75 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.assertEqual(len(result["diff"][0]["deleted"]), 0)
         self.assertEqual(len(result["diff"][0]["skipped"]), 0)
 
+    def test_dcnm_intf_override_eth_intf_types_only_deleted_nd42_switch_only_fail_closed(
+        self,
+    ):
+
+        self.prepare_nd42_deleted_all_eth_test(
+            edit_allowed=False,
+            omit_deletable=True,
+        )
+
+        set_module_args(
+            dict(
+                state="deleted",
+                fabric="test_fabric",
+                override_intf_types=["eth"],
+                deploy=False,
+                config=[
+                    {
+                        "switch": ["192.168.1.108"],
+                        "deploy": False,
+                    }
+                ],
+            )
+        )
+        result = self.execute_module(changed=False, failed=False)
+
+        self.assertEqual(len(result["diff"][0]["deleted"]), 0)
+        self.assertEqual(len(result["diff"][0]["replaced"]), 0)
+        self.assertEqual(len(result["diff"][0]["deploy"]), 0)
+        self.assertEqual(len(result["diff"][0]["skipped"]), 3)
+        self.assertTrue(
+            all(
+                skipped["Reason"]
+                == (
+                    "Physical interface reset is not allowed because neither "
+                    "deletable nor editAllowed is true"
+                )
+                for skipped in result["diff"][0]["skipped"]
+            )
+        )
+        self.assertFalse(result.get("response"))
+        self.assert_no_mutating_dcnm_calls()
+
+    def test_dcnm_intf_override_eth_intf_types_only_deleted_nd42_switch_only_check_mode(
+        self,
+    ):
+
+        self.prepare_nd42_deleted_all_eth_test()
+
+        set_module_args(
+            dict(
+                state="deleted",
+                _ansible_check_mode=True,
+                fabric="test_fabric",
+                override_intf_types=["eth"],
+                deploy=False,
+                config=[
+                    {
+                        "switch": ["192.168.1.108"],
+                        "deploy": False,
+                    }
+                ],
+            )
+        )
+        result = self.execute_module(changed=True, failed=False)
+
+        self.assertEqual(len(result["diff"][0]["replaced"]), 3)
+        self.assertFalse(result.get("response"))
+        self.assert_no_mutating_dcnm_calls()
+
     def test_dcnm_intf_override_eth_intf_types_only_deleted_nd42_dependency(
         self,
     ):
@@ -6680,6 +6936,7 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.prepare_nd42_deleted_all_eth_test()
         for intf in self.have_all_payloads_data["payloads"]["DATA"]:
             if intf["ifName"] == "Ethernet1/1":
+                intf.pop("deletable", None)
                 intf["underlayPolicies"] = [
                     {"source": "port-channel300"}
                 ]

--- a/tests/unit/modules/dcnm/test_dcnm_intf.py
+++ b/tests/unit/modules/dcnm/test_dcnm_intf.py
@@ -451,6 +451,7 @@ class TestDcnmIntfModule(TestDcnmModule):
             for intf in playbook_have_all_data["DATA"]:
                 if intf["ifName"] == "Ethernet1/1":
                     intf["deletable"] = "False"
+                    intf["editAllowed"] = True
                     intf["underlayPolicies"] = None
                     break
 
@@ -583,6 +584,36 @@ class TestDcnmIntfModule(TestDcnmModule):
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+                self.playbook_mock_succ_resp,
+            ]
+
+        if (
+            "test_dcnm_intf_override_eth_intf_types_only_deleted_nd42_switch_only"
+            in self._testMethodName
+        ):
+
+            playbook_have_all_data = self.have_all_payloads_data.get(
+                "payloads"
+            )
+            eth_bulk_payload = self.build_bulk_payload(
+                self.have_all_payloads_data.get("eth_1_1_access_payload"),
+                self.have_all_payloads_data.get("eth_1_2_access_payload"),
+                self.have_all_payloads_data.get("eth_3_2_access_payload"),
+            )
+            self.breakout_policies_data = loadPlaybookData(
+                "dcnm_intf_breakout_policies"
+            )
+            empty_breakout_resp = self.breakout_policies_data.get(
+                "empty_breakout_policies"
+            )
+
+            self.run_dcnm_send.side_effect = [
+                self.mock_monitor_false_resp,
+                playbook_have_all_data,
+                empty_breakout_resp,
+                eth_bulk_payload,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
                 self.playbook_mock_succ_resp,
@@ -3943,16 +3974,16 @@ class TestDcnmIntfModule(TestDcnmModule):
         # Monitor port will not bedeployed
         self.assertEqual(len(result["diff"][0]["deploy"]), 4)
 
-    def test_dcnm_intf_eth_deleted_existing(self):
+    def prepare_eth_deleted_existing_test(self):
 
-        # load the json from playbooks
         self.config_data = loadPlaybookData("dcnm_intf_eth_configs")
-        self.payloads_data = loadPlaybookData("dcnm_intf_eth_payloads")
-        self.have_all_payloads_data = loadPlaybookData(
-            "dcnm_intf_have_all_payloads"
+        self.payloads_data = copy.deepcopy(
+            loadPlaybookData("dcnm_intf_eth_payloads")
+        )
+        self.have_all_payloads_data = copy.deepcopy(
+            loadPlaybookData("dcnm_intf_have_all_payloads")
         )
 
-        # load required config data
         self.playbook_config = self.config_data.get("eth_deleted_config")
         self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
         self.mock_ip_sn = self.config_data.get("mock_ip_sn")
@@ -3964,6 +3995,46 @@ class TestDcnmIntfModule(TestDcnmModule):
             "mock_monitor_false_resp"
         )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
+
+    def set_eth_deleted_capabilities(self, deletable, edit_allowed=None):
+
+        for intf in self.have_all_payloads_data["eth_payloads"]["DATA"]:
+            intf["deletable"] = deletable
+            if edit_allowed is None:
+                intf.pop("editAllowed", None)
+            else:
+                intf["editAllowed"] = edit_allowed
+
+    def prepare_nd42_deleted_all_eth_test(self):
+
+        self.config_data = loadPlaybookData("dcnm_intf_common_configs")
+        self.have_all_payloads_data = copy.deepcopy(
+            loadPlaybookData("dcnm_intf_have_all_payloads")
+        )
+
+        for intf in self.have_all_payloads_data["payloads"]["DATA"]:
+            if (
+                intf["ifType"] == "INTERFACE_ETHERNET"
+                and str(intf["isPhysical"]).lower() == "true"
+            ):
+                intf["deletable"] = False
+                intf["editAllowed"] = True
+
+        self.playbook_config = self.config_data.get("override_eth_only_config")
+        self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
+        self.mock_ip_sn = self.config_data.get("mock_ip_sn")
+        self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
+        self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
+
+    def test_dcnm_intf_eth_deleted_existing(self):
+
+        self.prepare_eth_deleted_existing_test()
 
         set_module_args(
             dict(
@@ -3977,6 +4048,172 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.assertEqual(len(result["diff"][0]["deleted"]), 0)
         self.assertEqual(len(result["diff"][0]["merged"]), 0)
         self.assertEqual(len(result["diff"][0]["replaced"]), 5)
+
+    def test_dcnm_intf_eth_deleted_existing_nd42_edit_allowed(self):
+
+        self.prepare_eth_deleted_existing_test()
+        self.set_eth_deleted_capabilities(False, True)
+
+        set_module_args(
+            dict(
+                state="deleted",
+                fabric="test_fabric",
+                config=self.playbook_config,
+            )
+        )
+        result = self.execute_module(changed=True, failed=False)
+
+        self.assertEqual(len(result["diff"][0]["deleted"]), 0)
+        self.assertEqual(len(result["diff"][0]["replaced"]), 5)
+        self.assertEqual(len(result["diff"][0]["skipped"]), 0)
+        self.assertTrue(
+            all(
+                payload["policy"] == "int_routed_host_11_1"
+                for payload in result["diff"][0]["replaced"]
+            )
+        )
+
+    def test_dcnm_intf_eth_deleted_existing_nd42_string_edit_allowed(self):
+
+        self.prepare_eth_deleted_existing_test()
+        self.set_eth_deleted_capabilities("False", " TRUE ")
+
+        set_module_args(
+            dict(
+                state="deleted",
+                fabric="test_fabric",
+                config=self.playbook_config,
+            )
+        )
+        result = self.execute_module(changed=True, failed=False)
+
+        self.assertEqual(len(result["diff"][0]["replaced"]), 5)
+        self.assertEqual(len(result["diff"][0]["skipped"]), 0)
+
+    def test_dcnm_intf_eth_deleted_existing_nd42_check_mode(self):
+
+        self.prepare_eth_deleted_existing_test()
+        self.set_eth_deleted_capabilities(False, True)
+
+        set_module_args(
+            dict(
+                state="deleted",
+                _ansible_check_mode=True,
+                fabric="test_fabric",
+                config=self.playbook_config,
+            )
+        )
+        result = self.execute_module(changed=False, failed=False)
+
+        self.assertEqual(len(result["diff"][0]["replaced"]), 5)
+        self.assertFalse(result.get("response"))
+
+    def test_dcnm_intf_eth_deleted_existing_nd42_idempotent(self):
+
+        self.prepare_eth_deleted_existing_test()
+        self.set_eth_deleted_capabilities(False, True)
+
+        payload_names = [
+            "eth_merged_trunk_payloads",
+            "eth_merged_access_payloads",
+            "eth_merged_routed_payloads",
+            "eth_merged_epl_routed_payloads",
+            "eth_merged_monitor_payloads",
+        ]
+        for payload_name in payload_names:
+            payload = self.payloads_data[payload_name]["DATA"][0]
+            ifname = payload["interfaces"][0]["ifName"]
+            payload["policy"] = "int_routed_host_11_1"
+            payload["interfaces"][0]["nvPairs"] = {
+                "MTU": 9216,
+                "SPEED": "Auto",
+                "DESC": "",
+                "CONF": "no shutdown",
+                "ADMIN_STATE": True,
+                "INTF_NAME": ifname,
+                "INTF_VRF": "",
+                "IP": "",
+                "PREFIX": "",
+                "ROUTING_TAG": "",
+            }
+
+        set_module_args(
+            dict(
+                state="deleted",
+                fabric="test_fabric",
+                config=self.playbook_config,
+            )
+        )
+        result = self.execute_module(changed=False, failed=False)
+
+        self.assertEqual(len(result["diff"][0]["replaced"]), 0)
+        self.assertEqual(len(result["diff"][0]["skipped"]), 0)
+        self.assertFalse(result.get("response"))
+
+    def test_dcnm_intf_eth_deleted_existing_nd42_underlay_dependency(self):
+
+        self.prepare_eth_deleted_existing_test()
+        self.set_eth_deleted_capabilities(False, True)
+        self.have_all_payloads_data["eth_payloads"]["DATA"][0][
+            "underlayPolicies"
+        ] = [{"source": "port-channel300"}]
+
+        set_module_args(
+            dict(
+                state="deleted",
+                fabric="test_fabric",
+                config=self.playbook_config,
+            )
+        )
+        result = self.execute_module(changed=True, failed=False)
+
+        replaced_names = {
+            payload["interfaces"][0]["ifName"]
+            for payload in result["diff"][0]["replaced"]
+        }
+        self.assertNotIn("Ethernet1/30", replaced_names)
+        self.assertEqual(len(replaced_names), 4)
+        self.assertTrue(
+            any(
+                skipped["Name"] == "Ethernet1/30"
+                and "underlay policy source" in skipped["Reason"]
+                for skipped in result["diff"][0]["skipped"]
+            )
+        )
+
+    def test_dcnm_intf_eth_deleted_existing_not_editable(self):
+
+        self.prepare_eth_deleted_existing_test()
+        self.set_eth_deleted_capabilities(False, False)
+
+        set_module_args(
+            dict(
+                state="deleted",
+                fabric="test_fabric",
+                config=self.playbook_config,
+            )
+        )
+        result = self.execute_module(changed=False, failed=False)
+
+        self.assertEqual(len(result["diff"][0]["replaced"]), 0)
+        self.assertEqual(len(result["diff"][0]["skipped"]), 5)
+
+    def test_dcnm_intf_eth_deleted_existing_missing_edit_allowed(self):
+
+        self.prepare_eth_deleted_existing_test()
+        self.set_eth_deleted_capabilities(False)
+
+        set_module_args(
+            dict(
+                state="deleted",
+                fabric="test_fabric",
+                config=self.playbook_config,
+            )
+        )
+        result = self.execute_module(changed=False, failed=False)
+
+        self.assertEqual(len(result["diff"][0]["replaced"]), 0)
+        self.assertEqual(len(result["diff"][0]["skipped"]), 5)
 
     def test_dcnm_intf_eth_overridden_existing(self):
 
@@ -6383,6 +6620,96 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.assertEqual(len(result["diff"][0]["deleted"]), 0)
         self.assertEqual(len(result["diff"][0]["replaced"]), 3)
         self.assertEqual(len(result["diff"][0]["overridden"]), 0)
+
+    def test_dcnm_intf_override_eth_intf_types_only_deleted_nd42(self):
+
+        self.prepare_nd42_deleted_all_eth_test()
+
+        set_module_args(
+            dict(
+                state="deleted",
+                fabric="test_fabric",
+                override_intf_types=["eth"],
+                deploy=False,
+                config=[],
+            )
+        )
+        result = self.execute_module(changed=True, failed=False)
+
+        self.assertEqual(len(result["diff"][0]["deleted"]), 0)
+        self.assertEqual(len(result["diff"][0]["replaced"]), 3)
+        self.assertEqual(len(result["diff"][0]["skipped"]), 0)
+
+    def test_dcnm_intf_override_eth_intf_types_only_deleted_nd42_switch_only(
+        self,
+    ):
+
+        self.prepare_nd42_deleted_all_eth_test()
+
+        set_module_args(
+            dict(
+                state="deleted",
+                fabric="test_fabric",
+                override_intf_types=["eth"],
+                deploy=False,
+                config=[
+                    {
+                        "switch": ["192.168.1.108"],
+                        "deploy": False,
+                    }
+                ],
+            )
+        )
+        result = self.execute_module(changed=True, failed=False)
+
+        replaced_names = {
+            payload["interfaces"][0]["ifName"]
+            for payload in result["diff"][0]["replaced"]
+        }
+        self.assertEqual(
+            replaced_names,
+            {"Ethernet1/1", "Ethernet1/2", "Ethernet3/2"},
+        )
+        self.assertEqual(len(result["diff"][0]["deleted"]), 0)
+        self.assertEqual(len(result["diff"][0]["skipped"]), 0)
+
+    def test_dcnm_intf_override_eth_intf_types_only_deleted_nd42_dependency(
+        self,
+    ):
+
+        self.prepare_nd42_deleted_all_eth_test()
+        for intf in self.have_all_payloads_data["payloads"]["DATA"]:
+            if intf["ifName"] == "Ethernet1/1":
+                intf["underlayPolicies"] = [
+                    {"source": "port-channel300"}
+                ]
+
+        set_module_args(
+            dict(
+                state="deleted",
+                fabric="test_fabric",
+                override_intf_types=["eth"],
+                deploy=False,
+                config=[],
+            )
+        )
+        result = self.execute_module(changed=True, failed=False)
+
+        replaced_names = {
+            payload["interfaces"][0]["ifName"]
+            for payload in result["diff"][0]["replaced"]
+        }
+        self.assertEqual(
+            replaced_names,
+            {"Ethernet1/2", "Ethernet3/2"},
+        )
+        self.assertTrue(
+            any(
+                deferred["Name"] == "Ethernet1/1"
+                and deferred["Source"] == "port-channel300"
+                for deferred in result["diff"][0]["deferred"]
+            )
+        )
 
     def test_dcnm_intf_override_eth_intf_types_skip_non_resolvable_deferred(
         self,


### PR DESCRIPTION
## Summary

ND 4.2 reports physical Ethernet interfaces as `deletable: false` and
`editAllowed: true`. `dcnm_interface` previously gated `state: deleted` only
on `deletable`, so a requested reset was silently skipped.

This change:

- accepts `editAllowed` as the ND 4.2 capability for resetting a physical
  Ethernet interface to its default policy;
- preserves the existing ND 4.1 `deletable` behavior;
- limits the compatibility fallback to `state: deleted`, leaving true
  `overridden` behavior unchanged;
- preserves port-channel/member and underlay-policy dependency handling;
- reports an explicit skipped result when neither capability permits the
  reset, or when an unresolved underlay dependency makes the fallback unsafe;
- adds coverage for named deletes, delete-all and switch-only forms, check
  mode, idempotency, string and boolean capability values, unsupported
  interfaces, and underlay dependencies.

`state: deleted` resets controller intent to the default Ethernet policy; it
does not delete the physical port.

## Validation

- ND 4.1 / NDFC 12.4.1 live baseline: check mode proposed one default
  replacement; the real run produced one replacement with no deployment; the
  repeat run was idempotent
- ND 4.2 / NDFC 12.5.0 pre-fix reproduction: `deletable: false`,
  `editAllowed: true`, and the module returned no diff
- ND 4.2 / NDFC 12.5.0 post-fix verification: named delete produced one
  default-policy replacement with no deployment; the repeat run was
  idempotent; the original controller intent was restored exactly after the
  test

Fixes #709
