### PR TITLE
Adding support for svi_enabled, freeform and vlan_id under net attachments

### DIFF
--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -1686,9 +1686,13 @@ class DcnmNetwork:
         # NDFC expects lowercase-string booleans inside the instanceValues JSON payload.
         # NDFC-managed keys already present in have (isVPC, isActive, ...) are merged
         # back in later by diff_for_attach_deploy.
-        svi_enabled = bool(attach.pop("svi_enabled", True))
-        inst_values = {"sviEnabled": "true" if svi_enabled else "false"}
-        attach.update({"instanceValues": json.dumps(inst_values)})
+        nd_version = get_nd_version(self._action_module, self._task_vars, self._tmp)
+        if nd_version >= 12.4:
+            svi_enabled = bool(attach.pop("svi_enabled", True))
+            inst_values = {"sviEnabled": "true" if svi_enabled else "false"}
+            attach.update({"instanceValues": json.dumps(inst_values)})
+        else:
+            attach.update({"instanceValues": ""})
         attach.update({"freeformConfig": ""})
         attach.update({"is_deploy": deploy})
 

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -1612,7 +1612,6 @@ class DcnmNetwork:
         # Clean up vlan_id from attach dict before sending to API
         if "vlan_id" in attach:
             del attach["vlan_id"]
-    
 
         if "deploy" in attach:
             del attach["deploy"]

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -336,6 +336,13 @@ options:
             type: list
             elements: str
             required: true
+          vlan_id:
+            description:
+            - VLAN ID override for this specific switch attachment
+            - If not specified, uses the network-level vlan_id
+            - If neither is specified, NDFC will auto-select an available VLAN
+            type: int
+            required: false
           deploy:
             description:
             - Per switch knob to control whether to deploy the attachment
@@ -1418,7 +1425,7 @@ class DcnmNetwork:
                                 # This is needed to handle cases where vlan is updated after deploying the network
                                 # and attachments. This ensures that the attachments before vlan update will use previous
                                 # vlan id. All the active attachments on ND will have a vlan-id.
-                                if have.get("vlan"):
+                                if want.get("vlan") == 0 and have.get("vlan"):
                                     want["vlan"] = have.get("vlan")
 
                                 if sorted(h_sw_ports) != sorted(w_sw_ports):
@@ -1577,7 +1584,7 @@ class DcnmNetwork:
         attach.update({"serialNumber": serial})
         attach.update({"switchPorts": ",".join(attach["ports"])})
         attach.update({"detachSwitchPorts": ""})  # Is this supported??Need to handle correct
-        attach.update({"vlan": 0})
+        attach.update({"vlan": attach.get("vlan_id", 0)})     # Use attachment vlan_id if provided
         attach.update({"dot1QVlan": 0})
         attach.update({"untagged": False})
         # This flag is not to be confused for deploy of attachment.
@@ -1601,6 +1608,11 @@ class DcnmNetwork:
                 torlist.append(torports)
             del attach["tor_ports"]
         attach.update({"torports": torlist})
+
+        # Clean up vlan_id from attach dict before sending to API
+        if "vlan_id" in attach:
+            del attach["vlan_id"]
+    
 
         if "deploy" in attach:
             del attach["deploy"]
@@ -5041,6 +5053,7 @@ class DcnmNetwork:
                 ip_address=dict(required=True, type="str"),
                 ports=dict(type="list", default=[]),
                 deploy=dict(type="bool", default=True),
+                vlan_id=dict(type="int", required=False),
             )
 
             if self.config:
@@ -5079,6 +5092,7 @@ class DcnmNetwork:
                 ports=dict(type="list", default=[]),
                 deploy=dict(type="bool", default=True),
                 tor_ports=dict(required=False, type="list", elements="dict"),
+                vlan_id=dict(type="int", required=False),
             )
             tor_att_spec = dict(
                 ip_address=dict(required=True, type="str"),

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -343,6 +343,12 @@ options:
               There will not be any functional impact if specified in playbook.
             type: bool
             default: true
+          freeform_config:
+            description:
+            - Freeform CLI configuration for this specific switch attachment
+            - Allows custom configuration to be applied to the network attachment on the switch
+            type: str
+            required: false
           tor_ports:
             description:
             - List of interfaces in the paired TOR switch for this leaf where the network will be attached
@@ -1421,8 +1427,12 @@ class DcnmNetwork:
                                 if have.get("vlan"):
                                     want["vlan"] = have.get("vlan")
 
+                                atch_sw_ports = []
                                 if sorted(h_sw_ports) != sorted(w_sw_ports):
                                     atch_sw_ports = list(set(w_sw_ports) - set(h_sw_ports))
+
+                                if not want.get("freeformConfig") and have.get("freeformConfig"):
+                                    want["freeformConfig"] = have.get("freeformConfig")
 
                                     # Adding some logic which is needed for replace and override.
                                     if replace:
@@ -1587,7 +1597,7 @@ class DcnmNetwork:
         attach.update({"isAttached": True})
         attach.update({"extensionValues": ""})
         attach.update({"instanceValues": ""})
-        attach.update({"freeformConfig": ""})
+        attach.update({"freeformConfig": attach.get("freeform_config", "")})
         attach.update({"is_deploy": deploy})
 
         if attach.get("tor_ports"):
@@ -1601,6 +1611,9 @@ class DcnmNetwork:
                 torlist.append(torports)
             del attach["tor_ports"]
         attach.update({"torports": torlist})
+
+        if "freeform_config" in attach:
+            del attach["freeform_config"]
 
         if "deploy" in attach:
             del attach["deploy"]
@@ -2707,7 +2720,7 @@ class DcnmNetwork:
                 attach.update({"deployment": deploy})
                 attach.update({"extensionValues": ""})
                 attach.update({"instanceValues": ""})
-                attach.update({"freeformConfig": ""})
+                attach.update({"freeformConfig": attach.get("freeformConfig", "")})
                 attach.update({"isAttached": attach_state})
                 attach.update({"dot1QVlan": 0})
                 attach.update({"detachSwitchPorts": ""})
@@ -5041,6 +5054,7 @@ class DcnmNetwork:
                 ip_address=dict(required=True, type="str"),
                 ports=dict(type="list", default=[]),
                 deploy=dict(type="bool", default=True),
+                freeform_config=dict(type="str", required=False),
             )
 
             if self.config:
@@ -5079,6 +5093,7 @@ class DcnmNetwork:
                 ports=dict(type="list", default=[]),
                 deploy=dict(type="bool", default=True),
                 tor_ports=dict(required=False, type="list", elements="dict"),
+                freeform_config=dict(type="str", required=False),
             )
             tor_att_spec = dict(
                 ip_address=dict(required=True, type="str"),

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -336,13 +336,6 @@ options:
             type: list
             elements: str
             required: true
-          vlan_id:
-            description:
-            - VLAN ID override for this specific switch attachment
-            - If not specified, uses the network-level vlan_id
-            - If neither is specified, NDFC will auto-select an available VLAN
-            type: int
-            required: false
           deploy:
             description:
             - Per switch knob to control whether to deploy the attachment

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -343,6 +343,12 @@ options:
               There will not be any functional impact if specified in playbook.
             type: bool
             default: true
+          svi_enabled:
+            description:
+            - Per switch knob to control whether the Switched Virtual Interface (SVI) is enabled
+            type: bool
+            required: false
+            default: true
           tor_ports:
             description:
             - List of interfaces in the paired TOR switch for this leaf where the network will be attached
@@ -1347,6 +1353,23 @@ class DcnmNetwork:
                     if want["serialNumber"] == have["serialNumber"] and want["networkName"] == have["networkName"]:
                         found = True
 
+                        # Merge instanceValues so playbook-driven keys (sviEnabled) override
+                        # while NDFC-managed keys (isVPC, isActive) are preserved from have.
+                        want_inst_raw = want.get("instanceValues") or ""
+                        have_inst_raw = have.get("instanceValues") or ""
+                        want_inst = json.loads(want_inst_raw) if want_inst_raw else {}
+                        have_inst = json.loads(have_inst_raw) if have_inst_raw else {}
+                        merged_inst = dict(have_inst)
+                        merged_inst.update(want_inst)
+                        want["instanceValues"] = json.dumps(merged_inst) if merged_inst else ""
+                        # Only diff on sviEnabled when NDFC actually returned it.
+                        # Absence in have means "no opinion" - avoids spurious re-deploys
+                        # driven purely by the playbook default.
+                        svi_changed = (
+                            "sviEnabled" in have_inst
+                            and have_inst["sviEnabled"] != want_inst.get("sviEnabled", "false")
+                        )
+
                         if want.get("isAttached") is not None:
                             if bool(have["isAttached"]) and bool(want["isAttached"]):
                                 torports_configured = False
@@ -1464,7 +1487,7 @@ class DcnmNetwork:
                                         dep_net = True
                                     continue
 
-                                elif torports_configured:
+                                elif torports_configured or svi_changed:
                                     del want["isAttached"]
                                     attach_list.append(want)
                                     if bool(want["is_deploy"]):
@@ -1586,7 +1609,12 @@ class DcnmNetwork:
         attach.update({"deployment": True})
         attach.update({"isAttached": True})
         attach.update({"extensionValues": ""})
-        attach.update({"instanceValues": ""})
+        # NDFC expects lowercase-string booleans inside the instanceValues JSON payload.
+        # NDFC-managed keys already present in have (isVPC, isActive, ...) are merged
+        # back in later by diff_for_attach_deploy.
+        svi_enabled = bool(attach.pop("svi_enabled", True))
+        inst_values = {"sviEnabled": "true" if svi_enabled else "false"}
+        attach.update({"instanceValues": json.dumps(inst_values)})
         attach.update({"freeformConfig": ""})
         attach.update({"is_deploy": deploy})
 
@@ -2706,7 +2734,10 @@ class DcnmNetwork:
                 attach.update({"serialNumber": sn})
                 attach.update({"deployment": deploy})
                 attach.update({"extensionValues": ""})
-                attach.update({"instanceValues": ""})
+                # Preserve instanceValues from NDFC so diff can honor sviEnabled.
+                # NDFC returns null for unattached switches; normalize to "".
+                raw_inst = attach.get("instanceValues")
+                attach.update({"instanceValues": raw_inst if raw_inst else ""})
                 attach.update({"freeformConfig": ""})
                 attach.update({"isAttached": attach_state})
                 attach.update({"dot1QVlan": 0})
@@ -5041,6 +5072,7 @@ class DcnmNetwork:
                 ip_address=dict(required=True, type="str"),
                 ports=dict(type="list", default=[]),
                 deploy=dict(type="bool", default=True),
+                svi_enabled=dict(type="bool", default=True),
             )
 
             if self.config:
@@ -5079,6 +5111,7 @@ class DcnmNetwork:
                 ports=dict(type="list", default=[]),
                 deploy=dict(type="bool", default=True),
                 tor_ports=dict(required=False, type="list", elements="dict"),
+                svi_enabled=dict(type="bool", default=True),
             )
             tor_att_spec = dict(
                 ip_address=dict(required=True, type="str"),

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -343,12 +343,6 @@ options:
               There will not be any functional impact if specified in playbook.
             type: bool
             default: true
-          svi_enabled:
-            description:
-            - Per switch knob to control whether the Switched Virtual Interface (SVI) is enabled
-            type: bool
-            required: false
-            default: true
           tor_ports:
             description:
             - List of interfaces in the paired TOR switch for this leaf where the network will be attached

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -1686,8 +1686,7 @@ class DcnmNetwork:
         # NDFC expects lowercase-string booleans inside the instanceValues JSON payload.
         # NDFC-managed keys already present in have (isVPC, isActive, ...) are merged
         # back in later by diff_for_attach_deploy.
-        nd_version = get_nd_version(self._action_module, self._task_vars, self._tmp)
-        if nd_version >= 12.4:
+        if self.dcnm_version >= 12.4:
             svi_enabled = bool(attach.pop("svi_enabled", True))
             inst_values = {"sviEnabled": "true" if svi_enabled else "false"}
             attach.update({"instanceValues": json.dumps(inst_values)})

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -343,12 +343,6 @@ options:
               There will not be any functional impact if specified in playbook.
             type: bool
             default: true
-          freeform_config:
-            description:
-            - Freeform CLI configuration for this specific switch attachment
-            - Allows custom configuration to be applied to the network attachment on the switch
-            type: str
-            required: false
           tor_ports:
             description:
             - List of interfaces in the paired TOR switch for this leaf where the network will be attached

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -2714,7 +2714,7 @@ class DcnmNetwork:
                 resp = dcnm_send(self.module, "GET", path)
             except Exception as exc:
                 self.log.debug(
-                    f"_overlay_have_freeform_from_switch_details: fetch failed for serial {serial}: {exc}"
+                    f"_overlay_have_freeform_from_switch_details: fetch failed for serial %s:%s", serial, exc
                 )
                 continue
 
@@ -2736,9 +2736,9 @@ class DcnmNetwork:
                     continue
 
                 self.log.debug(
-                    f"_overlay_have_freeform_from_switch_details: candidate policy on {serial}: "
-                    f"entityName={policy.get('entityName')!r} description={policy.get('description')!r} "
-                    f"nvPairs.keys={list(nv_pairs.keys())}"
+                    f"_overlay_have_freeform_from_switch_details: candidate policy on %s: "
+                    f"entityName= %s description=%s nvPairs.keys=%s", serial, 
+                    policy.get('entityName')!r, policy.get('description')!r, list(nv_pairs.keys())
                 )
 
                 scope_network = self._match_freeform_policy_to_network(policy, candidate_networks)

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -2737,7 +2737,7 @@ class DcnmNetwork:
 
                 self.log.debug(
                     "_overlay_have_freeform_from_switch_details: candidate policy on %s: "
-                    "entityName= %r description=%r nvPairs.keys=%r", serial, 
+                    "entityName= %r description=%r nvPairs.keys=%r", serial,
                     policy.get('entityName'), policy.get('description'), list(nv_pairs.keys())
                 )
 

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -1435,16 +1435,21 @@ class DcnmNetwork:
                         have_inst_raw = have.get("instanceValues") or ""
                         want_inst = json.loads(want_inst_raw) if want_inst_raw else {}
                         have_inst = json.loads(have_inst_raw) if have_inst_raw else {}
+                        svi_supplied = bool(want.get("_svi_supplied"))
+                        # Under merged, an omitted svi_enabled must preserve have's value
+                        # even when the payload requires a sviEnabled key: drop want's
+                        # default sviEnabled from the merge so have wins.
+                        if not svi_supplied and not replace:
+                            want_inst_for_merge = {k: v for k, v in want_inst.items() if k != "sviEnabled"}
+                        else:
+                            want_inst_for_merge = want_inst
                         merged_inst = dict(have_inst)
-                        merged_inst.update(want_inst)
+                        merged_inst.update(want_inst_for_merge)
                         want["instanceValues"] = json.dumps(merged_inst) if merged_inst else ""
-                        # Only diff on sviEnabled when NDFC actually returned it.
-                        # Absence in have means "no opinion" - avoids spurious re-deploys
-                        # driven purely by the playbook default.
-                        svi_changed = (
-                            "sviEnabled" in have_inst
-                            and have_inst["sviEnabled"] != want_inst.get("sviEnabled", "false")
-                        )
+                        if svi_supplied or replace:
+                            svi_changed = want_inst.get("sviEnabled") != have_inst.get("sviEnabled")
+                        else:
+                            svi_changed = False
 
                         if want.get("isAttached") is not None:
                             if bool(have["isAttached"]) and bool(want["isAttached"]):
@@ -1704,11 +1709,27 @@ class DcnmNetwork:
         # NDFC expects lowercase-string booleans inside the instanceValues JSON payload.
         # NDFC-managed keys already present in have (isVPC, isActive, ...) are merged
         # back in later by diff_for_attach_deploy.
+        # svi_enabled is an Ansible-side input; strip it before the version branch
+        # so the raw key can never survive to the outgoing NDFC payload.
+        svi_raw = attach.pop("svi_enabled", None)
+
         if self.dcnm_version >= 12.4:
-            svi_enabled = bool(attach.pop("svi_enabled", True))
-            inst_values = {"sviEnabled": "true" if svi_enabled else "false"}
-            attach.update({"instanceValues": json.dumps(inst_values)})
+            if svi_raw is None:
+                svi_val = "true"
+                attach["_svi_supplied"] = False
+            else:
+                svi_val = "true" if bool(svi_raw) else "false"
+                attach["_svi_supplied"] = True
+            attach.update({"instanceValues": json.dumps({"sviEnabled": svi_val})})
         else:
+            if svi_raw is not None:
+                self.module.fail_json(
+                    msg=(
+                        "svi_enabled is only supported on NDFC 12.4+. "
+                        "Detected NDFC version: {0}. Remove svi_enabled from the "
+                        "playbook or upgrade the controller.".format(self.dcnm_version)
+                    )
+                )
             attach.update({"instanceValues": ""})
         attach.update({"freeformConfig": attach.get("freeform_config")})
         attach.update({"is_deploy": deploy})
@@ -3948,6 +3969,14 @@ class DcnmNetwork:
                 if a_w.get("vlan"):
                     attach_d.update({"vlan_id": a_w["vlan"]})
                 attach_d.update({"freeform_config": a_w.get("freeformConfig") or ""})
+                inst_raw = a_w.get("instanceValues") or ""
+                if inst_raw:
+                    try:
+                        inst_dict = json.loads(inst_raw)
+                    except (json.JSONDecodeError, TypeError):
+                        inst_dict = {}
+                    if "sviEnabled" in inst_dict:
+                        attach_d.update({"svi_enabled": inst_dict["sviEnabled"] == "true"})
                 torports = self.get_attachment_torports_string(a_w)
                 if torports:
                     attach_d.update({"tor_ports": torports})
@@ -3980,6 +4009,14 @@ class DcnmNetwork:
                 if a_w.get("vlan"):
                     attach_d.update({"vlan_id": a_w["vlan"]})
                 attach_d.update({"freeform_config": a_w.get("freeformConfig") or ""})
+                inst_raw = a_w.get("instanceValues") or ""
+                if inst_raw:
+                    try:
+                        inst_dict = json.loads(inst_raw)
+                    except (json.JSONDecodeError, TypeError):
+                        inst_dict = {}
+                    if "sviEnabled" in inst_dict:
+                        attach_d.update({"svi_enabled": inst_dict["sviEnabled"] == "true"})
                 torports = self.get_attachment_torports_string(a_w)
                 if torports:
                     attach_d.update({"tor_ports": torports})
@@ -5032,6 +5069,7 @@ class DcnmNetwork:
                 for v_a in d_a["lanAttachList"]:
                     if v_a.get("is_deploy"):
                         del v_a["is_deploy"]
+                    v_a.pop("_svi_supplied", None)
                     self.normalize_attachment_torports_for_payload(v_a)
 
             # Calculate dynamic retry count based on number of attachments
@@ -5381,7 +5419,7 @@ class DcnmNetwork:
                 deploy=dict(type="bool", default=True),
                 vlan_id=dict(type="int", range_max=4094, required=False),
                 freeform_config=dict(type="str", required=False),
-                svi_enabled=dict(type="bool", default=True),
+                svi_enabled=dict(type="bool"),
             )
 
             if self.config:
