### PR TITLE
Fix post-merge FEC and XConnect review findings

### DIFF
--- a/plugins/action/dcnm_network.py
+++ b/plugins/action/dcnm_network.py
@@ -116,6 +116,7 @@ class ActionModule(ActionBase):
         self.logger.info("NDFC Network Action Plugin initialized")
         # Default NDFC version
         self.ndfc_version = 12.2
+        self.ndfc_full_version = None
 
     def run(self, tmp=None, task_vars=None):
         """
@@ -165,8 +166,25 @@ class ActionModule(ActionBase):
             return result
 
         # Get ND version for API path selection (similar to dcnm_vrf)
-        self.ndfc_version = get_nd_version(self, task_vars, tmp)
-        display.vvv(f"ND version: {self.ndfc_version}")
+        version_info = get_nd_version(
+            self, task_vars, tmp, return_full_version=True
+        )
+        if isinstance(version_info, dict) and version_info.get("failed"):
+            return version_info
+
+        if isinstance(version_info, tuple):
+            self.ndfc_version, self.ndfc_full_version = version_info
+        else:
+            # Keep compatibility with tests or external mocks that return only
+            # the historical major/minor value.
+            self.ndfc_version = version_info
+            self.ndfc_full_version = None
+
+        display.vvv(
+            "ND version: {0} (full: {1})".format(
+                self.ndfc_version, self.ndfc_full_version
+            )
+        )
 
         if self.ndfc_version is None:
             result['failed'] = True
@@ -365,7 +383,15 @@ class ActionModule(ActionBase):
         display.vvv("=" * 80)
 
         # Validate fabric hierarchy before processing
-        configs, error_msg = self._split_config(fabrics, fabric_name, config, state, result, self.ndfc_version)
+        configs, error_msg = self._split_config(
+            fabrics,
+            fabric_name,
+            config,
+            state,
+            result,
+            self.ndfc_version,
+            self.ndfc_full_version,
+        )
 
         if configs is None:
             result['failed'] = True
@@ -417,7 +443,16 @@ class ActionModule(ActionBase):
             'cluster_name': fabric_info.get('cluster_name', '')
         }
 
-    def _split_config(self, fabrics, fabric_name, config, state, result, ndfc_version):
+    def _split_config(
+        self,
+        fabrics,
+        fabric_name,
+        config,
+        state,
+        result,
+        ndfc_version,
+        ndfc_full_version=None,
+    ):
         """
         Validate MSD fabric hierarchy and split network configurations for parent/child processing.
 
@@ -459,7 +494,9 @@ class ActionModule(ActionBase):
                     'fabric': fabric_name,
                     '_fabric_details': {
                         'fabric_type': 'multisite_parent'|'multisite_child'|'standalone'|'unknown',
-                        'cluster_name': 'cluster_name' or ''
+                        'cluster_name': 'cluster_name' or '',
+                        'nd_version': 12.4,
+                        'ndfc_version': '12.4.1.321'
                     },
                     'state': state,  # For parent: original state; For child: 'replaced' if parent state is 'overridden', otherwise original state
                     'config': [network_configs...]  # deploy defaults to True, child always inherits from parent
@@ -592,6 +629,7 @@ class ActionModule(ActionBase):
         parent_fabric_details = self._get_fabric_details(fabric_name, fabrics)
         # Add nd_version to fabric_details for module consumption (similar to dcnm_vrf)
         parent_fabric_details['nd_version'] = ndfc_version
+        parent_fabric_details['ndfc_version'] = ndfc_full_version
         parent_fabric_config = {
             'fabric': fabric_name,
             '_fabric_details': parent_fabric_details,
@@ -609,6 +647,7 @@ class ActionModule(ActionBase):
             child_fabric_details = self._get_fabric_details(child_fabric_name, fabrics)
             # Add nd_version to child fabric_details for module consumption (similar to dcnm_vrf)
             child_fabric_details['nd_version'] = ndfc_version
+            child_fabric_details['ndfc_version'] = ndfc_full_version
 
             # Determine child fabric state: if parent state is 'overridden', child state should be 'replaced'
             # Child state should never be 'overridden'

--- a/plugins/module_utils/network/dcnm/dcnm.py
+++ b/plugins/module_utils/network/dcnm/dcnm.py
@@ -649,20 +649,23 @@ def dcnm_reset_connection(module):
     return conn.login(conn.get_option("remote_user"), conn.get_option("password"))
 
 
-def dcnm_version_supported(module):
+def dcnm_version_supported(module, return_full_version=False):
     """
-    Query DCNM/NDFC and return the major software version
+    Query DCNM/NDFC and return the software version.
 
     Parameters:
         module: String representing the module
+        return_full_version: Return ``(major_version, full_version)`` when True
 
     Returns:
-        int: Major software version for DCNM/NDFC
+        int or tuple: Major software version, optionally with the full version
     """
 
     method = "GET"
     supported = None
+    full_version = None
     data = None
+    responses = []
 
     paths = [
         "/fm/fmrest/about/version",
@@ -670,32 +673,45 @@ def dcnm_version_supported(module):
     ]
     for path in paths:
         response = dcnm_send(module, method, path)
-        if response["RETURN_CODE"] == 200:
-            data = response.get("DATA")
-            break
+        responses.append({path: response})
+        if not isinstance(response, dict):
+            continue
+        if response.get("RETURN_CODE") != 200:
+            continue
 
-    if data:
+        candidate = response.get("DATA")
+        if not isinstance(candidate, dict) or not candidate.get("version"):
+            continue
+
+        data = candidate
+        break
+
+    if isinstance(data, dict):
         # Parse version information
         # Examples:
         #   11.5(1), 12.0.1a'
         # For these examples 11 or 12 would be returned
-        raw_version = data["version"]
+        raw_version = data.get("version")
 
         if raw_version == "DEVEL":
             raw_version = "11.5(1)"
 
-        regex = r"^(\d+)\.\d+"
-        mo = re.search(regex, raw_version)
-        if mo:
-            supported = int(mo.group(1))
+        if isinstance(raw_version, str):
+            version_parts = re.findall(r"\d+", raw_version)
+            if len(version_parts) >= 2:
+                supported = int(version_parts[0])
+                full_version = ".".join(version_parts)
 
     if supported is None:
         msg = (
             "Unable to determine the DCNM/NDFC Software Version, "
-            + "RESP = "
-            + str(response)
+            + "RESPONSES = "
+            + str(responses)
         )
         module.fail_json(msg=msg)
+
+    if return_full_version:
+        return supported, full_version
 
     return supported
 
@@ -1324,20 +1340,32 @@ def sanitize_lan_attach_list(attach_objects: list) -> list:
 # Action plugin utilities
 
 
-def get_nd_version(action_module, task_vars, tmp):
+def get_nd_version(
+    action_module, task_vars, tmp, return_full_version=False
+):
     """
-    Query NDFC and return the exact software version
+    Query NDFC and return its software version.
 
     Parameters:
-        module: String representing the module
+        action_module: Action plugin instance used to execute dcnm_rest.
+        task_vars: Ansible task variables.
+        tmp: Action plugin temporary directory.
+        return_full_version: Return both the historical major/minor value and
+            the normalized full version when True.
 
     Returns:
-        float: Major software version for NDFC
+        float: Major/minor software version used for API path selection.
+        tuple: (major/minor version, normalized full version) when
+            return_full_version is True.
+        dict: Structured action-plugin failure when the version cannot be
+            retrieved or parsed.
     """
 
     method = "GET"
     supported = None
     data = None
+    full_version = None
+    errors = []
 
     paths = [
         "/fm/fmrest/about/version",
@@ -1353,15 +1381,37 @@ def get_nd_version(action_module, task_vars, tmp):
             task_vars=task_vars,
             tmp=tmp
         )
-        if not response.get("failed"):
-            # Extract response data section
-            resp = response.get("response")
-            if isinstance(resp, dict):
-                return_code = resp.get("RETURN_CODE")
-                if return_code == 200:
-                    data = resp.get("DATA")
-                    break
-    if data:
+        if not isinstance(response, dict):
+            errors.append(f"{path}: invalid response {response!r}")
+            continue
+        if response.get("failed"):
+            errors.append(
+                f"{path}: {response.get('msg', 'request failed')}"
+            )
+            continue
+
+        resp = response.get("response")
+        if not isinstance(resp, dict):
+            errors.append(f"{path}: invalid response payload {resp!r}")
+            continue
+
+        return_code = resp.get("RETURN_CODE")
+        if return_code != 200:
+            detail = resp.get("MESSAGE") or resp.get("DATA") or "request failed"
+            errors.append(f"{path}: HTTP {return_code}: {detail}")
+            continue
+
+        candidate = resp.get("DATA")
+        if not isinstance(candidate, dict) or not candidate.get("version"):
+            errors.append(
+                f"{path}: successful response did not contain DATA.version"
+            )
+            continue
+
+        data = candidate
+        break
+
+    if data is not None:
         # Parse version information
         # Examples:
         #   11.5(1), 12.0.1a, 12.4.1.321
@@ -1371,19 +1421,27 @@ def get_nd_version(action_module, task_vars, tmp):
         if raw_version == "DEVEL":
             raw_version = "11.5(1)"
 
-        # Capture major.minor version (first two digits with dot)
-        regex = r"^(\d+\.\d+)"
-        mo = re.search(regex, raw_version)
-        if mo:
-            supported = float(mo.group(1))
+        version_parts = re.findall(r"\d+", str(raw_version))
+        if len(version_parts) >= 2:
+            supported = float(".".join(version_parts[:2]))
+            full_version = ".".join(version_parts)
+        else:
+            errors.append(
+                f"controller returned malformed version {raw_version!r}"
+            )
 
-        if supported >= 11.0 and supported < 12.0:
+        if supported is not None and 11.0 <= supported < 12.0:
             # For versions 11.x, return only 11.0
             supported = 11.0
 
     if supported is None:
         error_msg = "Failed to retrieve NDFC version from API responses."
+        if errors:
+            error_msg += " " + "; ".join(errors)
         return action_module.error_handler.handle_failure(error_msg)
+
+    if return_full_version:
+        return supported, full_version
 
     return supported
 

--- a/plugins/modules/dcnm_interface.py
+++ b/plugins/modules/dcnm_interface.py
@@ -1895,11 +1895,6 @@ from ansible_collections.cisco.dcnm.plugins.module_utils.network.dcnm.dcnm impor
     find_dict_in_list_by_key_value,
 )
 from ..module_utils.common.log_v2 import Log