@@ -5422,7 +5460,7 @@ class DcnmNetwork:
                 tor_ports=dict(required=False, type="list", elements="dict"),
                 vlan_id=dict(type="int", range_max=4094, required=False),
                 freeform_config=dict(type="str", required=False),
-                svi_enabled=dict(type="bool", default=True),
+                svi_enabled=dict(type="bool"),
             )
             tor_att_spec = dict(
                 ip_address=dict(required=True, type="str"),

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -1027,6 +1027,7 @@ class DcnmNetwork:
             "GET_VRF": "/rest/top-down/fabrics/{}/vrfs",
             "GET_VRF_NET": "/rest/top-down/fabrics/{}/networks?vrf-name={}",
             "GET_NET_ATTACH": "/rest/top-down/fabrics/{}/networks/attachments?network-names={}",
+            "GET_SWITCH_POLICIES": "/rest/control/policies/switches?serialNumber={}",
             "GET_NET_ID": "/rest/managed-pool/fabrics/{}/segments/ids",
             "GET_NET": "/rest/top-down/fabrics/{}/networks",
             "GET_NET_NAME": "/rest/top-down/fabrics/{}/networks/{}",
@@ -1041,6 +1042,7 @@ class DcnmNetwork:
             "GET_VRF": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{}/vrfs",
             "GET_VRF_NET": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{}/networks?vrf-name={}",
             "GET_NET_ATTACH": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{}/networks/attachments?network-names={}",
+            "GET_SWITCH_POLICIES": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/policies/switches?serialNumber={}",
             "GET_NET_ID": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{}/netinfo",
             "GET_NET": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{}/networks",
             "GET_NET_NAME": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{}/networks/{}",
@@ -1524,19 +1526,24 @@ class DcnmNetwork:
 
                                 vlan_changed = want_vlan != have_vlan
 
-                                atch_sw_ports = []
+                                if not replace and want.get("freeformConfig") is None and have.get("freeformConfig"):
+                                    want["freeformConfig"] = have.get("freeformConfig")
+
+                                if want.get("freeformConfig") is None:
+                                    want["freeformConfig"] = ""
+
+                                freeform_changed = want.get("freeformConfig", "") != (have.get("freeformConfig") or "")
+
+                                any_non_port_change = torports_configured or svi_changed or vlan_changed or freeform_changed
+
                                 if sorted(h_sw_ports) != sorted(w_sw_ports):
                                     atch_sw_ports = list(set(w_sw_ports) - set(h_sw_ports))
 
-                                if not want.get("freeformConfig") and have.get("freeformConfig"):
-                                    want["freeformConfig"] = have.get("freeformConfig")
-
-                                    # Adding some logic which is needed for replace and override.
                                     if replace:
                                         dtach_sw_ports = list(set(h_sw_ports) - set(w_sw_ports))
 
                                         if not atch_sw_ports and not dtach_sw_ports:
-                                            if torports_configured or vlan_changed:
+                                            if any_non_port_change:
                                                 del want["isAttached"]
                                                 attach_list.append(want)
                                                 if bool(want["is_deploy"]):
@@ -1554,8 +1561,7 @@ class DcnmNetwork:
                                         continue
 
                                     if not atch_sw_ports:
-                                        # The attachments in the have consist of attachments in want and more.
-                                        if torports_configured or vlan_changed:
+                                        if any_non_port_change:
                                             del want["isAttached"]
                                             attach_list.append(want)
                                             if bool(want["is_deploy"]):
@@ -1571,14 +1577,7 @@ class DcnmNetwork:
                                         dep_net = True
                                     continue
 
-                                elif torports_configured or svi_changed:
-                                    del want["isAttached"]
-                                    attach_list.append(want)
-                                    if bool(want["is_deploy"]):
-                                        dep_net = True
-                                    continue
-
-                                elif vlan_changed:
+                                elif any_non_port_change:
                                     del want["isAttached"]
                                     attach_list.append(want)
                                     if bool(want["is_deploy"]):
@@ -1630,6 +1629,8 @@ class DcnmNetwork:
                     del want["torports"]
                     del want["isAttached"]
                     want["deployment"] = True
+                    if want.get("freeformConfig") is None:
+                        want["freeformConfig"] = ""
                     attach_list.append(want)
                     if bool(want["is_deploy"]):
                         dep_net = True
@@ -1709,7 +1710,7 @@ class DcnmNetwork:
             attach.update({"instanceValues": json.dumps(inst_values)})
         else:
             attach.update({"instanceValues": ""})
-        attach.update({"freeformConfig": attach.get("freeform_config", "")})
+        attach.update({"freeformConfig": attach.get("freeform_config")})
         attach.update({"is_deploy": deploy})
 
         if attach.get("tor_ports"):
@@ -2654,6 +2655,111 @@ class DcnmNetwork:
 
         return False
 
+    def _overlay_have_freeform_from_switch_details(self, have_attach, network_to_sns):
+        """
+        NDFC's /networks/attachments GET does not include per-attach freeformConfig.
+        The per-attach freeform CLI is stored as a switch policy with template
+        switch_freeform_config. This method fetches all policies for each switch
+        that has attachments in have_attach, filters for the freeform template,
+        and overlays nvPairs.CONF onto the matching have_attach entries so
+        diff_for_attach_deploy can detect freeform-only updates and explicit clears.
+
+        Policy-to-network matching is a two-stage best-effort:
+          1. If only one attached network exists on the switch, that network wins.
+          2. Otherwise match by entityName == networkName, then by
+             description containing the network name.
+        Raw policy dicts are logged at debug level so we can refine matching once
+        we have concrete NDFC responses.
+        """
+        if not network_to_sns:
+            return
+
+        attach_by_key = {}
+        for net_attach in have_attach:
+            net_name = net_attach.get("networkName")
+            for attach in net_attach.get("lanAttachList", []):
+                sn = attach.get("serialNumber")
+                if net_name and sn:
+                    attach_by_key[(net_name, sn)] = attach
+
+        serial_to_networks = {}
+        for net, serials in network_to_sns.items():
+            for sn in serials or []:
+                serial_to_networks.setdefault(sn, []).append(net)
+
+        for serial in sorted(serial_to_networks.keys()):
+            path = self.paths["GET_SWITCH_POLICIES"].format(serial)
+            try:
+                resp = dcnm_send(self.module, "GET", path)
+            except Exception as exc:
+                self.log.debug(
+                    f"_overlay_have_freeform_from_switch_details: fetch failed for serial {serial}: {exc}"
+                )
+                continue
+
+            if not isinstance(resp, dict) or resp.get("RETURN_CODE") != 200:
+                continue
+            data = resp.get("DATA")
+            if not isinstance(data, list):
+                continue
+
+            candidate_networks = serial_to_networks[serial]
+            for policy in data:
+                if not isinstance(policy, dict):
+                    continue
+                if policy.get("templateName") not in ("switch_freeform_config", "switch_freeform"):
+                    continue
+                nv_pairs = policy.get("nvPairs") or {}
+                conf = nv_pairs.get("CONF")
+                if conf is None:
+                    continue
+
+                self.log.debug(
+                    f"_overlay_have_freeform_from_switch_details: candidate policy on {serial}: "
+                    f"entityName={policy.get('entityName')!r} description={policy.get('description')!r} "
+                    f"nvPairs.keys={list(nv_pairs.keys())}"
+                )
+
+                scope_network = self._match_freeform_policy_to_network(policy, candidate_networks)
+                if scope_network is None:
+                    continue
+
+                target = attach_by_key.get((scope_network, serial))
+                if target is None:
+                    continue
+                target["freeformConfig"] = conf
+
+    @staticmethod
+    def _match_freeform_policy_to_network(policy, candidate_networks):
+        """Best-effort match a switch_freeform_config policy to one of the
+        candidate networks attached to the same switch. Returns the matched
+        network name or None."""
+        if not candidate_networks:
+            return None
+        if len(candidate_networks) == 1:
+            return candidate_networks[0]
+
+        entity_name = policy.get("entityName") or ""
+        for net in candidate_networks:
+            if entity_name == net:
+                return net
+
+        description = policy.get("description") or ""
+        for net in candidate_networks:
+            if net and net in description:
+                return net
+
+        nv_pairs = policy.get("nvPairs") or {}
+        for candidate_field in ("NETWORK_NAME", "networkName", "network_name"):
+            value = nv_pairs.get(candidate_field)
+            if not value:
+                continue
+            for net in candidate_networks:
+                if value == net:
+                    return net
+
+        return None
+
     def get_have(self):
         caller = inspect.stack()[1][3]
 
@@ -2924,6 +3030,8 @@ class DcnmNetwork:
                     network_to_sns[network_name] = []
                 if serial not in network_to_sns[network_name]:
                     network_to_sns[network_name].append(serial)
+
+        self._overlay_have_freeform_from_switch_details(have_attach, network_to_sns)
 
         self.have_create = have_create
         self.have_attach = have_attach
@@ -3839,6 +3947,7 @@ class DcnmNetwork:
                 attach_d.update({"deploy": a_w["deployment"]})
                 if a_w.get("vlan"):
                     attach_d.update({"vlan_id": a_w["vlan"]})
+                attach_d.update({"freeform_config": a_w.get("freeformConfig") or ""})
                 torports = self.get_attachment_torports_string(a_w)
                 if torports:
                     attach_d.update({"tor_ports": torports})
@@ -3870,6 +3979,7 @@ class DcnmNetwork:
                 attach_d.update({"deploy": a_w["deployment"]})
                 if a_w.get("vlan"):
                     attach_d.update({"vlan_id": a_w["vlan"]})
+                attach_d.update({"freeform_config": a_w.get("freeformConfig") or ""})
                 torports = self.get_attachment_torports_string(a_w)
                 if torports:
                     attach_d.update({"tor_ports": torports})

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -3802,6 +3802,8 @@ class DcnmNetwork:
                     found_c["attach"].append(detach_d)
                 attach_d.update({"ports": a_w["switchPorts"]})
                 attach_d.update({"deploy": a_w["deployment"]})
+                if a_w.get("vlan"):
+                    attach_d.update({"vlan_id": a_w["vlan"]})
                 torports = self.get_attachment_torports_string(a_w)
                 if torports:
                     attach_d.update({"tor_ports": torports})
@@ -3831,6 +3833,8 @@ class DcnmNetwork:
                     new_attach_list.append(detach_d)
                 attach_d.update({"ports": a_w["switchPorts"]})
                 attach_d.update({"deploy": a_w["deployment"]})
+                if a_w.get("vlan"):
+                    attach_d.update({"vlan_id": a_w["vlan"]})
                 torports = self.get_attachment_torports_string(a_w)
                 if torports:
                     attach_d.update({"tor_ports": torports})

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -5230,7 +5230,7 @@ class DcnmNetwork:
                 ip_address=dict(required=True, type="str"),
                 ports=dict(type="list", default=[]),
                 deploy=dict(type="bool", default=True),
-                vlan_id=dict(type="int", required=False),
+                vlan_id=dict(type="int", range_max=4094, required=False),
             )
 
             if self.config:
@@ -5269,7 +5269,7 @@ class DcnmNetwork:
                 ports=dict(type="list", default=[]),
                 deploy=dict(type="bool", default=True),
                 tor_ports=dict(required=False, type="list", elements="dict"),
-                vlan_id=dict(type="int", required=False),
+                vlan_id=dict(type="int", range_max=4094, required=False),
             )
             tor_att_spec = dict(
                 ip_address=dict(required=True, type="str"),

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -2737,8 +2737,8 @@ class DcnmNetwork:
 
                 self.log.debug(
                     f"_overlay_have_freeform_from_switch_details: candidate policy on %s: "
-                    f"entityName= %s description=%s nvPairs.keys=%s", serial, 
-                    policy.get('entityName')!r, policy.get('description')!r, list(nv_pairs.keys())
+                    f"entityName= %r description=%r nvPairs.keys=%r", serial, 
+                    policy.get('entityName'), policy.get('description'), list(nv_pairs.keys())
                 )
 
                 scope_network = self._match_freeform_policy_to_network(policy, candidate_networks)

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -1403,7 +1403,7 @@ class DcnmNetwork:
                 )
         return serials
 
-    def diff_for_attach_deploy(self, want_a, have_a, replace=False):
+    def diff_for_attach_deploy(self, want_a, have_a, replace=False, network_vlan=0):
         caller = inspect.stack()[1][3]
 
         msg = "ENTERED. "
@@ -1495,11 +1495,17 @@ class DcnmNetwork:
                                 h_sw_ports = have["switchPorts"].split(",") if have["switchPorts"] else []
                                 w_sw_ports = want["switchPorts"].split(",") if want["switchPorts"] else []
 
-                                # This is needed to handle cases where vlan is updated after deploying the network
-                                # and attachments. This ensures that the attachments before vlan update will use previous
-                                # vlan id. All the active attachments on ND will have a vlan-id.
-                                if want.get("vlan") == 0 and have.get("vlan"):
-                                    want["vlan"] = have.get("vlan")
+                                want_vlan = int(want.get("vlan") or 0)
+                                have_vlan = int(have.get("vlan") or 0)
+
+                                if not replace and want_vlan == 0 and have_vlan:
+                                    want_vlan = have_vlan
+                                    want["vlan"] = have_vlan
+                                elif replace and want_vlan == 0 and network_vlan:
+                                    want_vlan = int(network_vlan)
+                                    want["vlan"] = int(network_vlan)
+
+                                vlan_changed = want_vlan != have_vlan
 
                                 if sorted(h_sw_ports) != sorted(w_sw_ports):
                                     atch_sw_ports = list(set(w_sw_ports) - set(h_sw_ports))
@@ -1509,7 +1515,7 @@ class DcnmNetwork:
                                         dtach_sw_ports = list(set(h_sw_ports) - set(w_sw_ports))
 
                                         if not atch_sw_ports and not dtach_sw_ports:
-                                            if torports_configured:
+                                            if torports_configured or vlan_changed:
                                                 del want["isAttached"]
                                                 attach_list.append(want)
                                                 if bool(want["is_deploy"]):
@@ -1528,7 +1534,7 @@ class DcnmNetwork:
 
                                     if not atch_sw_ports:
                                         # The attachments in the have consist of attachments in want and more.
-                                        if torports_configured:
+                                        if torports_configured or vlan_changed:
                                             del want["isAttached"]
                                             attach_list.append(want)
                                             if bool(want["is_deploy"]):
@@ -1545,6 +1551,13 @@ class DcnmNetwork:
                                     continue
 
                                 elif torports_configured:
+                                    del want["isAttached"]
+                                    attach_list.append(want)
+                                    if bool(want["is_deploy"]):
+                                        dep_net = True
+                                    continue
+
+                                elif vlan_changed:
                                     del want["isAttached"]
                                     attach_list.append(want)
                                     if bool(want["is_deploy"]):
@@ -1657,7 +1670,7 @@ class DcnmNetwork:
         attach.update({"serialNumber": serial})
         attach.update({"switchPorts": ",".join(attach["ports"])})
         attach.update({"detachSwitchPorts": ""})  # Is this supported??Need to handle correct
-        attach.update({"vlan": attach.get("vlan_id", 0)})     # Use attachment vlan_id if provided
+        attach.update({"vlan": attach.get("vlan_id") or 0})     # Use attachment vlan_id if provided; None/omitted -> 0
         attach.update({"dot1QVlan": 0})
         attach.update({"untagged": False})
         # This flag is not to be confused for deploy of attachment.
@@ -2965,6 +2978,7 @@ class DcnmNetwork:
                             # )
                 net_attach.update({"networkName": net["net_name"]})
                 net_attach.update({"lanAttachList": networks})
+                net_attach.update({"vlan_id": net.get("vlan_id") or 0})
                 want_attach.append(net_attach)
 
             all_networks += net["net_name"] + ","
@@ -3418,11 +3432,17 @@ class DcnmNetwork:
                 if want_a["networkName"] == have_a["networkName"]:
 
                     found = True
-                    diff, net = self.diff_for_attach_deploy(want_a["lanAttachList"], have_a["lanAttachList"], replace)
+                    diff, net = self.diff_for_attach_deploy(
+                        want_a["lanAttachList"],
+                        have_a["lanAttachList"],
+                        replace,
+                        network_vlan=want_a.get("vlan_id") or 0,
+                    )
 
                     if diff:
                         base = want_a.copy()
                         del base["lanAttachList"]
+                        base.pop("vlan_id", None)
                         base.update({"lanAttachList": diff})
                         diff_attach.append(base)
                         if net:
@@ -3474,6 +3494,7 @@ class DcnmNetwork:
                 if atch_list:
                     base = want_a.copy()
                     del base["lanAttachList"]
+                    base.pop("vlan_id", None)
                     base.update({"lanAttachList": atch_list})
                     diff_attach.append(base)
                     if bool(attach["is_deploy"]):

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -1585,13 +1585,6 @@ class DcnmNetwork:
                                         dep_net = True
                                     continue
 
-                                elif vlan_changed:
-                                    del want["isAttached"]
-                                    attach_list.append(want)
-                                    if bool(want["is_deploy"]):
-                                        dep_net = True
-                                    continue
-
                             if bool(have["isAttached"]) is not bool(want["isAttached"]):
                                 # When the attachment is to be detached and undeployed, ignore any changes
                                 # to the attach section in the want(i.e in the playbook).

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -2714,7 +2714,7 @@ class DcnmNetwork:
                 resp = dcnm_send(self.module, "GET", path)
             except Exception as exc:
                 self.log.debug(
-                    f"_overlay_have_freeform_from_switch_details: fetch failed for serial %s:%s", serial, exc
+                    "_overlay_have_freeform_from_switch_details: fetch failed for serial %s:%s", serial, exc
                 )
                 continue
 
@@ -2736,8 +2736,8 @@ class DcnmNetwork:
                     continue
 
                 self.log.debug(
-                    f"_overlay_have_freeform_from_switch_details: candidate policy on %s: "
-                    f"entityName= %r description=%r nvPairs.keys=%r", serial, 
+                    "_overlay_have_freeform_from_switch_details: candidate policy on %s: "
+                    "entityName= %r description=%r nvPairs.keys=%r", serial, 
                     policy.get('entityName'), policy.get('description'), list(nv_pairs.keys())
                 )
 

--- a/tests/integration/targets/dcnm_network/tests/dcnm/standalone/merged.yaml
+++ b/tests/integration/targets/dcnm_network/tests/dcnm/standalone/merged.yaml
@@ -1462,6 +1462,144 @@
       - result.changed == false
   tags: merged
 
+- name: MERGED - TC17 - Baseline - Create Network with single-port attach and empty freeform
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ test_data_common.fabric }}"
+    state: merged
+    config:
+      - net_name: ansible-net-portadd
+        vrf_name: Tenant-1
+        net_id: 7017
+        net_template: Default_Network_Universal
+        net_extension_template: Default_Network_Extension_Universal
+        vlan_id: 2317
+        gw_ip_subnet: '192.168.31.1/24'
+        attach:
+          - ip_address: "{{ test_data_common.sw1 }}"
+            ports:
+              - "{{ test_data_common.sw1_int1 }}"
+        deploy: true
+  register: result
+  tags: merged
+
+- name: MERGED - TC17 - ASSERT - Baseline created
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+  tags: merged
+
+- name: MERGED - TC17 - Add a port to the existing attach (empty freeform)
+  cisco.dcnm.dcnm_network: &conf17_add
+    fabric: "{{ test_data_common.fabric }}"
+    state: merged
+    config:
+      - net_name: ansible-net-portadd
+        vrf_name: Tenant-1
+        net_id: 7017
+        net_template: Default_Network_Universal
+        net_extension_template: Default_Network_Extension_Universal
+        vlan_id: 2317
+        gw_ip_subnet: '192.168.31.1/24'
+        attach:
+          - ip_address: "{{ test_data_common.sw1 }}"
+            ports:
+              - "{{ test_data_common.sw1_int1 }}"
+              - "{{ test_data_common.sw1_int2 }}"
+        deploy: true
+  register: result
+  tags: merged
+
+- name: MERGED - TC17 - ASSERT - Port addition produced a diff
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.diff | length > 0
+  tags: merged
+
+- name: MERGED - TC17 - Idempotence - Rerun the port addition
+  cisco.dcnm.dcnm_network: *conf17_add
+  register: result
+  tags: merged
+
+- name: MERGED - TC17 - ASSERT - Idempotent rerun changed flag is false
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+  tags: merged
+
+- name: MERGED - TC18 - DELETED - Clean up any existing networks
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ test_data_common.fabric }}"
+    state: deleted
+  tags: merged
+
+- name: MERGED - TC18 - Baseline - Create Network with attach and initial freeform config
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ test_data_common.fabric }}"
+    state: merged
+    config:
+      - net_name: ansible-net-ffupd
+        vrf_name: Tenant-1
+        net_id: 7018
+        net_template: Default_Network_Universal
+        net_extension_template: Default_Network_Extension_Universal
+        vlan_id: 2318
+        gw_ip_subnet: '192.168.34.1/24'
+        attach:
+          - ip_address: "{{ test_data_common.sw1 }}"
+            ports:
+              - "{{ test_data_common.sw1_int1 }}"
+            freeform_config: "interface Vlan2318\n  description Old"
+        deploy: true
+  register: result
+  tags: merged
+
+- name: MERGED - TC18 - ASSERT - Baseline created
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+  tags: merged
+
+- name: MERGED - TC18 - Update freeform config on existing attach (ports unchanged)
+  cisco.dcnm.dcnm_network: &conf18_update
+    fabric: "{{ test_data_common.fabric }}"
+    state: merged
+    config:
+      - net_name: ansible-net-ffupd
+        vrf_name: Tenant-1
+        net_id: 7018
+        net_template: Default_Network_Universal
+        net_extension_template: Default_Network_Extension_Universal
+        vlan_id: 2318
+        gw_ip_subnet: '192.168.34.1/24'
+        attach:
+          - ip_address: "{{ test_data_common.sw1 }}"
+            ports:
+              - "{{ test_data_common.sw1_int1 }}"
+            freeform_config: "interface Vlan2318\n  description New"
+        deploy: true
+  register: result
+  tags: merged
+
+- name: MERGED - TC18 - ASSERT - Freeform update produced a diff
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.diff | length > 0
+      - "'description New' in (result.diff[0].attach[0].freeform_config | default(''))"
+  tags: merged
+
+- name: MERGED - TC18 - Idempotence - Rerun the freeform update
+  cisco.dcnm.dcnm_network: *conf18_update
+  register: result
+  tags: merged
+
+- name: MERGED - TC18 - ASSERT - Idempotent rerun changed flag is false
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+  tags: merged
+
 ##############################################
 ##                 CLEAN-UP                 ##
 ##############################################

--- a/tests/integration/targets/dcnm_network/tests/dcnm/standalone/merged.yaml
+++ b/tests/integration/targets/dcnm_network/tests/dcnm/standalone/merged.yaml
@@ -1435,6 +1435,33 @@
       - result.response | length == 0
   tags: merged
 
+- name: MERGED - TC16 - Create Network with invalid attachment vlan id
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ test_data_common.fabric }}"
+    state: merged
+    config:
+      - net_name: ansible-net13
+        vrf_name: Tenant-1
+        net_id: 7005
+        net_template: Default_Network_Universal
+        net_extension_template: Default_Network_Extension_Universal
+        vlan_id: 1500
+        gw_ip_subnet: '192.168.30.1/24'
+        attach:
+          - ip_address: "{{ test_data_common.sw1 }}"
+            vlan_id: 15000
+        deploy: true
+  register: result
+  ignore_errors: true
+  tags: merged
+
+- name: MERGED - TC16 - ASSERT - Check invalid attachment vlan id
+  ansible.builtin.assert:
+    that:
+      - '"Invalid parameters in playbook: vlan_id:15000 : The item exceeds the allowed range of max 4094" in result.msg'
+      - result.changed == false
+  tags: merged
+
 ##############################################
 ##                 CLEAN-UP                 ##
 ##############################################

--- a/tests/integration/targets/dcnm_network/tests/dcnm/standalone/overridden.yaml
+++ b/tests/integration/targets/dcnm_network/tests/dcnm/standalone/overridden.yaml
@@ -247,6 +247,151 @@
   tags: overridden
 
 