-from ..module_utils.common.controller_version_v2 import ControllerVersion
-from ..module_utils.common.rest_send_v2 import RestSend
-from ..module_utils.common.response_handler import ResponseHandler
-from ..module_utils.common.sender_dcnm import Sender
-from ..module_utils.common.exceptions import ControllerResponseError
 
 
 def json_pretty(msg):
@@ -2020,8 +2015,16 @@ class DcnmIntf:
             }
         ]
 
-        self.dcnm_version = dcnm_version_supported(self.module)
-        self.ndfc_version = self._get_ndfc_version()
+        version_info = dcnm_version_supported(
+            self.module, return_full_version=True
+        )
+        if isinstance(version_info, tuple):
+            self.dcnm_version, self.ndfc_version = version_info
+        else:
+            # Preserve compatibility with tests and external mocks that still
+            # return only the historical major-version integer.
+            self.dcnm_version = version_info
+            self.ndfc_version = None
 
         # Check for bulk API support
         self.has_bulk_api = dcnm_get_bulk_api_support(self.module)
@@ -2232,24 +2235,6 @@ class DcnmIntf:
 
         msg = "ENTERED DcnmIntf: "
         self.log.debug(msg)
-
-    def _get_ndfc_version(self):
-        """Return the full NDFC version string (e.g. '12.4.1.245') using ControllerVersion, or None on failure."""
-        try:
-            sender = Sender()
-            sender.ansible_module = self.module
-            rest_send = RestSend(self.module.params)
-            rest_send.response_handler = ResponseHandler()
-            rest_send.sender = sender
-            controller_version = ControllerVersion()
-            controller_version.rest_send = rest_send
-            controller_version.refresh()
-            raw_version = controller_version.version
-            if raw_version:
-                return re.sub(r'[a-zA-Z]+$', '', raw_version)
-        except (ControllerResponseError, ValueError, AssertionError, Exception):
-            pass
-        return None
 
     def _ndfc_version_gte(self, target):
         """Check if NDFC version >= target. Uses tuple comparison on version segments."""

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -39,7 +39,7 @@ options:
     description:
     - INTERNAL PARAMETER - DO NOT USE
     - Fabric details dictionary automatically provided by the action plugin
-    - Contains fabric_type, cluster_name, and nd_version information
+    - Contains fabric_type, cluster_name, nd_version, and ndfc_version information
     - This parameter is used internally by the action plugin for MSD/MFD fabric processing
     type: dict
     required: false
@@ -62,6 +62,12 @@ options:
         - Automatically provided by action plugin
         - Module will fail if this is not provided by action plugin
         type: float
+        required: false
+      ndfc_version:
+        description:
+        - Exact normalized NDFC version used for feature validation
+        - Automatically provided by action plugin
+        type: str
         required: false
   state:
     description:
@@ -321,9 +327,13 @@ options:
         required: false
       xconnect:
         description:
-        - Enable XConnect feature. Only available for ND version > 4.1.
+        - Enable XConnect for a Layer-2-only network.
+        - Supported only on standalone fabrics running ND 4.1/NDFC 12.4.1
+          or later.
+        - XConnect network attachments support dot1q ports only.
+        - In C(state=merged), omitting this option preserves the value
+          returned by the controller.
         type: bool
-        default: false
         required: false
       attach:
         description:
@@ -595,6 +605,22 @@ EXAMPLES = """
           - ip_address: 192.168.1.225
             ports: [Ethernet1/11, Ethernet1/12]
         deploy: false
+
+- name: Merge a standalone Layer-2 XConnect network with dot1q attachments
+  cisco.dcnm.dcnm_network:
+    fabric: vxlan-fabric
+    state: merged
+    config:
+      - net_name: ansible-xconnect-net
+        is_l2only: true
+        xconnect: true
+        vlan_id: 152
+        attach:
+          - ip_address: 192.168.1.224
+            ports: [Ethernet1/18]
+          - ip_address: 192.168.1.225
+            ports: [Ethernet1/18]
+        deploy: true
 
 # ---------------------------------------------------------------------------
 # STATE: REPLACED - Replace Network Configuration
@@ -1022,11 +1048,6 @@ from ansible_collections.cisco.dcnm.plugins.module_utils.network.dcnm.dcnm impor
     sanitize_lan_attach_list
 )
 from ..module_utils.common.log_v2 import Log
-from ..module_utils.common.controller_version_v2 import ControllerVersion
-from ..module_utils.common.rest_send_v2 import RestSend
-from ..module_utils.common.response_handler import ResponseHandler
-from ..module_utils.common.sender_dcnm import Sender
-from ..module_utils.common.exceptions import ControllerResponseError
 
 
 class DcnmNetwork:
@@ -1145,7 +1166,9 @@ class DcnmNetwork:
         msg = f"self.dcnm_version: {self.dcnm_version}"
         self.log.debug(msg)
 
-        self.ndfc_version = self._get_ndfc_version()
+        # Reuse the exact version obtained by the action plugin instead of
+        # issuing a second controller request from the module.
+        self.ndfc_version = self.fabric_details.get("ndfc_version")
 
         # Check for bulk API support
         self.has_bulk_api = dcnm_get_bulk_api_support(self.module)
@@ -2667,8 +2690,8 @@ class DcnmNetwork:
             t_conf.update(ENABLE_NETFLOW=json_to_dict.get("ENABLE_NETFLOW", False))
             t_conf.update(SVI_NETFLOW_MONITOR=json_to_dict.get("SVI_NETFLOW_MONITOR", ""))
             t_conf.update(VLAN_NETFLOW_MONITOR=json_to_dict.get("VLAN_NETFLOW_MONITOR", ""))
-        if self._ndfc_version_gte("12.4.1"):
-            t_conf.update(xconnect=json_to_dict.get("xconnect", False))
+        if "xconnect" in json_to_dict:
+            t_conf.update(xconnect=json_to_dict["xconnect"])
 
         if self.fabric_type not in ["multisite_child", "multicluster_child"]:
             t_conf["secondaryGWs"] = self.get_secondary_gws_template_config(t_conf)
@@ -3973,8 +3996,8 @@ class DcnmNetwork:
                 found_c.update({"netflow_enable": json_to_dict.get("ENABLE_NETFLOW", False)})
                 found_c.update({"intfvlan_nf_monitor": json_to_dict.get("SVI_NETFLOW_MONITOR", "")})
                 found_c.update({"vlan_nf_monitor": json_to_dict.get("VLAN_NETFLOW_MONITOR", "")})
-            if self._ndfc_version_gte("12.4.1"):
-                found_c.update({"xconnect": json_to_dict.get("xconnect", False)})
+            if "xconnect" in json_to_dict:
+                found_c.update({"xconnect": json_to_dict["xconnect"]})
             found_c.update({"attach": []})
 
             del found_c["fabric"]
@@ -5061,8 +5084,8 @@ class DcnmNetwork:
                     t_conf.update(ENABLE_NETFLOW=json_to_dict.get("ENABLE_NETFLOW", False))
                     t_conf.update(SVI_NETFLOW_MONITOR=json_to_dict.get("SVI_NETFLOW_MONITOR", ""))
                     t_conf.update(VLAN_NETFLOW_MONITOR=json_to_dict.get("VLAN_NETFLOW_MONITOR", ""))
-                if self._ndfc_version_gte("12.4.1"):
-                    t_conf.update(xconnect=json_to_dict.get("xconnect", False))
+                if "xconnect" in json_to_dict:
+                    t_conf.update(xconnect=json_to_dict["xconnect"])
 
                 if self.fabric_type not in ["multisite_child", "multicluster_child"]:
                     t_conf["secondaryGWs"] = self.get_secondary_gws_template_config(t_conf)
@@ -5261,24 +5284,6 @@ class DcnmNetwork:
                          if attr not in ["net_name", "deploy", "vlan_id", "vrf_name", "is_l2only"]]
 
         return skipped_attrs
-
-    def _get_ndfc_version(self):
-        """Return the full NDFC version string (e.g. '12.4.1.245') using ControllerVersion, or None on failure."""
-        try:
-            sender = Sender()
-            sender.ansible_module = self.module
-            rest_send = RestSend(self.module.params)
-            rest_send.response_handler = ResponseHandler()
-            rest_send.sender = sender
-            controller_version = ControllerVersion()
-            controller_version.rest_send = rest_send
-            controller_version.refresh()
-            raw_version = controller_version.version
-            if raw_version:
-                return re.sub(r'[a-zA-Z]+$', '', raw_version)
-        except (ControllerResponseError, ValueError, AssertionError, Exception):
-            pass
-        return None
 
     def _ndfc_version_gte(self, target):
         """Check if NDFC version >= target. Uses tuple comparison on version segments."""
@@ -5993,9 +5998,14 @@ class DcnmNetwork:
         if self.dcnm_version > 11 and cfg.get("intfvlan_nf_monitor", None) is None:
             json_to_dict_want["SVI_NETFLOW_MONITOR"] = json_to_dict_have["SVI_NETFLOW_MONITOR"]
 
-        # XConnect configuration (NDFC >= 12.4.1 only)
-        if self._ndfc_version_gte("12.4.1") and cfg.get("xconnect", None) is None:
-            json_to_dict_want["xconnect"] = json_to_dict_have.get("xconnect", False)
+        # Preserve controller-returned XConnect intent when it is omitted from
+        # a merged request. Read-side preservation must not depend on a version
+        # lookup succeeding.
+        if (
+            cfg.get("xconnect", None) is None
+            and "xconnect" in json_to_dict_have
+        ):
+            json_to_dict_want["xconnect"] = json_to_dict_have["xconnect"]
             if str(json_to_dict_want["xconnect"]).lower() == "true":
                 json_to_dict_want["xconnect"] = True
             else:
@@ -6076,7 +6086,8 @@ def main():
                     choices=["multicluster_parent", "multicluster_child", "multisite_parent", "multisite_child", "standalone"]
                 ),
                 cluster_name=dict(required=False, type="str", default=""),
-                nd_version=dict(required=False, type="float")
+                nd_version=dict(required=False, type="float"),
+                ndfc_version=dict(required=False, type="str")
             )
         ),
         config=dict(required=False, type="list", elements="dict"),

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -5443,7 +5443,7 @@ class DcnmNetwork:
                 intfvlan_nf_monitor=dict(type="str"),
                 vlan_nf_monitor=dict(type="str"),
             )
-            net_spec["xconnect"] = dict(type="bool")
+            net_spec["xconnect"] = dict(type="bool", default=False)
             # Adjust deploy field for query state
             if is_query_state:
                 net_spec["deploy"] = dict(type="bool")

--- a/plugins/modules/dcnm_network.py
+++ b/plugins/modules/dcnm_network.py
@@ -2588,7 +2588,10 @@ class DcnmNetwork:
             template_conf.update(SVI_NETFLOW_MONITOR=net.get("intfvlan_nf_monitor", ""))
             template_conf.update(VLAN_NETFLOW_MONITOR=net.get("vlan_nf_monitor", ""))
         if self._ndfc_version_gte("12.4.1"):
-            template_conf.update(xconnect=net.get("xconnect", False))
+            xconnect = net.get("xconnect")
+            template_conf.update(
+                xconnect=False if xconnect is None else xconnect
+            )
 
         if template_conf["vlanId"] is None:
             template_conf["vlanId"] = ""
@@ -5443,7 +5446,7 @@ class DcnmNetwork:
                 intfvlan_nf_monitor=dict(type="str"),
                 vlan_nf_monitor=dict(type="str"),
             )
-            net_spec["xconnect"] = dict(type="bool", default=False)
+            net_spec["xconnect"] = dict(type="bool")
             # Adjust deploy field for query state
             if is_query_state:
                 net_spec["deploy"] = dict(type="bool")

--- a/tests/unit/module_utils/common/test_dcnm_version_supported.py
+++ b/tests/unit/module_utils/common/test_dcnm_version_supported.py
@@ -1,0 +1,238 @@
+# Copyright (c) 2026 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from ansible_collections.cisco.dcnm.plugins.module_utils.network.dcnm import (
+    dcnm,
+)
+
+
+def version_response(version):
+    return {
+        "RETURN_CODE": 200,
+        "DATA": {
+            "version": version,
+        },
+    }
+
+
+def action_version_response(version):
+    return {
+        "failed": False,
+        "response": version_response(version),
+    }
+
+
+def test_dcnm_version_supported_returns_major_by_default():
+    module = Mock()
+
+    with patch.object(
+        dcnm,
+        "dcnm_send",
+        return_value=version_response("12.4.1.245"),
+    ) as dcnm_send:
+        assert dcnm.dcnm_version_supported(module) == 12
+
+    dcnm_send.assert_called_once()
+
+
+def test_dcnm_version_supported_reuses_response_for_full_version():
+    module = Mock()
+
+    with patch.object(
+        dcnm,
+        "dcnm_send",
+        return_value=version_response("12.4.1.245"),
+    ) as dcnm_send:
+        assert dcnm.dcnm_version_supported(
+            module, return_full_version=True
+        ) == (12, "12.4.1.245")
+
+    dcnm_send.assert_called_once()
+
+
+def test_dcnm_version_supported_normalizes_alpha_suffix():
+    module = Mock()
+
+    with patch.object(
+        dcnm,
+        "dcnm_send",
+        return_value=version_response("12.1.2e"),
+    ):
+        assert dcnm.dcnm_version_supported(
+            module, return_full_version=True
+        ) == (12, "12.1.2")
+
+
+def test_dcnm_version_supported_normalizes_parenthesized_version():
+    module = Mock()
+
+    with patch.object(
+        dcnm,
+        "dcnm_send",
+        return_value=version_response("11.5(1)"),
+    ):
+        assert dcnm.dcnm_version_supported(
+            module, return_full_version=True
+        ) == (11, "11.5.1")
+
+
+def test_dcnm_version_supported_reports_malformed_response():
+    module = Mock()
+    module.fail_json.side_effect = RuntimeError("fail_json")
+    response = {
+        "RETURN_CODE": 200,
+        "DATA": {
+            "unexpected": "value",
+        },
+    }
+
+    with patch.object(dcnm, "dcnm_send", return_value=response):
+        with pytest.raises(RuntimeError, match="fail_json"):
+            dcnm.dcnm_version_supported(
+                module, return_full_version=True
+            )
+
+    message = module.fail_json.call_args.kwargs["msg"]
+    assert "Unable to determine the DCNM/NDFC Software Version" in message
+    assert str(response) in message
+
+
+def test_dcnm_version_supported_reports_failed_http_responses():
+    module = Mock()
+    module.fail_json.side_effect = RuntimeError("fail_json")
+    responses = [
+        {
+            "RETURN_CODE": 401,
+            "MESSAGE": "Unauthorized",
+        },
+        {
+            "RETURN_CODE": 503,
+            "MESSAGE": "Service unavailable",
+        },
+    ]
+
+    with patch.object(dcnm, "dcnm_send", side_effect=responses):
+        with pytest.raises(RuntimeError, match="fail_json"):
+            dcnm.dcnm_version_supported(
+                module, return_full_version=True
+            )
+
+    message = module.fail_json.call_args.kwargs["msg"]
+    assert "Unauthorized" in message
+    assert "Service unavailable" in message
+
+
+def test_dcnm_version_supported_reports_non_mapping_responses():
+    module = Mock()
+    module.fail_json.side_effect = RuntimeError("fail_json")
+
+    with patch.object(dcnm, "dcnm_send", side_effect=[None, []]):
+        with pytest.raises(RuntimeError, match="fail_json"):
+            dcnm.dcnm_version_supported(
+                module, return_full_version=True
+            )
+
+    message = module.fail_json.call_args.kwargs["msg"]
+    assert "None" in message
+    assert "[]" in message
+
+
+def test_get_nd_version_returns_major_minor_and_full_version():
+    action = Mock()
+    action._execute_module.return_value = action_version_response(
+        "12.4.1.245"
+    )
+
+    assert dcnm.get_nd_version(
+        action, {}, None, return_full_version=True
+    ) == (12.4, "12.4.1.245")
+
+    action._execute_module.assert_called_once()
+
+
+def test_get_nd_version_normalizes_full_version_from_fallback_endpoint():
+    action = Mock()
+    action._execute_module.side_effect = [
+        {
+            "failed": False,
+            "response": {
+                "RETURN_CODE": 503,
+                "MESSAGE": "Service unavailable",
+            },
+        },
+        action_version_response("12.4.1a"),
+    ]
+
+    assert dcnm.get_nd_version(
+        action, {}, None, return_full_version=True
+    ) == (12.4, "12.4.1")
+
+    assert action._execute_module.call_count == 2
+
+
+def test_get_nd_version_preserves_actionable_lookup_failures():
+    action = Mock()
+    action._execute_module.side_effect = [
+        {
+            "failed": True,
+            "msg": "Authentication failed",
+        },
+        {
+            "failed": False,
+            "response": {
+                "RETURN_CODE": 503,
+                "MESSAGE": "Service unavailable",
+            },
+        },
+    ]
+    action.error_handler.handle_failure.side_effect = (
+        lambda msg: {"failed": True, "changed": False, "msg": msg}
+    )
+
+    result = dcnm.get_nd_version(
+        action, {}, None, return_full_version=True
+    )
+
+    assert result["failed"] is True
+    assert "Authentication failed" in result["msg"]
+    assert "HTTP 503: Service unavailable" in result["msg"]
+
+
+def test_get_nd_version_reports_malformed_success_responses():
+    action = Mock()
+    action._execute_module.side_effect = [
+        {
+            "failed": False,
+            "response": {
+                "RETURN_CODE": 200,
+                "DATA": {"unexpected": "value"},
+            },
+        },
+        action_version_response("not-a-version"),
+    ]
+    action.error_handler.handle_failure.side_effect = (
+        lambda msg: {"failed": True, "changed": False, "msg": msg}
+    )
+
+    result = dcnm.get_nd_version(
+        action, {}, None, return_full_version=True
+    )
+
+    assert result["failed"] is True
+    assert "did not contain DATA.version" in result["msg"]
+    assert "malformed version 'not-a-version'" in result["msg"]

--- a/tests/unit/modules/dcnm/test_dcnm_intf.py
+++ b/tests/unit/modules/dcnm/test_dcnm_intf.py
@@ -321,6 +321,7 @@ class TestDcnmIntfModule(TestDcnmModule):
     def test_dcnm_intf_leaf_default_payload_clears_storm_control(self):
         dcnm_intf = object.__new__(dcnm_interface.DcnmIntf)
         dcnm_intf.dcnm_version = 12
+        dcnm_intf.ndfc_version = "12.4.1.245"
         dcnm_intf.pol_types = {
             12: {
                 "eth_trunk": "int_trunk_host",
@@ -354,9 +355,13 @@ class TestDcnmIntfModule(TestDcnmModule):
         for key in expected:
             self.assertNotIn(key, routed_nv_pairs)
 
+        self.assertEqual(leaf_nv_pairs["FEC"], "auto")
+        self.assertEqual(routed_nv_pairs["FEC"], "auto")
+
     def test_dcnm_intf_default_compare_detects_storm_only_drift(self):
         dcnm_intf = object.__new__(dcnm_interface.DcnmIntf)
         dcnm_intf.dcnm_version = 12
+        dcnm_intf.ndfc_version = "12.4.1.245"
         dcnm_intf.pol_types = {
             12: {
                 "eth_trunk": "int_trunk_host",
@@ -381,6 +386,62 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.assertEqual(
             dcnm_intf.dcnm_compare_default_payload(default_payload, have),
             "DCNM_INTF_NOT_MATCH",
+        )
+
+    def test_dcnm_intf_default_compare_detects_fec_only_drift(self):
+        dcnm_intf = object.__new__(dcnm_interface.DcnmIntf)
+        dcnm_intf.dcnm_version = 12
+        dcnm_intf.ndfc_version = "12.4.1.245"
+        dcnm_intf.pol_types = {
+            12: {
+                "eth_trunk": "int_trunk_host",
+                "eth_routed": "int_routed_host",
+            }
+        }
+        dcnm_intf.sno_to_switch_role = {
+            "LEAF_SERIAL": "leaf",
+            "SPINE_SERIAL": "spine",
+        }
+
+        for serial in ("LEAF_SERIAL", "SPINE_SERIAL"):
+            with self.subTest(serial=serial):
+                default_payload = dcnm_intf.dcnm_intf_get_default_eth_payload(
+                    "Ethernet1/50",
+                    serial,
+                    "test_fabric",
+                )
+                have = copy.deepcopy(default_payload)
+                have["interfaces"][0]["nvPairs"]["FEC"] = "rs-fec"
+
+                self.assertEqual(
+                    dcnm_intf.dcnm_compare_default_payload(
+                        default_payload, have
+                    ),
+                    "DCNM_INTF_NOT_MATCH",
+                )
+
+    def test_dcnm_intf_default_compare_treats_omitted_fec_as_auto(self):
+        dcnm_intf = object.__new__(dcnm_interface.DcnmIntf)
+        dcnm_intf.dcnm_version = 12
+        dcnm_intf.ndfc_version = "12.4.1.245"
+        dcnm_intf.pol_types = {
+            12: {
+                "eth_trunk": "int_trunk_host",
+                "eth_routed": "int_routed_host",
+            }
+        }
+        dcnm_intf.sno_to_switch_role = {"LEAF_SERIAL": "leaf"}
+        default_payload = dcnm_intf.dcnm_intf_get_default_eth_payload(
+            "Ethernet1/50",
+            "LEAF_SERIAL",
+            "test_fabric",
+        )
+        have = copy.deepcopy(default_payload)
+        have["interfaces"][0]["nvPairs"].pop("FEC")
+
+        self.assertEqual(
+            dcnm_intf.dcnm_compare_default_payload(default_payload, have),
+            "DCNM_INTF_MATCH",
         )
 
     def test_dcnm_intf_default_compare_normalizes_omitted_storm_defaults(self):
@@ -688,6 +749,35 @@ class TestDcnmIntfModule(TestDcnmModule):
             },
         }
 
+    def _build_eth_trunk_delem(self, fec):
+        return {
+            "name": "eth1/4",
+            "type": "eth",
+            "switch": ["10.1.1.1"],
+            "deploy": True,
+            "profile": {
+                "mode": "trunk",
+                "bpdu_guard": "true",
+                "port_type_fast": True,
+                "mtu": "jumbo",
+                "speed": "Auto",
+                "allowed_vlans": "all",
+                "native_vlan": "",
+                "orphan_port": False,
+                "cmds": None,
+                "description": "test",
+                "admin_state": True,
+                "enable_cdp": True,
+                "enable_pfc": False,
+                "enable_monitor": False,
+                "duplex": "auto",
+                "enable_qos": False,
+                "qos_policy": "",
+                "queuing_policy": "",
+                "fec": fec,
+            },
+        }
+
     def _build_vpc_delem(self, mode, enable_cdp):
         profile = {
             "mode": mode,
@@ -758,6 +848,54 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.assertEqual(
             intf["interfaces"][0]["nvPairs"]["CDP_ENABLE"], True
         )
+
+    def test_dcnm_intf_eth_payload_serializes_requested_fec(self):
+        dcnm_intf = object.__new__(dcnm_interface.DcnmIntf)
+        dcnm_intf.ndfc_version = "12.4.1.245"
+        delem = self._build_eth_trunk_delem("rs-fec")
+        intf = self._build_intf_skeleton("INTERFACE_ETHERNET")
+
+        dcnm_intf.dcnm_intf_get_eth_payload(delem, intf, "profile")
+
+        self.assertEqual(
+            intf["interfaces"][0]["nvPairs"]["FEC"], "rs-fec"
+        )
+
+    def test_dcnm_intf_fec_version_validation(self):
+        cases = (
+            (None, True, "version could not be determined"),
+            ("12.3.1", True, "requires NDFC >= 12.4.1"),
+            ("12.4.1", False, None),
+            ("12.4.1.245", False, None),
+        )
+
+        for version, should_fail, expected_message in cases:
+            with self.subTest(version=version):
+                dcnm_intf = object.__new__(dcnm_interface.DcnmIntf)
+                dcnm_intf.ndfc_version = version
+                dcnm_intf.module = Mock()
+                dcnm_intf.module.fail_json.side_effect = RuntimeError(
+                    "fail_json"
+                )
+                dcnm_intf.dcnm_intf_validate_interface_input = Mock()
+                config = [self._build_eth_trunk_delem("rs-fec")]
+
+                if should_fail:
+                    with self.assertRaisesRegex(
+                        RuntimeError, "fail_json"
+                    ):
+                        dcnm_intf.dcnm_intf_validate_ethernet_interface_input(
+                            config
+                        )
+                    self.assertIn(
+                        expected_message,
+                        dcnm_intf.module.fail_json.call_args.kwargs["msg"],
+                    )
+                else:
+                    dcnm_intf.dcnm_intf_validate_ethernet_interface_input(
+                        config
+                    )
+                    dcnm_intf.module.fail_json.assert_not_called()
 
     def test_dcnm_intf_vpc_trunk_payload_disables_cdp(self):
         dcnm_intf = object.__new__(dcnm_interface.DcnmIntf)
@@ -2787,7 +2925,18 @@ class TestDcnmIntfModule(TestDcnmModule):
             eth_3_2_access_intf = self.have_all_payloads_data.get(
                 "eth_3_2_access_payload"
             )
-            eth_bulk_sal = self.build_bulk_payload(playbook_eth_intf1)
+            if "_fec_" in self._testMethodName:
+                # The bulk endpoint returns every configured interface for the
+                # switch. Include the physical interfaces exercised by the FEC
+                # defaulting test so the cache reflects a real response.
+                eth_bulk_sal = self.build_bulk_payload(
+                    playbook_eth_intf1,
+                    eth_1_1_access_intf,
+                    eth_1_2_access_intf,
+                    eth_3_2_access_intf,
+                )
+            else:
+                eth_bulk_sal = self.build_bulk_payload(playbook_eth_intf1)
 
             self.run_dcnm_send.side_effect = [
                 self.mock_monitor_false_resp,
@@ -3600,7 +3749,12 @@ class TestDcnmIntfModule(TestDcnmModule):
         # setup the side effects
         self.run_dcnm_fabric_details.side_effect = [self.mock_fab_inv]
         self.run_dcnm_ip_sn.side_effect = [[self.mock_ip_sn, []]]
-        self.run_dcnm_version_supported.side_effect = [11]
+        if "_fec_" in self._testMethodName:
+            self.run_dcnm_version_supported.side_effect = [
+                (12, "12.4.1.245")
+            ]
+        else:
+            self.run_dcnm_version_supported.side_effect = [11]
 
         # Load AA_FEX fixtures
         self.load_aa_fex_fixtures()
@@ -4579,7 +4733,9 @@ class TestDcnmIntfModule(TestDcnmModule):
         )
         self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
 
-    def set_eth_deleted_payloads_to_role_default(self):
+    def set_eth_deleted_payloads_to_role_default(
+        self, policy="int_trunk_host_11_1"
+    ):
 
         payload_names = [
             "eth_merged_trunk_payloads",
@@ -4591,7 +4747,7 @@ class TestDcnmIntfModule(TestDcnmModule):
         for payload_name in payload_names:
             payload = self.payloads_data[payload_name]["DATA"][0]
             ifname = payload["interfaces"][0]["ifName"]
-            payload["policy"] = "int_trunk_host_11_1"
+            payload["policy"] = policy
             payload["interfaces"][0]["nvPairs"] = {
                 "interfaceType": "INTERFACE_ETHERNET",
                 "MTU": "jumbo",
@@ -4604,6 +4760,44 @@ class TestDcnmIntfModule(TestDcnmModule):
                 "PORTTYPE_FAST_ENABLED": True,
                 "ALLOWED_VLANS": "none",
                 "NATIVE_VLAN": "",
+                **self.storm_control_default_nvpairs(),
+            }
+
+    def prepare_eth_deleted_fec_only_test(self):
+        self.prepare_eth_deleted_existing_test()
+        self.set_eth_deleted_payloads_to_role_default(
+            policy="int_trunk_host"
+        )
+        self.payloads_data["eth_merged_trunk_payloads"]["DATA"][0][
+            "interfaces"
+        ][0]["nvPairs"]["FEC"] = "rs-fec"
+
+    def set_eth_overridden_payloads_to_role_default(
+        self, fec_interface=None
+    ):
+        for payload_name in (
+            "eth_1_1_access_payload",
+            "eth_1_2_access_payload",
+            "eth_3_2_access_payload",
+        ):
+            payload = self.have_all_payloads_data[payload_name]["DATA"][0]
+            ifname = payload["interfaces"][0]["ifName"]
+            payload["policy"] = "int_trunk_host"
+            payload["interfaces"][0]["nvPairs"] = {
+                "interfaceType": "INTERFACE_ETHERNET",
+                "MTU": "jumbo",
+                "SPEED": "Auto",
+                "DESC": "",
+                "CONF": "no shutdown",
+                "ADMIN_STATE": True,
+                "INTF_NAME": ifname,
+                "BPDUGUARD_ENABLED": False,
+                "PORTTYPE_FAST_ENABLED": True,
+                "ALLOWED_VLANS": "none",
+                "NATIVE_VLAN": "",
+                "FEC": (
+                    "rs-fec" if ifname == fec_interface else "auto"
+                ),
                 **self.storm_control_default_nvpairs(),
             }
 
@@ -4726,6 +4920,70 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.assertEqual(len(result["diff"][0]["skipped"]), 0)
         self.assertFalse(result.get("response"))
         self.assert_no_mutating_dcnm_calls()
+
+    def test_dcnm_intf_eth_deleted_existing_fec_only(self):
+        self.prepare_eth_deleted_fec_only_test()
+
+        set_module_args(
+            dict(
+                state="deleted",
+                fabric="test_fabric",
+                config=self.playbook_config,
+            )
+        )
+        result = self.execute_module(changed=True, failed=False)
+
+        self.assertEqual(
+            len(result["diff"][0]["replaced"]), 1, result
+        )
+        replacement = result["diff"][0]["replaced"][0]
+        self.assertEqual(
+            replacement["interfaces"][0]["ifName"], "Ethernet1/30"
+        )
+        self.assertEqual(
+            replacement["interfaces"][0]["nvPairs"]["FEC"], "auto"
+        )
+
+    def test_dcnm_intf_eth_deleted_existing_fec_only_check_mode(self):
+        self.prepare_eth_deleted_fec_only_test()
+
+        set_module_args(
+            dict(
+                state="deleted",
+                _ansible_check_mode=True,
+                fabric="test_fabric",
+                config=self.playbook_config,
+            )
+        )
+        result = self.execute_module(changed=True, failed=False)
+
+        self.assertEqual(len(result["diff"][0]["replaced"]), 1)
+        self.assertEqual(
+            result["diff"][0]["replaced"][0]["interfaces"][0]["nvPairs"][
+                "FEC"
+            ],
+            "auto",
+        )
+        self.assertFalse(result.get("response"))
+        self.assert_no_mutating_dcnm_calls()
+
+    def test_dcnm_intf_eth_deleted_existing_fec_default_idempotent(self):
+        self.prepare_eth_deleted_existing_test()
+        self.set_eth_deleted_payloads_to_role_default(
+            policy="int_trunk_host"
+        )
+
+        set_module_args(
+            dict(
+                state="deleted",
+                fabric="test_fabric",
+                config=self.playbook_config,
+            )
+        )
+        result = self.execute_module(changed=False, failed=False)
+
+        self.assertEqual(len(result["diff"][0]["replaced"]), 0)
+        self.assertFalse(result.get("response"))
 
     def test_dcnm_intf_eth_deleted_existing_nd42_underlay_dependency(self):
 
@@ -7041,6 +7299,53 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.assertEqual(len(result["diff"][0]["overridden"]), 1)
         self.assertEqual(len(result["diff"][0]["merged"]), 0)
 
+    def test_dcnm_intf_eth_overridden_existing_fec_only(self):
+        self.config_data = loadPlaybookData("dcnm_intf_eth_configs")
+        self.payloads_data = copy.deepcopy(
+            loadPlaybookData("dcnm_intf_eth_payloads")
+        )
+        self.have_all_payloads_data = copy.deepcopy(
+            loadPlaybookData("dcnm_intf_have_all_payloads")
+        )
+        self.playbook_config = self.config_data.get(
+            "eth_overridden_config"
+        )
+        self.playbook_mock_succ_resp = self.config_data.get("mock_succ_resp")
+        self.mock_ip_sn = self.config_data.get("mock_ip_sn")
+        self.mock_fab_inv = self.config_data.get("mock_fab_inv_data")
+        for switch in self.mock_fab_inv.values():
+            switch["switchRole"] = "leaf"
+        self.mock_monitor_true_resp = self.config_data.get(
+            "mock_monitor_true_resp"
+        )
+        self.mock_monitor_false_resp = self.config_data.get(
+            "mock_monitor_false_resp"
+        )
+        self.playbook_mock_vpc_resp = self.config_data.get("mock_vpc_resp")
+        self.set_eth_overridden_payloads_to_role_default(
+            fec_interface="Ethernet3/2"
+        )
+
+        set_module_args(
+            dict(
+                state="overridden",
+                fabric="test_fabric",
+                config=self.playbook_config,
+            )
+        )
+        result = self.execute_module(changed=True, failed=False)
+
+        self.assertEqual(
+            len(result["diff"][0]["replaced"]), 1, result
+        )
+        replacement = result["diff"][0]["replaced"][0]
+        self.assertEqual(
+            replacement["interfaces"][0]["ifName"], "Ethernet3/2"
+        )
+        self.assertEqual(
+            replacement["interfaces"][0]["nvPairs"]["FEC"], "auto"
+        )
+
     def test_dcnm_intf_override_all_but_eth_intf_types_only(self):
 
         # load the json from playbooks
@@ -7249,6 +7554,37 @@ class TestDcnmIntfModule(TestDcnmModule):
         self.assertEqual(len(result["diff"][0]["deleted"]), 0)
         self.assertEqual(len(result["diff"][0]["replaced"]), 3)
         self.assertEqual(len(result["diff"][0]["skipped"]), 0)
+
+    def test_dcnm_intf_override_eth_intf_types_only_deleted_nd42_fec_only(
+        self,
+    ):
+
+        self.prepare_nd42_deleted_all_eth_test()
+        for switch in self.mock_fab_inv.values():
+            switch["switchRole"] = "leaf"
+        self.set_eth_overridden_payloads_to_role_default(
+            fec_interface="Ethernet3/2"
+        )
+
+        set_module_args(
+            dict(
+                state="deleted",
+                fabric="test_fabric",
+                override_intf_types=["eth"],
+                deploy=False,
+                config=[],
+            )
+        )
+        result = self.execute_module(changed=True, failed=False)
+
+        self.assertEqual(len(result["diff"][0]["replaced"]), 1)
+        replacement = result["diff"][0]["replaced"][0]
+        self.assertEqual(
+            replacement["interfaces"][0]["ifName"], "Ethernet3/2"
+        )
+        self.assertEqual(
+            replacement["interfaces"][0]["nvPairs"]["FEC"], "auto"
+        )
 
     def test_dcnm_intf_override_eth_intf_types_only_deleted_nd42_fail_closed(
         self,

--- a/tests/unit/modules/dcnm/test_dcnm_network.py
+++ b/tests/unit/modules/dcnm/test_dcnm_network.py
@@ -317,6 +317,18 @@ class TestDcnmNetworkModule(TestDcnmModule):
                     dcnm_net.module.fail_json.call_args.kwargs["msg"],
                 )
 
+    def test_dcnm_net_omitted_xconnect_skips_version_validation(self):
+        for version in (None, "11.1", "12.2.1.321"):
+            with self.subTest(version=version):
+                dcnm_net = self._build_xconnect_validator(
+                    version, None
+                )
+                del dcnm_net.config[0]["xconnect"]
+                dcnm_net.validate_input()
+                self.assertIsNone(
+                    dcnm_net.validated[0]["xconnect"]
+                )
+
     def test_dcnm_net_xconnect_is_rejected_outside_standalone_fabrics(self):
         dcnm_net = self._build_xconnect_validator(
             "12.4.1",
@@ -344,8 +356,12 @@ class TestDcnmNetworkModule(TestDcnmModule):
         dcnm_net.is_ms_fabric = False
         dcnm_net.fabric_type = "standalone"
 
-        for xconnect in (True, False):
-            with self.subTest(xconnect=xconnect):
+        for xconnect, expected in (
+            (True, True),
+            (False, False),
+            (None, False),
+        ):
+            with self.subTest(xconnect=xconnect, expected=expected):
                 payload = dcnm_net.update_create_params(
                     {
                         "net_name": "xconnect-net",
@@ -356,7 +372,7 @@ class TestDcnmNetworkModule(TestDcnmModule):
                 template = json.loads(
                     payload["networkTemplateConfig"]
                 )
-                self.assertIs(template["xconnect"], xconnect)
+                self.assertIs(template["xconnect"], expected)
 
     def test_dcnm_net_normalize_preserves_returned_xconnect_without_version(self):
         dcnm_net = dcnm_network.DcnmNetwork.__new__(

--- a/tests/unit/modules/dcnm/test_dcnm_network.py
+++ b/tests/unit/modules/dcnm/test_dcnm_network.py
@@ -222,6 +222,9 @@ class TestDcnmNetworkModule(TestDcnmModule):
             "rtBothAuto": False,
             "enableL3OnBorder": False,
             "networkName": "sec-ip-test",
+            "ENABLE_NETFLOW": False,
+            "SVI_NETFLOW_MONITOR": "",
+            "VLAN_NETFLOW_MONITOR": "",
         }
 
     def _build_diff_network(self, inventory_data, ip_sn=None):
@@ -250,6 +253,184 @@ class TestDcnmNetworkModule(TestDcnmModule):
             "networkExtensionTemplate": "Default_Network_Extension_Universal",
             "networkTemplateConfig": json.dumps(template_conf),
         }
+
+    def _build_xconnect_validator(
+        self, version, xconnect, is_l2only=True, fabric_type="standalone"
+    ):
+        dcnm_net = dcnm_network.DcnmNetwork.__new__(
+            dcnm_network.DcnmNetwork
+        )
+        dcnm_net.params = {"state": "merged"}
+        dcnm_net.config = [
+            {
+                "net_name": "xconnect-net",
+                "is_l2only": is_l2only,
+                "xconnect": xconnect,
+            }
+        ]
+        dcnm_net.fabric_type = fabric_type
+        dcnm_net.ndfc_version = version
+        dcnm_net.dcnm_version = 12
+        dcnm_net.check_extra_params = True
+        dcnm_net.validated = []
+        dcnm_net.log = self._build_test_logger()
+        dcnm_net.module = Mock()
+        dcnm_net.module.fail_json.side_effect = ValueError
+        dcnm_net.get_fabric_multicast_group_address = Mock(
+            return_value=""
+        )
+        return dcnm_net
+
+    def test_dcnm_net_xconnect_validation_matrix(self):
+        valid_cases = [
+            ("12.4.1", True),
+            ("12.4.1.245", False),
+        ]
+        for version, xconnect in valid_cases:
+            with self.subTest(version=version, xconnect=xconnect):
+                dcnm_net = self._build_xconnect_validator(
+                    version, xconnect
+                )
+                dcnm_net.validate_input()
+                self.assertEqual(
+                    dcnm_net.validated[0]["xconnect"], xconnect
+                )
+
+        invalid_cases = [
+            ("12.4.0", True, True, "NDFC >= 12.4.1"),
+            (None, False, True, "version lookup failed"),
+            ("12.4.1", True, False, "requires is_l2only=true"),
+        ]
+        for version, xconnect, is_l2only, message in invalid_cases:
+            with self.subTest(
+                version=version,
+                xconnect=xconnect,
+                is_l2only=is_l2only,
+            ):
+                dcnm_net = self._build_xconnect_validator(
+                    version, xconnect, is_l2only
+                )
+                with self.assertRaises(ValueError):
+                    dcnm_net.validate_input()
+                self.assertIn(
+                    message,
+                    dcnm_net.module.fail_json.call_args.kwargs["msg"],
+                )
+
+    def test_dcnm_net_xconnect_is_rejected_outside_standalone_fabrics(self):
+        dcnm_net = self._build_xconnect_validator(
+            "12.4.1",
+            True,
+            fabric_type="multisite_parent",
+        )
+
+        with self.assertRaises(ValueError):
+            dcnm_net.validate_input()
+
+        self.assertIn(
+            "xconnect",
+            dcnm_net.module.fail_json.call_args.kwargs["msg"],
+        )
+
+    def test_dcnm_net_xconnect_payload_serializes_exact_boolean(self):
+        dcnm_net = dcnm_network.DcnmNetwork.__new__(
+            dcnm_network.DcnmNetwork
+        )
+        dcnm_net.params = {"state": "merged"}
+        dcnm_net.fabric = "test-fabric"
+        dcnm_net.dcnm_version = 12
+        dcnm_net.ndfc_version = "12.4.1.245"
+        dcnm_net.log = self._build_test_logger()
+        dcnm_net.is_ms_fabric = False
+        dcnm_net.fabric_type = "standalone"
+
+        for xconnect in (True, False):
+            with self.subTest(xconnect=xconnect):
+                payload = dcnm_net.update_create_params(
+                    {
+                        "net_name": "xconnect-net",
+                        "is_l2only": True,
+                        "xconnect": xconnect,
+                    }
+                )
+                template = json.loads(
+                    payload["networkTemplateConfig"]
+                )
+                self.assertIs(template["xconnect"], xconnect)
+
+    def test_dcnm_net_normalize_preserves_returned_xconnect_without_version(self):
+        dcnm_net = dcnm_network.DcnmNetwork.__new__(
+            dcnm_network.DcnmNetwork
+        )
+        dcnm_net.dcnm_version = 12
+        dcnm_net.ndfc_version = None
+        dcnm_net.fabric_type = "standalone"
+        template = self._build_secondary_ip_network_template()
+        template["xconnect"] = True
+        network = self._build_secondary_ip_update_payload(template)
+
+        normalized = dcnm_net.normalize_have_network(network)
+        normalized_template = json.loads(
+            normalized["networkTemplateConfig"]
+        )
+
+        self.assertIs(normalized_template["xconnect"], True)
+
+    def test_dcnm_net_merged_omission_preserves_returned_xconnect(self):
+        dcnm_net = self._build_secondary_ip_update_network()
+        dcnm_net.dcnm_version = 12
+        dcnm_net.ndfc_version = None
+        have_template = self._build_secondary_ip_network_template()
+        have_template["xconnect"] = True
+        want_template = self._build_secondary_ip_network_template()
+        have = self._build_secondary_ip_update_payload(have_template)
+        want = self._build_secondary_ip_update_payload(want_template)
+
+        dcnm_net.dcnm_update_network_information(want, have, {})
+
+        updated_template = json.loads(want["networkTemplateConfig"])
+        self.assertIs(updated_template["xconnect"], True)
+
+    def test_dcnm_net_formatted_output_preserves_returned_xconnect(self):
+        dcnm_net = dcnm_network.DcnmNetwork.__new__(
+            dcnm_network.DcnmNetwork
+        )
+        template = self._build_secondary_ip_network_template()
+        template["xconnect"] = True
+        dcnm_net.diff_create = [
+            self._build_secondary_ip_update_payload(template)
+        ]
+        dcnm_net.diff_create_quick = []
+        dcnm_net.diff_create_update = []
+        dcnm_net.diff_attach = []
+        dcnm_net.diff_detach = []
+        dcnm_net.diff_deploy = {}
+        dcnm_net.diff_undeploy = {}
+        dcnm_net.dcnm_version = 12
+        dcnm_net.ndfc_version = None
+
+        dcnm_net.format_diff()
+
+        self.assertIs(dcnm_net.diff_input_format[0]["xconnect"], True)
+
+    def test_dcnm_net_xconnect_equal_state_is_idempotent(self):
+        dcnm_net = dcnm_network.DcnmNetwork.__new__(
+            dcnm_network.DcnmNetwork
+        )
+        dcnm_net.log = self._build_test_logger()
+        dcnm_net.module = Mock()
+        dcnm_net.fabric_type = "standalone"
+        dcnm_net.dcnm_version = 12
+        dcnm_net.ndfc_version = "12.4.1"
+        template = self._build_secondary_ip_network_template()
+        template["xconnect"] = True
+        want = self._build_secondary_ip_update_payload(template)
+        have = copy.deepcopy(want)
+
+        diff = dcnm_net.diff_for_create(want, have)
+
+        self.assertEqual(diff[0], {})
+        self.assertFalse(diff[-1])
 
     def test_dcnm_net_secondary_gws_template_config(self):
         template_conf = self._build_secondary_ip_network_template(
@@ -389,13 +570,29 @@ class TestDcnmNetworkModule(TestDcnmModule):
             }
         ]
 
-        configs, error_msg = action._split_config(fabrics, "msd-parent", config, "merged", {}, 12)
+        configs, error_msg = action._split_config(
+            fabrics,
+            "msd-parent",
+            config,
+            "merged",
+            {},
+            12,
+            "12.4.1.245",
+        )
 
         self.assertIsNone(error_msg)
         self.assertEqual(configs[0]["config"][0]["secondary_ip_gw1"], "192.166.88.1/24")
         self.assertEqual(configs[0]["config"][0]["secondary_ip_gw2"], "")
+        self.assertEqual(
+            configs[0]["_fabric_details"]["ndfc_version"],
+            "12.4.1.245",
+        )
         child_config = configs[1]["config"][0]
         self.assertEqual(child_config["dhcp_loopback_id"], 204)
+        self.assertEqual(
+            configs[1]["_fabric_details"]["ndfc_version"],
+            "12.4.1.245",
+        )
 
     def test_dcnm_net_delete_switch_config_deploy_serials_are_dynamic(self):
         dcnm_net = dcnm_network.DcnmNetwork.__new__(dcnm_network.DcnmNetwork)


### PR DESCRIPTION
## Summary

Addresses outstanding review feedback after PR #661 and PR #612 were merged into `develop`.

## PR #661: dcnm_interface FEC

- Reuses the existing controller-version response instead of issuing a second version request.
- Preserves the exact normalized NDFC version needed for the NDFC 12.4.1 FEC boundary.
- Reports malformed and failed version responses with actionable response context.
- Adds focused coverage for supported, older, unknown, malformed, and failed version responses.
- Adds regression coverage for exact FEC payloads, role-default reset behavior, FEC-only drift, named deleted, overridden, check mode, and idempotence.

## PR #612: dcnm_network XConnect

- Carries the exact NDFC version from the action plugin to the module through `_fabric_details`.
- Removes the duplicate module-level controller-version request.
- Preserves controller-returned `xconnect` intent when the option is omitted from an unrelated merged operation.
- Retains XConnect in normalized and formatted output whenever the controller returns the field.
- Keeps an omitted `xconnect` value unset during input validation so older and unknown NDFC versions are not rejected as though `xconnect: false` had been explicitly configured.
- On NDFC 12.4.1 and later, serializes an omitted `xconnect` value as JSON `false` at the network payload boundary instead of sending `null`. This prevents the NaC bulk-create failure `Invalid values provided for these parameters: [xconnect: null]`.
- Documents the standalone-fabric, Layer-2-only, ND 4.1/NDFC 12.4.1 minimum, and dot1q attachment contract.
- Adds a complete standalone XConnect example and focused validation, payload, preservation, output, and idempotence tests.
- Adds regression coverage for omitted `xconnect` on unknown, NDFC 11.1, and NDFC 12.2.1.321 versions, plus exact boolean serialization for the NDFC 12.4.1+ payload.

## Validation

- `263 passed, 61 subtests passed`
- `ansible-test sanity --test validate-modules`: passed
- Python 3.12 compile sanity: passed
- Pep8 sanity: passed
- `git diff --check`: passed

The `xconnect: null` failure was observed through NaC against a live NDFC deployment. No additional end-to-end live ND run was performed as part of this update.