+- name: OVERRIDDEN - TC3 - DELETED - Clean up any existing networks
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ test_data_common.fabric }}"
+    state: deleted
+  tags: overridden
+
+- name: OVERRIDDEN - TC3 - Baseline - Create Network with single-port attach and empty freeform
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ test_data_common.fabric }}"
+    state: merged
+    config:
+      - net_name: ansible-net-ovrswap
+        vrf_name: Tenant-1
+        net_id: 7035
+        net_template: Default_Network_Universal
+        net_extension_template: Default_Network_Extension_Universal
+        vlan_id: 2335
+        gw_ip_subnet: '192.168.33.1/24'
+        attach:
+          - ip_address: "{{ test_data_common.sw1 }}"
+            ports:
+              - "{{ test_data_common.sw1_int1 }}"
+        deploy: true
+  register: result
+  tags: overridden
+
+- name: OVERRIDDEN - TC3 - ASSERT - Baseline created
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+  tags: overridden
+
+- name: OVERRIDDEN - TC3 - Swap the port on the existing attach (empty freeform)
+  cisco.dcnm.dcnm_network: &conf3_swap
+    fabric: "{{ test_data_common.fabric }}"
+    state: overridden
+    config:
+      - net_name: ansible-net-ovrswap
+        vrf_name: Tenant-1
+        net_id: 7035
+        net_template: Default_Network_Universal
+        net_extension_template: Default_Network_Extension_Universal
+        vlan_id: 2335
+        gw_ip_subnet: '192.168.33.1/24'
+        attach:
+          - ip_address: "{{ test_data_common.sw1 }}"
+            ports:
+              - "{{ test_data_common.sw1_int2 }}"
+        deploy: true
+  register: result
+  tags: overridden
+
+- name: OVERRIDDEN - TC3 - ASSERT - Port swap produced a diff
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.diff | length > 0
+  tags: overridden
+
+- name: OVERRIDDEN - TC3 - Idempotence - Rerun the port swap
+  cisco.dcnm.dcnm_network: *conf3_swap
+  register: result
+  tags: overridden
+
+- name: OVERRIDDEN - TC3 - ASSERT - Idempotent rerun changed flag is false
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+  tags: overridden
+
+
+- name: OVERRIDDEN - TC4 - DELETED - Clean up any existing networks
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ test_data_common.fabric }}"
+    state: deleted
+  tags: overridden
+
+- name: OVERRIDDEN - TC4 - Baseline - Create Network with attach and freeform config
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ test_data_common.fabric }}"
+    state: merged
+    config:
+      - net_name: ansible-net-ovrffclr
+        vrf_name: Tenant-1
+        net_id: 7036
+        net_template: Default_Network_Universal
+        net_extension_template: Default_Network_Extension_Universal
+        vlan_id: 2336
+        gw_ip_subnet: '192.168.36.1/24'
+        attach:
+          - ip_address: "{{ test_data_common.sw1 }}"
+            ports:
+              - "{{ test_data_common.sw1_int1 }}"
+            freeform_config: "interface Vlan2336\n  description Old"
+        deploy: true
+  register: result
+  tags: overridden
+
+- name: OVERRIDDEN - TC4 - ASSERT - Baseline created
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+  tags: overridden
+
+- name: OVERRIDDEN - TC4 - Explicit clear of freeform config via empty string
+  cisco.dcnm.dcnm_network: &conf4_clear
+    fabric: "{{ test_data_common.fabric }}"
+    state: overridden
+    config:
+      - net_name: ansible-net-ovrffclr
+        vrf_name: Tenant-1
+        net_id: 7036
+        net_template: Default_Network_Universal
+        net_extension_template: Default_Network_Extension_Universal
+        vlan_id: 2336
+        gw_ip_subnet: '192.168.36.1/24'
+        attach:
+          - ip_address: "{{ test_data_common.sw1 }}"
+            ports:
+              - "{{ test_data_common.sw1_int1 }}"
+            freeform_config: ""
+        deploy: true
+  register: result
+  tags: overridden
+
+- name: OVERRIDDEN - TC4 - ASSERT - Freeform clear produced a diff
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.diff | length > 0
+      - result.diff[0].attach[0].freeform_config == ""
+  tags: overridden
+
+- name: OVERRIDDEN - TC4 - Idempotence - Rerun the freeform clear
+  cisco.dcnm.dcnm_network: *conf4_clear
+  register: result
+  tags: overridden
+
+- name: OVERRIDDEN - TC4 - ASSERT - Idempotent rerun changed flag is false
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+  tags: overridden
+
+
 ##############################################
 ##                 CLEAN-UP                 ##
 ##############################################

--- a/tests/integration/targets/dcnm_network/tests/dcnm/standalone/replaced.yaml
+++ b/tests/integration/targets/dcnm_network/tests/dcnm/standalone/replaced.yaml
@@ -324,6 +324,149 @@
       - result.changed == false
   tags: replaced
 
+- name: REPLACED - TC5 - DELETED - Clean up any existing networks
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ test_data_common.fabric }}"
+    state: deleted
+  tags: replaced
+
+- name: REPLACED - TC5 - Baseline - Create Network with single-port attach and empty freeform
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ test_data_common.fabric }}"
+    state: merged
+    config:
+      - net_name: ansible-net-portswap
+        vrf_name: Tenant-1
+        net_id: 7025
+        net_template: Default_Network_Universal
+        net_extension_template: Default_Network_Extension_Universal
+        vlan_id: 2325
+        gw_ip_subnet: '192.168.32.1/24'
+        attach:
+          - ip_address: "{{ test_data_common.sw1 }}"
+            ports:
+              - "{{ test_data_common.sw1_int1 }}"
+        deploy: true
+  register: result
+  tags: replaced
+
+- name: REPLACED - TC5 - ASSERT - Baseline created
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+  tags: replaced
+
+- name: REPLACED - TC5 - Swap the port on the existing attach (empty freeform)
+  cisco.dcnm.dcnm_network: &conf5_swap
+    fabric: "{{ test_data_common.fabric }}"
+    state: replaced
+    config:
+      - net_name: ansible-net-portswap
+        vrf_name: Tenant-1
+        net_id: 7025
+        net_template: Default_Network_Universal
+        net_extension_template: Default_Network_Extension_Universal
+        vlan_id: 2325
+        gw_ip_subnet: '192.168.32.1/24'
+        attach:
+          - ip_address: "{{ test_data_common.sw1 }}"
+            ports:
+              - "{{ test_data_common.sw1_int2 }}"
+        deploy: true
+  register: result
+  tags: replaced
+
+- name: REPLACED - TC5 - ASSERT - Port swap produced a diff
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.diff | length > 0
+  tags: replaced
+
+- name: REPLACED - TC5 - Idempotence - Rerun the port swap
+  cisco.dcnm.dcnm_network: *conf5_swap
+  register: result
+  tags: replaced
+
+- name: REPLACED - TC5 - ASSERT - Idempotent rerun changed flag is false
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+  tags: replaced
+
+- name: REPLACED - TC6 - DELETED - Clean up any existing networks
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ test_data_common.fabric }}"
+    state: deleted
+  tags: replaced
+
+- name: REPLACED - TC6 - Baseline - Create Network with attach and freeform config
+  cisco.dcnm.dcnm_network:
+    fabric: "{{ test_data_common.fabric }}"
+    state: merged
+    config:
+      - net_name: ansible-net-ffclr
+        vrf_name: Tenant-1
+        net_id: 7026
+        net_template: Default_Network_Universal
+        net_extension_template: Default_Network_Extension_Universal
+        vlan_id: 2326
+        gw_ip_subnet: '192.168.35.1/24'
+        attach:
+          - ip_address: "{{ test_data_common.sw1 }}"
+            ports:
+              - "{{ test_data_common.sw1_int1 }}"
+            freeform_config: "interface Vlan2326\n  description Old"
+        deploy: true
+  register: result
+  tags: replaced
+
+- name: REPLACED - TC6 - ASSERT - Baseline created
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+  tags: replaced
+
+- name: REPLACED - TC6 - Explicit clear of freeform config via empty string
+  cisco.dcnm.dcnm_network: &conf6_clear
+    fabric: "{{ test_data_common.fabric }}"
+    state: replaced
+    config:
+      - net_name: ansible-net-ffclr
+        vrf_name: Tenant-1
+        net_id: 7026
+        net_template: Default_Network_Universal
+        net_extension_template: Default_Network_Extension_Universal
+        vlan_id: 2326
+        gw_ip_subnet: '192.168.35.1/24'
+        attach:
+          - ip_address: "{{ test_data_common.sw1 }}"
+            ports:
+              - "{{ test_data_common.sw1_int1 }}"
+            freeform_config: ""
+        deploy: true
+  register: result
+  tags: replaced
+
+- name: REPLACED - TC6 - ASSERT - Freeform clear produced a diff
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.diff | length > 0
+      - result.diff[0].attach[0].freeform_config == ""
+  tags: replaced
+
+- name: REPLACED - TC6 - Idempotence - Rerun the freeform clear
+  cisco.dcnm.dcnm_network: *conf6_clear
+  register: result
+  tags: replaced
+
+- name: REPLACED - TC6 - ASSERT - Idempotent rerun changed flag is false
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+  tags: replaced
+
 ##############################################
 ##                 CLEAN-UP                 ##
 ##############################################

--- a/tests/unit/modules/dcnm/fixtures/dcnm_network.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_network.json
@@ -2022,5 +2022,76 @@
                 ]
             }
         ]
+    },
+    "playbook_config_attach_freeform_config": [
+        {
+            "net_name": "test_network",
+            "vrf_name": "ansible-vrf-int1",
+            "net_id": "9008011",
+            "net_template": "Default_Network_Universal",
+            "net_extension_template": "Default_Network_Extension_Universal",
+            "vlan_id": "202",
+            "gw_ip_subnet": "192.168.30.1/24",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.217",
+                    "ports": ["Ethernet1/13", "Ethernet1/14"],
+                    "freeform_config": "interface Vlan202\n  description Custom Config",
+                    "deploy": true
+                },
+                {
+                    "ip_address": "10.10.10.218",
+                    "ports": ["Ethernet1/13", "Ethernet1/14"],
+                    "deploy": true
+                }
+            ],
+            "deploy": true
+        }
+    ],
+    "mock_net_attach_object_freeform_config": {
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200,
+        "DATA": [
+            {
+                "networkName": "test_network",
+                "lanAttachList": [
+                    {
+                        "networkName": "test_network",
+                        "displayName": "test_network",
+                        "switchName": "n9kv-218",
+                        "switchRole": "leaf",
+                        "fabricName": "test_net",
+                        "lanAttachState": "DEPLOYED",
+                        "isLanAttached": true,
+                        "portNames": "Ethernet1/13,Ethernet1/14",
+                        "switchSerialNo": "9YO9A29F27U",
+                        "switchDbId": 4191270,
+                        "ipAddress": "10.10.10.218",
+                        "networkId": 9008011,
+                        "vlanId": 202,
+                        "freeformConfig": "",
+                        "interfaceGroups": null
+                    },
+                    {
+                        "networkName": "test_network",
+                        "displayName": "test_network",
+                        "switchName": "n9kv-217",
+                        "switchRole": "leaf",
+                        "fabricName": "test_net",
+                        "lanAttachState": "DEPLOYED",
+                        "isLanAttached": true,
+                        "portNames": "Ethernet1/13,Ethernet1/14",
+                        "switchSerialNo": "9NN7E41N16A",
+                        "switchDbId": 4191250,
+                        "ipAddress": "10.10.10.217",
+                        "networkId": 9008011,
+                        "vlanId": 202,
+                        "freeformConfig": "interface Vlan202\n  description Custom Config",
+                        "interfaceGroups": null
+                    }
+                ]
+            }
+        ]
     }
 }

--- a/tests/unit/modules/dcnm/fixtures/dcnm_network.json
+++ b/tests/unit/modules/dcnm/fixtures/dcnm_network.json
@@ -2022,5 +2022,80 @@
                 ]
             }
         ]
+    },
+    "playbook_config_attach_vlan_override": [
+        {
+            "net_name": "test_network",
+            "vrf_name": "ansible-vrf-int1",
+            "net_id": "9008011",
+            "net_template": "Default_Network_Universal",
+            "net_extension_template": "Default_Network_Extension_Universal",
+            "vlan_id": "202",
+            "gw_ip_subnet": "192.168.30.1/24",
+            "attach": [
+                {
+                    "ip_address": "10.10.10.217",
+                    "ports": [
+                        "Ethernet1/13",
+                        "Ethernet1/14"
+                    ],
+                    "vlan_id": 300,
+                    "deploy": true
+                },
+                {
+                    "ip_address": "10.10.10.218",
+                    "ports": [
+                        "Ethernet1/13",
+                        "Ethernet1/14"
+                    ],
+                    "deploy": true
+                }
+            ],
+            "deploy": true
+        }
+    ],
+    "mock_net_attach_object_vlan_override": {
+        "MESSAGE": "OK",
+        "METHOD": "POST",
+        "RETURN_CODE": 200,
+        "DATA": [
+            {
+                "networkName": "test_network",
+                "lanAttachList": [
+                    {
+                        "networkName": "test_network",
+                        "displayName": "test_network",
+                        "switchName": "n9kv-218",
+                        "switchRole": "leaf",
+                        "fabricName": "test_net",
+                        "lanAttachState": "DEPLOYED",
+                        "isLanAttached": true,
+                        "portNames": "Ethernet1/13,Ethernet1/14",
+                        "switchSerialNo": "9YO9A29F27U",
+                        "switchDbId": 4191270,
+                        "ipAddress": "10.10.10.218",
+                        "networkId": 9008011,
+                        "vlanId": 202,
+                        "interfaceGroups": null
+                    },
+                    {
+                        "networkName": "test_network",
+                        "displayName": "test_network",
+                        "switchName": "n9kv-217",
+                        "switchRole": "leaf",
+                        "fabricName": "test_net",
+                        "lanAttachState": "DEPLOYED",
+                        "isLanAttached": true,
+                        "portNames": "Ethernet1/13,Ethernet1/14",
+                        "switchSerialNo": "9NN7E41N16A",
+                        "switchDbId": 4195850,
+                        "ipAddress": "10.10.10.217",
+                        "networkId": 9008011,
+                        "vlanId": 300,
+                        "interfaceGroups": null
+                    }
+                ]
+            }
+        ]
     }
 }

--- a/tests/unit/modules/dcnm/test_dcnm_network.py
+++ b/tests/unit/modules/dcnm/test_dcnm_network.py
@@ -64,6 +64,8 @@ class TestDcnmNetworkModule(TestDcnmModule):
     playbook_config_replace = test_data.get("playbook_config_replace")
     playbook_config_replace_no_atch = test_data.get("playbook_config_replace_no_atch")
     playbook_config_override = test_data.get("playbook_config_override")
+    playbook_config_attach_vlan_override = test_data.get("playbook_config_attach_vlan_override")
+    mock_net_attach_object_vlan_override = test_data.get("mock_net_attach_object_vlan_override")
     mock_net_attach_object_del_not_ready = test_data.get(
         "mock_net_attach_object_del_not_ready"
     )
@@ -632,6 +634,25 @@ class TestDcnmNetworkModule(TestDcnmModule):
                 self.blank_data,
                 self.attach_success_resp,
                 self.deploy_success_resp,
+            ]
+
+        elif "_merged_attach_vlan_override_new" in self._testMethodName:
+            self.init_data()
+            self.run_dcnm_send.side_effect = [
+                self.mock_vrf_object,
+                self.blank_data,
+                self.blank_data,
+                self.attach_success_resp,
+                self.deploy_success_resp,
+            ]
+
+        elif "_merged_attach_vlan_override_idempotent" in self._testMethodName:
+            self.init_data()
+            self.run_dcnm_get_url.side_effect = [self.mock_net_attach_object_vlan_override]
+            self.run_dcnm_fabric_details.side_effect = [self.fabric_details_vxlan_fabric]
+            self.run_dcnm_send.side_effect = [
+                self.mock_vrf_object,
+                self.mock_net_object,
             ]
 
         elif "replace_with_no_atch" in self._testMethodName:
@@ -2104,3 +2125,48 @@ class TestDcnmNetworkModule(TestDcnmModule):
         self.assertEqual(leaf4_attach["portNames"], "Ethernet1/16,Ethernet1/17")
         self.assertEqual(leaf4_attach["lanAttachState"], "IN PROGRESS")
         self.assertTrue(leaf4_attach["isLanAttached"])
+
+    # ==================== Attachment-level VLAN Override Tests ====================
+
+    def test_dcnm_net_merged_attach_vlan_override_new(self):
+        """Test creating a new network with attachment-level vlan_id override.
+
+        First attachment (10.10.10.217) specifies vlan_id=300 to override network-level vlan_id=202.
+        Second attachment (10.10.10.218) uses network-level vlan_id (no override).
+        """
+        set_module_args(
+            dict(state="merged", fabric="test_network", config=self.playbook_config_attach_vlan_override)
+        )
+        result = self.execute_module(changed=True, failed=False, use_action_plugin=True)
+        self.assertTrue(result.get("diff")[0]["attach"][0]["deploy"])
+        self.assertTrue(result.get("diff")[0]["attach"][1]["deploy"])
+
+    def test_dcnm_net_merged_attach_vlan_override_idempotent(self):
+        """Test idempotency when attachment-level vlan_id matches existing state.
+
+        Network already deployed with first switch having vlan 300 (override) and
+        second switch having vlan 202 (network default). Re-running with same config
+        should produce no changes.
+        """
+        set_module_args(
+            dict(state="merged", fabric="test_network", config=self.playbook_config_attach_vlan_override)
+        )
+        result = self.execute_module(changed=False, failed=False, use_action_plugin=True)
+        self.assertFalse(result.get("diff"))
+
+    def test_dcnm_net_diff_for_attach_deploy_vlan_inherit(self):
+        """Test that vlan=0 in want inherits vlan from have (no change detected)."""
+        dcnm_net = self._build_diff_network(self.net_inv_data)
+
+        have_attach = [
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", vlan=300),
+        ]
+        want_attach = [
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", vlan=0),
+        ]
+
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach))
+
+        # No diff - vlan=0 inherits existing vlan 300
+        self.assertFalse(diff)
+        self.assertFalse(dep_net)

--- a/tests/unit/modules/dcnm/test_dcnm_network.py
+++ b/tests/unit/modules/dcnm/test_dcnm_network.py
@@ -2328,9 +2328,10 @@ class TestDcnmNetworkModule(TestDcnmModule):
     def _make_bare_dcnm_net(self):
         dcnm_net = dcnm_network.DcnmNetwork.__new__(dcnm_network.DcnmNetwork)
         dcnm_net.log = type("Logger", (), {"debug": lambda *a, **k: None})()
-        dcnm_net.fabric = "juarocha-nac-fabric1"
-        dcnm_net.ip_sn = {"10.6.20.109": "9W28HEH9T5J"}
-        dcnm_net.inventory_data = {"10.6.20.109": {"switchRole": "leaf"}}
+        dcnm_net.fabric = "test-fabric"
+        dcnm_net.ip_sn = {"10.10.10.217": "9NN7E41N16A"}
+        dcnm_net.inventory_data = {"10.10.10.217": {"switchRole": "leaf"}}
+        dcnm_net.dcnm_version = 12.4
 
         class _Module:
             def fail_json(self, **kwargs):
@@ -2343,7 +2344,7 @@ class TestDcnmNetworkModule(TestDcnmModule):
         dcnm_net = self._make_bare_dcnm_net()
         with patch.object(dcnm_network, "dcnm_get_ip_addr_info", lambda module, ip, a, b: ip):
             attach = {
-                "ip_address": "10.6.20.109",
+                "ip_address": "10.10.10.217",
                 "ports": ["Ethernet1/3"],
                 "svi_enabled": True,
             }
@@ -2353,13 +2354,13 @@ class TestDcnmNetworkModule(TestDcnmModule):
         self.assertIn("instanceValues", out)
         inst = json.loads(out["instanceValues"])
         self.assertEqual(inst["sviEnabled"], "true")
-        self.assertEqual(out["serialNumber"], "9W28HEH9T5J")
+        self.assertEqual(out["serialNumber"], "9NN7E41N16A")
         self.assertEqual(out["networkName"], "Test_Network1")
 
     def test_dcnm_net_update_attach_params_defaults_svi_enabled_to_true_when_omitted(self):
         dcnm_net = self._make_bare_dcnm_net()
         with patch.object(dcnm_network, "dcnm_get_ip_addr_info", lambda module, ip, a, b: ip):
-            attach = {"ip_address": "10.6.20.109", "ports": ["Ethernet1/3"]}
+            attach = {"ip_address": "10.10.10.217", "ports": ["Ethernet1/3"]}
             out = dcnm_net.update_attach_params(attach, "Test_Network1", deploy=True)
 
         self.assertEqual(json.loads(out["instanceValues"])["sviEnabled"], "true")
@@ -2368,7 +2369,7 @@ class TestDcnmNetworkModule(TestDcnmModule):
         dcnm_net = self._make_bare_dcnm_net()
         with patch.object(dcnm_network, "dcnm_get_ip_addr_info", lambda module, ip, a, b: ip):
             attach = {
-                "ip_address": "10.6.20.109",
+                "ip_address": "10.10.10.217",
                 "ports": ["Ethernet1/3"],
                 "svi_enabled": False,
             }
@@ -2380,7 +2381,7 @@ class TestDcnmNetworkModule(TestDcnmModule):
         dcnm_net = self._make_bare_dcnm_net()
 
         have_attach = [{
-            "serialNumber": "9W28HEH9T5J",
+            "serialNumber": "9NN7E41N16A",
             "networkName": "Test_Network1",
             "switchPorts": "Ethernet1/3",
             "isAttached": True,
@@ -2405,7 +2406,7 @@ class TestDcnmNetworkModule(TestDcnmModule):
         dcnm_net = self._make_bare_dcnm_net()
 
         have_attach = [{
-            "serialNumber": "9W28HEH9T5J",
+            "serialNumber": "9NN7E41N16A",
             "networkName": "Test_Network1",
             "switchPorts": "Ethernet1/3",
             "isAttached": True,

--- a/tests/unit/modules/dcnm/test_dcnm_network.py
+++ b/tests/unit/modules/dcnm/test_dcnm_network.py
@@ -2104,3 +2104,100 @@ class TestDcnmNetworkModule(TestDcnmModule):
         self.assertEqual(leaf4_attach["portNames"], "Ethernet1/16,Ethernet1/17")
         self.assertEqual(leaf4_attach["lanAttachState"], "IN PROGRESS")
         self.assertTrue(leaf4_attach["isLanAttached"])
+
+    def _make_bare_dcnm_net(self):
+        dcnm_net = dcnm_network.DcnmNetwork.__new__(dcnm_network.DcnmNetwork)
+        dcnm_net.log = type("Logger", (), {"debug": lambda *a, **k: None})()
+        dcnm_net.fabric = "juarocha-nac-fabric1"
+        dcnm_net.ip_sn = {"10.6.20.109": "9W28HEH9T5J"}
+        dcnm_net.inventory_data = {"10.6.20.109": {"switchRole": "leaf"}}
+
+        class _Module:
+            def fail_json(self, **kwargs):
+                raise AssertionError(kwargs)
+
+        dcnm_net.module = _Module()
+        return dcnm_net
+
+    def test_dcnm_net_update_attach_params_serializes_svi_enabled_true(self):
+        dcnm_net = self._make_bare_dcnm_net()
+        with patch.object(dcnm_network, "dcnm_get_ip_addr_info", lambda module, ip, a, b: ip):
+            attach = {
+                "ip_address": "10.6.20.109",
+                "ports": ["Ethernet1/3"],
+                "svi_enabled": True,
+            }
+            out = dcnm_net.update_attach_params(attach, "Test_Network1", deploy=True)
+
+        self.assertNotIn("svi_enabled", out)
+        self.assertIn("instanceValues", out)
+        inst = json.loads(out["instanceValues"])
+        self.assertEqual(inst["sviEnabled"], "true")
+        self.assertEqual(out["serialNumber"], "9W28HEH9T5J")
+        self.assertEqual(out["networkName"], "Test_Network1")
+
+    def test_dcnm_net_update_attach_params_defaults_svi_enabled_to_true_when_omitted(self):
+        dcnm_net = self._make_bare_dcnm_net()
+        with patch.object(dcnm_network, "dcnm_get_ip_addr_info", lambda module, ip, a, b: ip):
+            attach = {"ip_address": "10.6.20.109", "ports": ["Ethernet1/3"]}
+            out = dcnm_net.update_attach_params(attach, "Test_Network1", deploy=True)
+
+        self.assertEqual(json.loads(out["instanceValues"])["sviEnabled"], "true")
+
+    def test_dcnm_net_update_attach_params_serializes_svi_enabled_false_when_explicit(self):
+        dcnm_net = self._make_bare_dcnm_net()
+        with patch.object(dcnm_network, "dcnm_get_ip_addr_info", lambda module, ip, a, b: ip):
+            attach = {
+                "ip_address": "10.6.20.109",
+                "ports": ["Ethernet1/3"],
+                "svi_enabled": False,
+            }
+            out = dcnm_net.update_attach_params(attach, "Test_Network1", deploy=True)
+
+        self.assertEqual(json.loads(out["instanceValues"])["sviEnabled"], "false")
+
+    def test_dcnm_net_diff_for_attach_deploy_svi_enabled_flip_triggers_change(self):
+        dcnm_net = self._make_bare_dcnm_net()
+
+        have_attach = [{
+            "serialNumber": "9W28HEH9T5J",
+            "networkName": "Test_Network1",
+            "switchPorts": "Ethernet1/3",
+            "isAttached": True,
+            "deployment": True,
+            "is_deploy": True,
+            "vlan": 1111,
+            "instanceValues": json.dumps({"isVPC": "false", "sviEnabled": "false", "isActive": "false"}),
+        }]
+        want_attach = copy.deepcopy(have_attach)
+        want_attach[0]["instanceValues"] = json.dumps({"sviEnabled": "true"})
+
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach))
+
+        self.assertTrue(diff)
+        self.assertTrue(dep_net)
+        merged = json.loads(diff[0]["instanceValues"])
+        self.assertEqual(merged["sviEnabled"], "true")
+        self.assertEqual(merged["isVPC"], "false")
+        self.assertEqual(merged["isActive"], "false")
+
+    def test_dcnm_net_diff_for_attach_deploy_svi_enabled_idempotent(self):
+        dcnm_net = self._make_bare_dcnm_net()
+
+        have_attach = [{
+            "serialNumber": "9W28HEH9T5J",
+            "networkName": "Test_Network1",
+            "switchPorts": "Ethernet1/3",
+            "isAttached": True,
+            "deployment": True,
+            "is_deploy": True,
+            "vlan": 1111,
+            "instanceValues": json.dumps({"isVPC": "false", "sviEnabled": "true", "isActive": "false"}),
+        }]
+        want_attach = copy.deepcopy(have_attach)
+        want_attach[0]["instanceValues"] = json.dumps({"sviEnabled": "true"})
+
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach))
+
+        self.assertFalse(diff)
+        self.assertFalse(dep_net)

--- a/tests/unit/modules/dcnm/test_dcnm_network.py
+++ b/tests/unit/modules/dcnm/test_dcnm_network.py
@@ -67,6 +67,8 @@ class TestDcnmNetworkModule(TestDcnmModule):
     mock_net_attach_object_del_not_ready = test_data.get(
         "mock_net_attach_object_del_not_ready"
     )
+    playbook_config_attach_freeform_config = test_data.get("playbook_config_attach_freeform_config")
+    mock_net_attach_object_freeform_config = test_data.get("mock_net_attach_object_freeform_config")
     mock_net_attach_object_del_ready = test_data.get("mock_net_attach_object_del_ready")
     mock_net_del_ready = test_data.get("mock_net_del_ready")
     attach_success_resp = test_data.get("attach_success_resp")
@@ -160,7 +162,7 @@ class TestDcnmNetworkModule(TestDcnmModule):
         self.mock_dcnm_get_url.stop()
 
     @staticmethod
-    def _build_attach_state(serial, switch_ports, torports=None, vlan=202):
+    def _build_attach_state(serial, switch_ports, torports=None, vlan=202, freeform_config=""):
         return {
             "serialNumber": serial,
             "networkName": "test_network",
@@ -170,6 +172,7 @@ class TestDcnmNetworkModule(TestDcnmModule):
             "is_deploy": True,
             "vlan": vlan,
             "torports": copy.deepcopy(torports or []),
+            "freeformConfig": freeform_config,
         }
 
     @staticmethod
@@ -2104,3 +2107,41 @@ class TestDcnmNetworkModule(TestDcnmModule):
         self.assertEqual(leaf4_attach["portNames"], "Ethernet1/16,Ethernet1/17")
         self.assertEqual(leaf4_attach["lanAttachState"], "IN PROGRESS")
         self.assertTrue(leaf4_attach["isLanAttached"])
+
+    def test_dcnm_net_diff_for_attach_deploy_freeform_config_inherit(self):
+        """Test that empty freeformConfig inwant inherits from have (no change detected)."""
+        dcnm_net = self._build_diff_network(self.net_inv_data)
+
+        have_attach = [
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", 
+                freeform_config="interface Vlan202\n  description Test"),
+        ]
+        want_attach = [
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", freeform_config=""),
+        ]
+
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach))
+
+        # No diff - empty freeformConfig inherits existing config
+        self.assertFalse(diff)
+        self.assertFalse(dep_net)
+
+    def test_dcnm_net_diff_for_attach_deploy_freeform_config_change(self):
+        """Test that different freeformConfig values trigger a diff."""
+        dcnm_net = self._build_diff_network(self.net_inv_data)
+
+        have_attach = [
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", 
+                freeform_config="interface Vlan202\n  description Old"),
+        ]
+        want_attach = [
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", 
+                freeform_config="interface Vlan202\n  description New"),
+        ]
+
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach))
+
+        # Diff should be detected due to freeformConfig change
+        # Current Implementation inherits if want is empty, but explicit change should diff
+        # This test documents expected behavior - adjust assertions based on actual implementation
+        self.assertEqual(want_attach[0]["freeformConfig"], "interface Vlan202\n  description New")

--- a/tests/unit/modules/dcnm/test_dcnm_network.py
+++ b/tests/unit/modules/dcnm/test_dcnm_network.py
@@ -2113,8 +2113,7 @@ class TestDcnmNetworkModule(TestDcnmModule):
         dcnm_net = self._build_diff_network(self.net_inv_data)
 
         have_attach = [
-            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", 
-                freeform_config="interface Vlan202\n  description Test"),
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", freeform_config="interface Vlan202\n  description Test"),
         ]
         want_attach = [
             self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", freeform_config=""),
@@ -2131,12 +2130,10 @@ class TestDcnmNetworkModule(TestDcnmModule):
         dcnm_net = self._build_diff_network(self.net_inv_data)
 
         have_attach = [
-            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", 
-                freeform_config="interface Vlan202\n  description Old"),
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", freeform_config="interface Vlan202\n  description Old"),
         ]
         want_attach = [
-            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", 
-                freeform_config="interface Vlan202\n  description New"),
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", freeform_config="interface Vlan202\n  description New"),
         ]
 
         diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach))

--- a/tests/unit/modules/dcnm/test_dcnm_network.py
+++ b/tests/unit/modules/dcnm/test_dcnm_network.py
@@ -1089,8 +1089,10 @@ class TestDcnmNetworkModule(TestDcnmModule):
         )
         result = self.execute_module(changed=True, failed=False, use_action_plugin=True)
         self.assertEqual(result.get("diff")[0]["vlan_id"], 203)
-        self.assertTrue(result.get("diff")[0]["attach"][0]["deploy"])
-        self.assertFalse(result.get("diff")[0]["attach"][1]["deploy"])
+        deploy_by_ip = {a["ip_address"]: a["deploy"] for a in result.get("diff")[0]["attach"]}
+        self.assertTrue(deploy_by_ip["10.10.10.218"])
+        self.assertTrue(deploy_by_ip["10.10.10.226"])
+        self.assertFalse(deploy_by_ip["10.10.10.217"])
         self.assertEqual(
             result["response"][0]["DATA"]["test-network--9NN7E41N16A(leaf1)"], "SUCCESS"
         )
@@ -1120,8 +1122,10 @@ class TestDcnmNetworkModule(TestDcnmModule):
         self.assertIn(("GET", get_net_path), request_calls)
         self.assertNotIn(("GET", get_net_name_path), request_calls)
         self.assertEqual(result.get("diff")[0]["vlan_id"], 203)
-        self.assertTrue(result.get("diff")[0]["attach"][0]["deploy"])
-        self.assertFalse(result.get("diff")[0]["attach"][1]["deploy"])
+        deploy_by_ip = {a["ip_address"]: a["deploy"] for a in result.get("diff")[0]["attach"]}
+        self.assertTrue(deploy_by_ip["10.10.10.218"])
+        self.assertTrue(deploy_by_ip["10.10.10.226"])
+        self.assertFalse(deploy_by_ip["10.10.10.217"])
 
     def test_dcnm_net_replace_with_no_atch(self):
         set_module_args(
@@ -1501,6 +1505,7 @@ class TestDcnmNetworkModule(TestDcnmModule):
                 "isAttached": True,
                 "deployment": True,
                 "is_deploy": True,
+                "vlan": 0,
                 "torports": [],
             },
             {
@@ -1510,6 +1515,7 @@ class TestDcnmNetworkModule(TestDcnmModule):
                 "isAttached": True,
                 "deployment": True,
                 "is_deploy": True,
+                "vlan": 0,
                 "torports": [
                     {"switch": "dt-n9k6", "torPorts": "Ethernet1/12"},
                     {"switch": "dt-n9k7", "torPorts": "Ethernet1/12"},
@@ -1546,7 +1552,7 @@ class TestDcnmNetworkModule(TestDcnmModule):
         ]
 
         dcnm_net.normalize_vpc_torports(want_attach)
-        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach), replace=True)
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach), replace=True, network_vlan=202)
 
         self.assertFalse(diff)
         self.assertFalse(dep_net)
@@ -2390,3 +2396,55 @@ class TestDcnmNetworkModule(TestDcnmModule):
         # No diff - vlan=0 inherits existing vlan 300
         self.assertFalse(diff)
         self.assertFalse(dep_net)
+
+    def test_dcnm_net_diff_for_attach_deploy_vlan_only_change_merged(self):
+        """Vlan-only change under merged must produce a diff with the new vlan."""
+        dcnm_net = self._build_diff_network(self.net_inv_data)
+
+        have_attach = [
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", vlan=300),
+        ]
+        want_attach = [
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", vlan=301),
+        ]
+
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach))
+
+        self.assertEqual(len(diff), 1)
+        self.assertEqual(diff[0]["vlan"], 301)
+        self.assertEqual(diff[0]["switchPorts"], "Ethernet1/13,Ethernet1/14")
+        self.assertTrue(dep_net)
+
+    def test_dcnm_net_diff_for_attach_deploy_vlan_only_change_replaced(self):
+        """Vlan-only change under replaced must produce a diff with the new vlan."""
+        dcnm_net = self._build_diff_network(self.net_inv_data)
+
+        have_attach = [
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", vlan=300),
+        ]
+        want_attach = [
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", vlan=301),
+        ]
+
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach), replace=True)
+
+        self.assertEqual(len(diff), 1)
+        self.assertEqual(diff[0]["vlan"], 301)
+        self.assertTrue(dep_net)
+
+    def test_dcnm_net_diff_for_attach_deploy_vlan_reset_replaced(self):
+        """Replaced with omitted attach vlan_id must send vlan=0 to reset the override."""
+        dcnm_net = self._build_diff_network(self.net_inv_data)
+
+        have_attach = [
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", vlan=300),
+        ]
+        want_attach = [
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", vlan=0),
+        ]
+
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach), replace=True)
+
+        self.assertEqual(len(diff), 1)
+        self.assertEqual(diff[0]["vlan"], 0)
+        self.assertTrue(dep_net)

--- a/tests/unit/modules/dcnm/test_dcnm_network.py
+++ b/tests/unit/modules/dcnm/test_dcnm_network.py
@@ -72,6 +72,10 @@ class TestDcnmNetworkModule(TestDcnmModule):
     playbook_config_attach_freeform_config = test_data.get("playbook_config_attach_freeform_config")
     mock_net_attach_object_freeform_config = test_data.get("mock_net_attach_object_freeform_config")
     mock_net_attach_object_del_ready = test_data.get("mock_net_attach_object_del_ready")
+
+    _real_overlay_have_freeform_from_switch_details = staticmethod(
+        dcnm_network.DcnmNetwork._overlay_have_freeform_from_switch_details
+    )
     mock_net_del_ready = test_data.get("mock_net_del_ready")
     attach_success_resp = test_data.get("attach_success_resp")
     attach_success_resp2 = test_data.get("attach_success_resp2")
@@ -156,12 +160,20 @@ class TestDcnmNetworkModule(TestDcnmModule):
         )
         self.run_dcnm_get_url = self.mock_dcnm_get_url.start()
 
+        self.mock_freeform_overlay = patch.object(
+            dcnm_network.DcnmNetwork,
+            "_overlay_have_freeform_from_switch_details",
+            lambda *args, **kwargs: None,
+        )
+        self.mock_freeform_overlay.start()
+
     def tearDown(self):
         super(TestDcnmNetworkModule, self).tearDown()
         self.mock_dcnm_send.stop()
         self.mock_dcnm_ip_sn.stop()
         self.mock_dcnm_fabric_details.stop()
         self.mock_dcnm_get_url.stop()
+        self.mock_freeform_overlay.stop()
 
     @staticmethod
     def _build_attach_state(serial, switch_ports, torports=None, vlan=202, freeform_config=""):
@@ -640,6 +652,16 @@ class TestDcnmNetworkModule(TestDcnmModule):
             ]
 
         elif "_merged_attach_vlan_override_new" in self._testMethodName:
+            self.init_data()
+            self.run_dcnm_send.side_effect = [
+                self.mock_vrf_object,
+                self.blank_data,
+                self.blank_data,
+                self.attach_success_resp,
+                self.deploy_success_resp,
+            ]
+
+        elif "_merged_attach_freeform_new" in self._testMethodName:
             self.init_data()
             self.run_dcnm_send.side_effect = [
                 self.mock_vrf_object,
@@ -2373,6 +2395,40 @@ class TestDcnmNetworkModule(TestDcnmModule):
         self.assertEqual(attach_by_ip["10.10.10.217"]["vlan_id"], 300)
         self.assertNotIn("vlan_id", attach_by_ip["10.10.10.218"])
 
+    def test_dcnm_net_merged_attach_freeform_new(self):
+        """Formatted user-facing diff must include attachment-level freeform_config when set."""
+        inline_config = [
+            {
+                "net_name": "test_network",
+                "vrf_name": "ansible-vrf-int1",
+                "net_id": "9008011",
+                "net_template": "Default_Network_Universal",
+                "net_extension_template": "Default_Network_Extension_Universal",
+                "vlan_id": "202",
+                "gw_ip_subnet": "192.168.30.1/24",
+                "attach": [
+                    {
+                        "ip_address": "10.10.10.217",
+                        "ports": ["Ethernet1/13", "Ethernet1/14"],
+                        "freeform_config": "interface Vlan202\n  description New",
+                        "deploy": True,
+                    },
+                    {
+                        "ip_address": "10.10.10.218",
+                        "ports": ["Ethernet1/13", "Ethernet1/14"],
+                        "deploy": True,
+                    },
+                ],
+                "deploy": True,
+            }
+        ]
+        set_module_args(dict(state="merged", fabric="test_network", config=inline_config))
+        result = self.execute_module(changed=True, failed=False, use_action_plugin=True)
+
+        attach_by_ip = {a["ip_address"]: a for a in result.get("diff")[0]["attach"]}
+        self.assertEqual(attach_by_ip["10.10.10.217"]["freeform_config"], "interface Vlan202\n  description New")
+        self.assertEqual(attach_by_ip["10.10.10.218"]["freeform_config"], "")
+
     def test_dcnm_net_merged_attach_vlan_override_idempotent(self):
         """Test idempotency when attachment-level vlan_id matches existing state.
 
@@ -2456,24 +2512,23 @@ class TestDcnmNetworkModule(TestDcnmModule):
         self.assertTrue(dep_net)
 
     def test_dcnm_net_diff_for_attach_deploy_freeform_config_inherit(self):
-        """Test that empty freeformConfig inwant inherits from have (no change detected)."""
+        """Merged: omitted freeform_config (want=None) inherits current controller value, no diff."""
         dcnm_net = self._build_diff_network(self.net_inv_data)
 
         have_attach = [
             self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", freeform_config="interface Vlan202\n  description Test"),
         ]
         want_attach = [
-            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", freeform_config=""),
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", freeform_config=None),
         ]
 
         diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach))
 
-        # No diff - empty freeformConfig inherits existing config
         self.assertFalse(diff)
         self.assertFalse(dep_net)
 
     def test_dcnm_net_diff_for_attach_deploy_freeform_config_change(self):
-        """Test that different freeformConfig values trigger a diff."""
+        """Merged: old->new freeform_config with unchanged ports produces a diff with the new value."""
         dcnm_net = self._build_diff_network(self.net_inv_data)
 
         have_attach = [
@@ -2485,10 +2540,81 @@ class TestDcnmNetworkModule(TestDcnmModule):
 
         diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach))
 
-        # Diff should be detected due to freeformConfig change
-        # Current Implementation inherits if want is empty, but explicit change should diff
-        # This test documents expected behavior - adjust assertions based on actual implementation
-        self.assertEqual(want_attach[0]["freeformConfig"], "interface Vlan202\n  description New")
+        self.assertEqual(len(diff), 1)
+        self.assertEqual(diff[0]["freeformConfig"], "interface Vlan202\n  description New")
+        self.assertTrue(dep_net)
+
+    def test_dcnm_net_diff_for_attach_deploy_freeform_config_explicit_clear_merged(self):
+        """Merged: explicit freeform_config='' clears an existing non-empty controller value."""
+        dcnm_net = self._build_diff_network(self.net_inv_data)
+
+        have_attach = [
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", freeform_config="interface Vlan202\n  description Old"),
+        ]
+        want_attach = [
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", freeform_config=""),
+        ]
+
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach))
+
+        self.assertEqual(len(diff), 1)
+        self.assertEqual(diff[0]["freeformConfig"], "")
+        self.assertTrue(dep_net)
+
+    def test_dcnm_net_diff_for_attach_deploy_freeform_config_explicit_clear_replaced(self):
+        """Replaced: explicit freeform_config='' clears an existing non-empty controller value (reviewer Example 2)."""
+        dcnm_net = self._build_diff_network(self.net_inv_data)
+
+        have_attach = [
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", freeform_config="interface Vlan202\n  description Old"),
+        ]
+        want_attach = [
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", freeform_config=""),
+        ]
+
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach), replace=True)
+
+        self.assertEqual(len(diff), 1)
+        self.assertEqual(diff[0]["freeformConfig"], "")
+        self.assertTrue(dep_net)
+
+    def test_dcnm_net_diff_for_attach_deploy_freeform_config_omitted_resets_replaced(self):
+        """Replaced: omitted freeform_config (want=None) resets an existing non-empty controller value to empty."""
+        dcnm_net = self._build_diff_network(self.net_inv_data)
+
+        have_attach = [
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", freeform_config="interface Vlan202\n  description Old"),
+        ]
+        want_attach = [
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", freeform_config=None),
+        ]
+
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach), replace=True)
+
+        self.assertEqual(len(diff), 1)
+        self.assertEqual(diff[0]["freeformConfig"], "")
+        self.assertTrue(dep_net)
+
+    def test_dcnm_net_diff_for_attach_deploy_freeform_config_idempotent_both_empty(self):
+        """Idempotency: matching empty freeform on both sides produces no diff under merged and replaced."""
+        dcnm_net = self._build_diff_network(self.net_inv_data)
+
+        have_attach = [
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", freeform_config=""),
+        ]
+        want_attach = [
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/13,Ethernet1/14", freeform_config=""),
+        ]
+
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach))
+        self.assertFalse(diff)
+        self.assertFalse(dep_net)
+
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(
+            copy.deepcopy(want_attach), copy.deepcopy(have_attach), replace=True, network_vlan=202
+        )
+        self.assertFalse(diff)
+        self.assertFalse(dep_net)
 
     def _make_bare_dcnm_net(self):
         dcnm_net = dcnm_network.DcnmNetwork.__new__(dcnm_network.DcnmNetwork)
@@ -2587,3 +2713,340 @@ class TestDcnmNetworkModule(TestDcnmModule):
 
         self.assertFalse(diff)
         self.assertFalse(dep_net)
+
+    def test_dcnm_net_diff_for_attach_deploy_port_add_merged_empty_freeform(self):
+        """Merged: adding a port on an attach with empty freeform on both sides must produce a diff."""
+        dcnm_net = self._build_diff_network(self.net_inv_data)
+
+        have_attach = [
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/1"),
+        ]
+        want_attach = [
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/1,Ethernet1/2"),
+        ]
+
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach))
+
+        self.assertEqual(len(diff), 1)
+        self.assertEqual(diff[0]["switchPorts"], "Ethernet1/2")
+        self.assertTrue(dep_net)
+
+    def test_dcnm_net_diff_for_attach_deploy_port_swap_replaced_empty_freeform(self):
+        """Replaced: swapping a port on an attach with empty freeform on both sides must attach the new and detach the old."""
+        dcnm_net = self._build_diff_network(self.net_inv_data)
+
+        have_attach = [
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/1"),
+        ]
+        want_attach = [
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/2"),
+        ]
+
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach), replace=True)
+
+        self.assertEqual(len(diff), 1)
+        self.assertEqual(diff[0]["switchPorts"], "Ethernet1/2")
+        self.assertEqual(diff[0]["detachSwitchPorts"], "Ethernet1/1")
+        self.assertTrue(dep_net)
+
+    def test_dcnm_net_diff_for_attach_deploy_port_unchanged_empty_freeform_idempotent(self):
+        """Idempotency: identical attach with empty freeform on both sides must produce no diff under both merged and replaced."""
+        dcnm_net = self._build_diff_network(self.net_inv_data)
+
+        have_attach = [
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/1,Ethernet1/2"),
+        ]
+        want_attach = [
+            self._build_attach_state("9NN7E41N16A", "Ethernet1/1,Ethernet1/2"),
+        ]
+
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach))
+        self.assertFalse(diff)
+        self.assertFalse(dep_net)
+
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(
+            copy.deepcopy(want_attach), copy.deepcopy(have_attach), replace=True, network_vlan=202
+        )
+        self.assertFalse(diff)
+        self.assertFalse(dep_net)
+
+    def test_dcnm_net_overlay_have_freeform_from_switch_details(self):
+        """The overlay fetches per-switch policies, filters for
+        switch_freeform_config, and overlays nvPairs.CONF onto matching
+        have_attach entries so diff_for_attach_deploy can see it."""
+        dcnm_net = self._make_bare_dcnm_net()
+        dcnm_net.paths = dcnm_network.DcnmNetwork.dcnm_network_paths[12]
+
+        have_attach = [
+            {
+                "networkName": "test_network",
+                "lanAttachList": [
+                    {"serialNumber": "SN_A", "freeformConfig": ""},
+                    {"serialNumber": "SN_B", "freeformConfig": ""},
+                ],
+            }
+        ]
+        network_to_sns = {"test_network": ["SN_A", "SN_B"]}
+
+        self.run_dcnm_send.side_effect = [
+            {
+                "MESSAGE": "OK",
+                "METHOD": "GET",
+                "RETURN_CODE": 200,
+                "DATA": [
+                    {
+                        "policyId": "POLICY-A1",
+                        "templateName": "switch_freeform_config",
+                        "serialNumber": "SN_A",
+                        "entityName": "test_network",
+                        "nvPairs": {"CONF": "interface Vlan202\n  no autostate"},
+                    },
+                    {
+                        "policyId": "POLICY-A2",
+                        "templateName": "some_other_template",
+                        "serialNumber": "SN_A",
+                        "nvPairs": {"CONF": "ignore me"},
+                    },
+                ],
+            },
+            {
+                "MESSAGE": "OK",
+                "METHOD": "GET",
+                "RETURN_CODE": 200,
+                "DATA": [],
+            },
+        ]
+
+        self._real_overlay_have_freeform_from_switch_details(
+            dcnm_net, have_attach, network_to_sns
+        )
+
+        by_sn = {a["serialNumber"]: a for a in have_attach[0]["lanAttachList"]}
+        self.assertEqual(by_sn["SN_A"]["freeformConfig"], "interface Vlan202\n  no autostate")
+        self.assertEqual(by_sn["SN_B"]["freeformConfig"], "")
+
+    def test_dcnm_net_overlay_have_freeform_fetch_failure_is_soft(self):
+        """A failing switch-policies GET must not raise; have_attach is left unchanged."""
+        dcnm_net = self._make_bare_dcnm_net()
+        dcnm_net.paths = dcnm_network.DcnmNetwork.dcnm_network_paths[12]
+
+        have_attach = [
+            {
+                "networkName": "test_network",
+                "lanAttachList": [
+                    {"serialNumber": "SN_A", "freeformConfig": ""},
+                ],
+            }
+        ]
+        network_to_sns = {"test_network": ["SN_A"]}
+
+        self.run_dcnm_send.side_effect = [
+            {"MESSAGE": "Not Found", "METHOD": "GET", "RETURN_CODE": 404, "DATA": None}
+        ]
+
+        self._real_overlay_have_freeform_from_switch_details(
+            dcnm_net, have_attach, network_to_sns
+        )
+
+        self.assertEqual(have_attach[0]["lanAttachList"][0]["freeformConfig"], "")
+
+    def _make_multinet_overlay_fixture(self):
+        dcnm_net = self._make_bare_dcnm_net()
+        dcnm_net.paths = dcnm_network.DcnmNetwork.dcnm_network_paths[12]
+        have_attach = [
+            {
+                "networkName": "net_A",
+                "lanAttachList": [
+                    {"serialNumber": "SN1", "freeformConfig": ""},
+                ],
+            },
+            {
+                "networkName": "net_B",
+                "lanAttachList": [
+                    {"serialNumber": "SN1", "freeformConfig": ""},
+                ],
+            },
+        ]
+        network_to_sns = {"net_A": ["SN1"], "net_B": ["SN1"]}
+        return dcnm_net, have_attach, network_to_sns
+
+    def test_dcnm_net_overlay_multinet_matches_by_entity_name(self):
+        """Two networks on one switch: policies scoped by entityName go to the right network."""
+        dcnm_net, have_attach, network_to_sns = self._make_multinet_overlay_fixture()
+
+        self.run_dcnm_send.side_effect = [
+            {
+                "MESSAGE": "OK", "METHOD": "GET", "RETURN_CODE": 200,
+                "DATA": [
+                    {
+                        "policyId": "P1",
+                        "templateName": "switch_freeform_config",
+                        "serialNumber": "SN1",
+                        "entityName": "net_A",
+                        "nvPairs": {"CONF": "cli for A"},
+                    },
+                    {
+                        "policyId": "P2",
+                        "templateName": "switch_freeform_config",
+                        "serialNumber": "SN1",
+                        "entityName": "net_B",
+                        "nvPairs": {"CONF": "cli for B"},
+                    },
+                ],
+            },
+        ]
+
+        self._real_overlay_have_freeform_from_switch_details(
+            dcnm_net, have_attach, network_to_sns
+        )
+
+        by_net = {n["networkName"]: n["lanAttachList"][0]["freeformConfig"] for n in have_attach}
+        self.assertEqual(by_net["net_A"], "cli for A")
+        self.assertEqual(by_net["net_B"], "cli for B")
+
+    def test_dcnm_net_overlay_multinet_matches_by_description(self):
+        """entityName missing/empty: fall back to description substring match."""
+        dcnm_net, have_attach, network_to_sns = self._make_multinet_overlay_fixture()
+
+        self.run_dcnm_send.side_effect = [
+            {
+                "MESSAGE": "OK", "METHOD": "GET", "RETURN_CODE": 200,
+                "DATA": [
+                    {
+                        "policyId": "P1",
+                        "templateName": "switch_freeform_config",
+                        "serialNumber": "SN1",
+                        "entityName": "",
+                        "description": "freeform for net_A on SN1",
+                        "nvPairs": {"CONF": "cli for A"},
+                    },
+                    {
+                        "policyId": "P2",
+                        "templateName": "switch_freeform_config",
+                        "serialNumber": "SN1",
+                        "entityName": "",
+                        "description": "freeform for net_B on SN1",
+                        "nvPairs": {"CONF": "cli for B"},
+                    },
+                ],
+            },
+        ]
+
+        self._real_overlay_have_freeform_from_switch_details(
+            dcnm_net, have_attach, network_to_sns
+        )
+
+        by_net = {n["networkName"]: n["lanAttachList"][0]["freeformConfig"] for n in have_attach}
+        self.assertEqual(by_net["net_A"], "cli for A")
+        self.assertEqual(by_net["net_B"], "cli for B")
+
+    def test_dcnm_net_overlay_multinet_matches_by_nvpairs_network_name(self):
+        """entityName and description miss: fall back to nvPairs.NETWORK_NAME."""
+        dcnm_net, have_attach, network_to_sns = self._make_multinet_overlay_fixture()
+
+        self.run_dcnm_send.side_effect = [
+            {
+                "MESSAGE": "OK", "METHOD": "GET", "RETURN_CODE": 200,
+                "DATA": [
+                    {
+                        "policyId": "P1",
+                        "templateName": "switch_freeform_config",
+                        "serialNumber": "SN1",
+                        "entityName": "",
+                        "description": "",
+                        "nvPairs": {"CONF": "cli for A", "NETWORK_NAME": "net_A"},
+                    },
+                    {
+                        "policyId": "P2",
+                        "templateName": "switch_freeform_config",
+                        "serialNumber": "SN1",
+                        "entityName": "",
+                        "description": "",
+                        "nvPairs": {"CONF": "cli for B", "NETWORK_NAME": "net_B"},
+                    },
+                ],
+            },
+        ]
+
+        self._real_overlay_have_freeform_from_switch_details(
+            dcnm_net, have_attach, network_to_sns
+        )
+
+        by_net = {n["networkName"]: n["lanAttachList"][0]["freeformConfig"] for n in have_attach}
+        self.assertEqual(by_net["net_A"], "cli for A")
+        self.assertEqual(by_net["net_B"], "cli for B")
+
+    def test_dcnm_net_overlay_multinet_no_matching_field_is_safe_no_op(self):
+        """No scoping field matches: policies are silently skipped, freeformConfig stays empty."""
+        dcnm_net, have_attach, network_to_sns = self._make_multinet_overlay_fixture()
+
+        self.run_dcnm_send.side_effect = [
+            {
+                "MESSAGE": "OK", "METHOD": "GET", "RETURN_CODE": 200,
+                "DATA": [
+                    {
+                        "policyId": "P1",
+                        "templateName": "switch_freeform_config",
+                        "serialNumber": "SN1",
+                        "entityName": "unrelated_thing",
+                        "description": "no network hint here",
+                        "nvPairs": {"CONF": "cli for A"},
+                    },
+                ],
+            },
+        ]
+
+        self._real_overlay_have_freeform_from_switch_details(
+            dcnm_net, have_attach, network_to_sns
+        )
+
+        for net_attach in have_attach:
+            self.assertEqual(net_attach["lanAttachList"][0]["freeformConfig"], "")
+
+    def test_dcnm_net_match_freeform_policy_to_network_strategies(self):
+        """_match_freeform_policy_to_network isolates each disambiguation strategy."""
+        matcher = dcnm_network.DcnmNetwork._match_freeform_policy_to_network
+
+        self.assertIsNone(matcher({"entityName": "net_A"}, []))
+
+        self.assertEqual(matcher({"entityName": "ignored"}, ["only_net"]), "only_net")
+
+        self.assertEqual(
+            matcher({"entityName": "net_B"}, ["net_A", "net_B"]),
+            "net_B",
+        )
+
+        self.assertEqual(
+            matcher(
+                {"entityName": "", "description": "freeform for net_A on SN1"},
+                ["net_A", "net_B"],
+            ),
+            "net_A",
+        )
+
+        self.assertEqual(
+            matcher(
+                {"entityName": "", "description": "", "nvPairs": {"NETWORK_NAME": "net_B"}},
+                ["net_A", "net_B"],
+            ),
+            "net_B",
+        )
+
+        self.assertEqual(
+            matcher(
+                {"entityName": "", "description": "", "nvPairs": {"networkName": "net_A"}},
+                ["net_A", "net_B"],
+            ),
+            "net_A",
+        )
+
+        self.assertIsNone(
+            matcher(
+                {
+                    "entityName": "not_a_match",
+                    "description": "nothing useful",
+                    "nvPairs": {"CONF": "just cli"},
+                },
+                ["net_A", "net_B"],
+            )
+        )

--- a/tests/unit/modules/dcnm/test_dcnm_network.py
+++ b/tests/unit/modules/dcnm/test_dcnm_network.py
@@ -2366,6 +2366,9 @@ class TestDcnmNetworkModule(TestDcnmModule):
         result = self.execute_module(changed=True, failed=False, use_action_plugin=True)
         self.assertTrue(result.get("diff")[0]["attach"][0]["deploy"])
         self.assertTrue(result.get("diff")[0]["attach"][1]["deploy"])
+        attach_by_ip = {a["ip_address"]: a for a in result.get("diff")[0]["attach"]}
+        self.assertEqual(attach_by_ip["10.10.10.217"]["vlan_id"], 300)
+        self.assertNotIn("vlan_id", attach_by_ip["10.10.10.218"])
 
     def test_dcnm_net_merged_attach_vlan_override_idempotent(self):
         """Test idempotency when attachment-level vlan_id matches existing state.

--- a/tests/unit/modules/dcnm/test_dcnm_network.py
+++ b/tests/unit/modules/dcnm/test_dcnm_network.py
@@ -2683,6 +2683,7 @@ class TestDcnmNetworkModule(TestDcnmModule):
         }]
         want_attach = copy.deepcopy(have_attach)
         want_attach[0]["instanceValues"] = json.dumps({"sviEnabled": "true"})
+        want_attach[0]["_svi_supplied"] = True
 
         diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach))
 
@@ -2713,6 +2714,378 @@ class TestDcnmNetworkModule(TestDcnmModule):
 
         self.assertFalse(diff)
         self.assertFalse(dep_net)
+
+    def _svi_have(self, svi_value):
+        return [{
+            "serialNumber": "9NN7E41N16A",
+            "networkName": "Test_Network1",
+            "switchPorts": "Ethernet1/3",
+            "isAttached": True,
+            "deployment": True,
+            "is_deploy": True,
+            "vlan": 1111,
+            "instanceValues": json.dumps({"isVPC": "false", "sviEnabled": svi_value, "isActive": "false"}),
+        }]
+
+    def _svi_want(self, svi_supplied, want_svi=None, ports="Ethernet1/3"):
+        inst = {}
+        if want_svi is not None:
+            inst["sviEnabled"] = want_svi
+        return [{
+            "serialNumber": "9NN7E41N16A",
+            "networkName": "Test_Network1",
+            "switchPorts": ports,
+            "isAttached": True,
+            "deployment": True,
+            "is_deploy": True,
+            "vlan": 1111,
+            "instanceValues": json.dumps(inst) if inst else "",
+            "_svi_supplied": svi_supplied,
+        }]
+
+    def test_dcnm_net_svi_enabled_merged_omitted_preserves_have_false(self):
+        """Merged + omitted svi_enabled must preserve NDFC's existing sviEnabled=false."""
+        dcnm_net = self._make_bare_dcnm_net()
+        have_attach = self._svi_have("false")
+        want_attach = self._svi_want(svi_supplied=False, want_svi="true")
+
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach))
+
+        self.assertFalse(diff)
+        self.assertFalse(dep_net)
+
+    def test_dcnm_net_svi_enabled_merged_omitted_preserves_have_true(self):
+        """Merged + omitted svi_enabled is idempotent when NDFC has sviEnabled=true."""
+        dcnm_net = self._make_bare_dcnm_net()
+        have_attach = self._svi_have("true")
+        want_attach = self._svi_want(svi_supplied=False, want_svi="true")
+
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach))
+
+        self.assertFalse(diff)
+        self.assertFalse(dep_net)
+
+    def test_dcnm_net_svi_enabled_merged_port_add_preserves_svi_value(self):
+        """Merged + port change + omitted svi: attach is in diff for the port change,
+        and its outgoing instanceValues carries have's sviEnabled=false, not the
+        argspec default of true."""
+        dcnm_net = self._make_bare_dcnm_net()
+        have_attach = self._svi_have("false")
+        want_attach = self._svi_want(svi_supplied=False, want_svi="true", ports="Ethernet1/3,Ethernet1/4")
+
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach))
+
+        self.assertEqual(len(diff), 1)
+        self.assertTrue(dep_net)
+        merged_inst = json.loads(diff[0]["instanceValues"])
+        self.assertEqual(merged_inst["sviEnabled"], "false")
+        self.assertEqual(merged_inst["isVPC"], "false")
+        self.assertEqual(merged_inst["isActive"], "false")
+
+    def test_dcnm_net_svi_enabled_merged_explicit_false_flips_have_true(self):
+        """Merged + explicit svi_enabled=false must disable an existing enabled SVI."""
+        dcnm_net = self._make_bare_dcnm_net()
+        have_attach = self._svi_have("true")
+        want_attach = self._svi_want(svi_supplied=True, want_svi="false")
+
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach))
+
+        self.assertEqual(len(diff), 1)
+        self.assertTrue(dep_net)
+        self.assertEqual(json.loads(diff[0]["instanceValues"])["sviEnabled"], "false")
+
+    def test_dcnm_net_svi_enabled_replaced_omitted_resets_to_true(self):
+        """Replaced + omitted svi_enabled must reset an existing sviEnabled=false to true."""
+        dcnm_net = self._make_bare_dcnm_net()
+        have_attach = self._svi_have("false")
+        want_attach = self._svi_want(svi_supplied=False, want_svi="true")
+
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach), replace=True)
+
+        self.assertEqual(len(diff), 1)
+        self.assertTrue(dep_net)
+        self.assertEqual(json.loads(diff[0]["instanceValues"])["sviEnabled"], "true")
+
+    def _svi_have_no_instance_values(self):
+        return [{
+            "serialNumber": "9NN7E41N16A",
+            "networkName": "Test_Network1",
+            "switchPorts": "Ethernet1/3",
+            "isAttached": True,
+            "deployment": True,
+            "is_deploy": True,
+            "vlan": 1111,
+            "instanceValues": "",
+        }]
+
+    def test_dcnm_net_svi_enabled_merged_explicit_true_when_have_has_no_instance_values(self):
+        """Merged + explicit true must apply even when NDFC returned no instanceValues."""
+        dcnm_net = self._make_bare_dcnm_net()
+        have_attach = self._svi_have_no_instance_values()
+        want_attach = self._svi_want(svi_supplied=True, want_svi="true")
+
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach))
+
+        self.assertEqual(len(diff), 1)
+        self.assertTrue(dep_net)
+        self.assertEqual(json.loads(diff[0]["instanceValues"])["sviEnabled"], "true")
+
+    def test_dcnm_net_svi_enabled_merged_explicit_false_when_have_has_no_instance_values(self):
+        """Merged + explicit false must apply even when NDFC returned no instanceValues."""
+        dcnm_net = self._make_bare_dcnm_net()
+        have_attach = self._svi_have_no_instance_values()
+        want_attach = self._svi_want(svi_supplied=True, want_svi="false")
+
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach))
+
+        self.assertEqual(len(diff), 1)
+        self.assertTrue(dep_net)
+        self.assertEqual(json.loads(diff[0]["instanceValues"])["sviEnabled"], "false")
+
+    def test_dcnm_net_svi_enabled_replaced_omitted_when_have_has_no_instance_values(self):
+        """Replaced + omitted must reset to default true even when NDFC returned no instanceValues."""
+        dcnm_net = self._make_bare_dcnm_net()
+        have_attach = self._svi_have_no_instance_values()
+        want_attach = self._svi_want(svi_supplied=False, want_svi="true")
+
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach), replace=True)
+
+        self.assertEqual(len(diff), 1)
+        self.assertTrue(dep_net)
+        self.assertEqual(json.loads(diff[0]["instanceValues"])["sviEnabled"], "true")
+
+    def test_dcnm_net_svi_enabled_replaced_explicit_false_when_have_has_no_instance_values(self):
+        """Replaced + explicit false must apply even when NDFC returned no instanceValues."""
+        dcnm_net = self._make_bare_dcnm_net()
+        have_attach = self._svi_have_no_instance_values()
+        want_attach = self._svi_want(svi_supplied=True, want_svi="false")
+
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach), replace=True)
+
+        self.assertEqual(len(diff), 1)
+        self.assertTrue(dep_net)
+        self.assertEqual(json.loads(diff[0]["instanceValues"])["sviEnabled"], "false")
+
+    def test_dcnm_net_svi_enabled_merged_omitted_when_have_has_no_instance_values_no_spurious_diff(self):
+        """Merged + omitted must not produce a spurious diff when NDFC returned no
+        instanceValues. Regression lock against future removal of the svi_supplied gate."""
+        dcnm_net = self._make_bare_dcnm_net()
+        have_attach = self._svi_have_no_instance_values()
+        want_attach = self._svi_want(svi_supplied=False, want_svi="true")
+
+        diff, dep_net = dcnm_net.diff_for_attach_deploy(want_attach, copy.deepcopy(have_attach))
+
+        self.assertFalse(diff)
+        self.assertFalse(dep_net)
+
+    def test_dcnm_net_update_attach_params_omitted_svi_sets_supplied_flag_false(self):
+        """Omitted svi_enabled must mark _svi_supplied=False while still defaulting the payload to true."""
+        dcnm_net = self._make_bare_dcnm_net()
+        with patch.object(dcnm_network, "dcnm_get_ip_addr_info", lambda module, ip, a, b: ip):
+            attach = {"ip_address": "10.10.10.217", "ports": ["Ethernet1/3"]}
+            out = dcnm_net.update_attach_params(attach, "Test_Network1", deploy=True)
+
+        self.assertNotIn("svi_enabled", out)
+        self.assertEqual(out.get("_svi_supplied"), False)
+        self.assertEqual(json.loads(out["instanceValues"])["sviEnabled"], "true")
+
+    def test_dcnm_net_update_attach_params_explicit_svi_sets_supplied_flag_true(self):
+        """Explicit svi_enabled must mark _svi_supplied=True."""
+        dcnm_net = self._make_bare_dcnm_net()
+        with patch.object(dcnm_network, "dcnm_get_ip_addr_info", lambda module, ip, a, b: ip):
+            attach_true = {"ip_address": "10.10.10.217", "ports": ["Ethernet1/3"], "svi_enabled": True}
+            out_true = dcnm_net.update_attach_params(attach_true, "Test_Network1", deploy=True)
+        self.assertNotIn("svi_enabled", out_true)
+        self.assertEqual(out_true.get("_svi_supplied"), True)
+        self.assertEqual(json.loads(out_true["instanceValues"])["sviEnabled"], "true")
+
+        dcnm_net = self._make_bare_dcnm_net()
+        with patch.object(dcnm_network, "dcnm_get_ip_addr_info", lambda module, ip, a, b: ip):
+            attach_false = {"ip_address": "10.10.10.217", "ports": ["Ethernet1/3"], "svi_enabled": False}
+            out_false = dcnm_net.update_attach_params(attach_false, "Test_Network1", deploy=True)
+        self.assertNotIn("svi_enabled", out_false)
+        self.assertEqual(out_false.get("_svi_supplied"), True)
+        self.assertEqual(json.loads(out_false["instanceValues"])["sviEnabled"], "false")
+
+    def test_dcnm_net_update_attach_params_pre_12_4_omitted_svi_no_leak(self):
+        """Pre-12.4 + omitted svi_enabled: neither the Ansible key nor any sviEnabled
+        translation appears in the outgoing attach dict."""
+        dcnm_net = self._make_bare_dcnm_net()
+        dcnm_net.dcnm_version = 12.3
+        with patch.object(dcnm_network, "dcnm_get_ip_addr_info", lambda module, ip, a, b: ip):
+            attach = {"ip_address": "10.10.10.217", "ports": ["Ethernet1/3"]}
+            out = dcnm_net.update_attach_params(attach, "Test_Network1", deploy=True)
+
+        self.assertNotIn("svi_enabled", out)
+        self.assertNotIn("_svi_supplied", out)
+        self.assertEqual(out["instanceValues"], "")
+
+    def test_dcnm_net_update_attach_params_pre_12_4_explicit_true_fails(self):
+        """Pre-12.4 + explicit svi_enabled: True must raise an actionable compatibility error."""
+        dcnm_net = self._make_bare_dcnm_net()
+        dcnm_net.dcnm_version = 12.3
+        with patch.object(dcnm_network, "dcnm_get_ip_addr_info", lambda module, ip, a, b: ip):
+            attach = {"ip_address": "10.10.10.217", "ports": ["Ethernet1/3"], "svi_enabled": True}
+            with self.assertRaises(AssertionError) as ctx:
+                dcnm_net.update_attach_params(attach, "Test_Network1", deploy=True)
+
+        self.assertIn("svi_enabled is only supported on NDFC 12.4+", str(ctx.exception))
+        self.assertIn("12.3", str(ctx.exception))
+
+    def test_dcnm_net_update_attach_params_pre_12_4_explicit_false_fails(self):
+        """Pre-12.4 + explicit svi_enabled: False must raise the same compatibility error."""
+        dcnm_net = self._make_bare_dcnm_net()
+        dcnm_net.dcnm_version = 12.3
+        with patch.object(dcnm_network, "dcnm_get_ip_addr_info", lambda module, ip, a, b: ip):
+            attach = {"ip_address": "10.10.10.217", "ports": ["Ethernet1/3"], "svi_enabled": False}
+            with self.assertRaises(AssertionError) as ctx:
+                dcnm_net.update_attach_params(attach, "Test_Network1", deploy=True)
+
+        self.assertIn("svi_enabled is only supported on NDFC 12.4+", str(ctx.exception))
+
+    def test_dcnm_net_update_attach_params_12_4_translates_svi_and_strips_input_key(self):
+        """12.4+ path: the Ansible svi_enabled key is stripped and its value translated
+        into instanceValues.sviEnabled with lowercase-string booleans."""
+        dcnm_net = self._make_bare_dcnm_net()
+        with patch.object(dcnm_network, "dcnm_get_ip_addr_info", lambda module, ip, a, b: ip):
+            attach = {"ip_address": "10.10.10.217", "ports": ["Ethernet1/3"], "svi_enabled": True}
+            out = dcnm_net.update_attach_params(attach, "Test_Network1", deploy=True)
+
+        self.assertNotIn("svi_enabled", out)
+        self.assertIn("instanceValues", out)
+        inst = json.loads(out["instanceValues"])
+        self.assertEqual(inst["sviEnabled"], "true")
+
+    def test_dcnm_net_push_to_remote_no_svi_enabled_or_flag_in_payload(self):
+        """The push_to_remote payload-prep loop guarantees neither the Ansible
+        svi_enabled key nor the internal _svi_supplied flag leaves the module
+        for any lanAttachList entry regardless of version path."""
+        diff_attach = [
+            {
+                "networkName": "Test_Network1",
+                "lanAttachList": [
+                    {"serialNumber": "SN_A", "_svi_supplied": True, "svi_enabled": True, "is_deploy": True},
+                    {"serialNumber": "SN_B", "_svi_supplied": False, "is_deploy": False},
+                    {"serialNumber": "SN_C"},
+                ],
+            }
+        ]
+        for d_a in diff_attach:
+            for v_a in d_a["lanAttachList"]:
+                if v_a.get("is_deploy"):
+                    del v_a["is_deploy"]
+                v_a.pop("_svi_supplied", None)
+                v_a.pop("svi_enabled", None)
+
+        for v_a in diff_attach[0]["lanAttachList"]:
+            self.assertNotIn("_svi_supplied", v_a)
+            self.assertNotIn("svi_enabled", v_a)
+
+    def test_dcnm_net_push_to_remote_svi_supplied_flag_stripped(self):
+        """The _svi_supplied internal flag is stripped from every lanAttachList
+        entry by the push_to_remote payload-prep loop before serialization."""
+        diff_attach = [
+            {
+                "networkName": "Test_Network1",
+                "lanAttachList": [
+                    {"serialNumber": "SN_A", "_svi_supplied": True, "is_deploy": True},
+                    {"serialNumber": "SN_B", "_svi_supplied": False},
+                ],
+            }
+        ]
+        for d_a in diff_attach:
+            for v_a in d_a["lanAttachList"]:
+                if v_a.get("is_deploy"):
+                    del v_a["is_deploy"]
+                v_a.pop("_svi_supplied", None)
+
+        for v_a in diff_attach[0]["lanAttachList"]:
+            self.assertNotIn("_svi_supplied", v_a)
+
+    def _make_format_diff_dcnm_net(self):
+        dcnm_net = self._make_bare_dcnm_net()
+        dcnm_net.diff_create = []
+        dcnm_net.diff_create_quick = []
+        dcnm_net.diff_create_update = []
+        dcnm_net.diff_detach = []
+        dcnm_net.diff_deploy = {}
+        dcnm_net.diff_undeploy = {}
+        return dcnm_net
+
+    def _format_diff_attach_payload(self, instance_values, switch_ports="Ethernet1/1"):
+        return [{
+            "networkName": "Test_Network1",
+            "lanAttachList": [{
+                "serialNumber": "9NN7E41N16A",
+                "switchPorts": switch_ports,
+                "deployment": True,
+                "detachSwitchPorts": "",
+                "instanceValues": instance_values,
+            }],
+        }]
+
+    def test_dcnm_net_format_diff_emits_svi_enabled_false_from_instance_values(self):
+        """format_diff must emit svi_enabled: False when the outgoing instanceValues carries sviEnabled=false."""
+        dcnm_net = self._make_format_diff_dcnm_net()
+        dcnm_net.diff_attach = self._format_diff_attach_payload(
+            json.dumps({"isVPC": "false", "sviEnabled": "false", "isActive": "false"})
+        )
+
+        dcnm_net.format_diff()
+
+        attach = dcnm_net.diff_input_format[0]["attach"][0]
+        self.assertIn("svi_enabled", attach)
+        self.assertEqual(attach["svi_enabled"], False)
+
+    def test_dcnm_net_format_diff_emits_svi_enabled_true_from_instance_values(self):
+        """format_diff must emit svi_enabled: True when the outgoing instanceValues carries sviEnabled=true."""
+        dcnm_net = self._make_format_diff_dcnm_net()
+        dcnm_net.diff_attach = self._format_diff_attach_payload(
+            json.dumps({"sviEnabled": "true"})
+        )
+
+        dcnm_net.format_diff()
+
+        attach = dcnm_net.diff_input_format[0]["attach"][0]
+        self.assertIn("svi_enabled", attach)
+        self.assertEqual(attach["svi_enabled"], True)
+
+    def test_dcnm_net_format_diff_omits_svi_enabled_when_not_in_instance_values(self):
+        """format_diff must not emit svi_enabled when the outgoing instanceValues has other keys but no sviEnabled."""
+        dcnm_net = self._make_format_diff_dcnm_net()
+        dcnm_net.diff_attach = self._format_diff_attach_payload(
+            json.dumps({"isVPC": "false", "isActive": "false"})
+        )
+
+        dcnm_net.format_diff()
+
+        attach = dcnm_net.diff_input_format[0]["attach"][0]
+        self.assertNotIn("svi_enabled", attach)
+
+    def test_dcnm_net_format_diff_omits_svi_enabled_when_instance_values_empty(self):
+        """format_diff must not emit svi_enabled when instanceValues is empty (pre-12.4 path)."""
+        dcnm_net = self._make_format_diff_dcnm_net()
+        dcnm_net.diff_attach = self._format_diff_attach_payload("")
+
+        dcnm_net.format_diff()
+
+        attach = dcnm_net.diff_input_format[0]["attach"][0]
+        self.assertNotIn("svi_enabled", attach)
+
+    def test_dcnm_net_format_diff_combined_port_and_svi_diff_shows_both(self):
+        """format_diff must expose both ports and svi_enabled when both participated in the change."""
+        dcnm_net = self._make_format_diff_dcnm_net()
+        dcnm_net.diff_attach = self._format_diff_attach_payload(
+            json.dumps({"sviEnabled": "false"}),
+            switch_ports="Ethernet1/1,Ethernet1/2",
+        )
+
+        dcnm_net.format_diff()
+
+        attach = dcnm_net.diff_input_format[0]["attach"][0]
+        self.assertEqual(attach["ports"], "Ethernet1/1,Ethernet1/2")
+        self.assertIn("svi_enabled", attach)
+        self.assertEqual(attach["svi_enabled"], False)
 
     def test_dcnm_net_diff_for_attach_deploy_port_add_merged_empty_freeform(self):
         """Merged: adding a port on an attach with empty freeform on both sides must produce a diff."""


### PR DESCRIPTION
Current PRs for this features generate conflicts, consolidating the 3 features in one PR:
- [Adding support for vlan_id override at network attachment level](https://github.com/CiscoDevNet/ansible-dcnm/pull/687)
- [Adding support for freeform config at network attachment level](https://github.com/CiscoDevNet/ansible-dcnm/pull/689)
- [Adding support for svi enabled at network attachment level (supported on >= 4.1)](https://github.com/CiscoDevNet/ansible-dcnm/pull/700)



Fixes #686, #689 and #700 