### PR TITLE
Policy Idempotence

### DIFF
--- a/plugins/modules/dcnm_policy.py
+++ b/plugins/modules/dcnm_policy.py
@@ -745,10 +745,30 @@ class DcnmPolicy:
         if pnv is None:
             return "DCNM_POLICY_MATCH"
 
+        if hnv is None:
+            hnv = {}
+
+        # Keys auto-populated by NDFC — skip during comparison
+        skip_keys = {"POLICY_ID", "SERIAL_NUMBER"}
+
         for k in pnv.keys():
-            pv = str(pnv.get(k, None))
-            hv = str(hnv.get(k, None))
-            if pv != hv:
+            if k in skip_keys and (pnv.get(k) is None or pnv.get(k) == ""):
+                continue
+
+            pv = pnv.get(k)
+            hv = hnv.get(k)
+
+            # Treat None and empty string as equivalent
+            if pv is None or pv == "":
+                pv = ""
+            if hv is None or hv == "":
+                hv = ""
+
+            # Normalize to string for comparison
+            pv = str(pv).strip()
+            hv = str(hv).strip()
+
+            if pv.lower() != hv.lower():
                 return "DCNM_POLICY_DONT_MATCH"
         return "DCNM_POLICY_MATCH"
 

--- a/plugins/modules/dcnm_policy.py
+++ b/plugins/modules/dcnm_policy.py
@@ -764,11 +764,15 @@ class DcnmPolicy:
             if hv is None or hv == "":
                 hv = ""
 
-            # Normalize to string for comparison
-            pv = str(pv).strip()
-            hv = str(hv).strip()
+            # Normalize booleans (NDFC may return "true"/"false" vs True/False)
+            if str(pv).strip().lower() in ("true", "false") or str(hv).strip().lower() in ("true", "false"):
+                pv = str(pv).strip().lower()
+                hv = str(hv).strip().lower()
+            else:
+                pv = str(pv).strip()
+                hv = str(hv).strip()
 
-            if pv.lower() != hv.lower():
+            if pv != hv:
                 return "DCNM_POLICY_DONT_MATCH"
         return "DCNM_POLICY_MATCH"
 


### PR DESCRIPTION
## Summary

Fix `dcnm_policy` idempotency — module reports `changed=true` on every run even when policies are already in desired state on NDFC.

## Bug

`dcnm_policy_compare_nvpairs()` fails to correctly compare nvPairs between the desired state (want) and the existing state (have) from NDFC, causing false positives on every merged/replaced operation with `use_desc_as_key: true`.

Three root causes:

### 1. Boolean case mismatch
Python `str(False)` produces `"False"`, but NDFC returns `"false"`. The string comparison fails:
```
want: EXPORT_GATEWAY_IP = True → str() → "True"
have: EXPORT_GATEWAY_IP = "true" (from NDFC API)
"True" != "true" → DONT_MATCH
```

### 2. None vs empty string
When NDFC returns `None` for an optional field but the template sends `""`:
```
want: INTF_CONF = ""
have: INTF_CONF = None (not in NDFC response)
"" != "None" → DONT_MATCH
```

### 3. NDFC auto-populated fields
`POLICY_ID` and `SERIAL_NUMBER` are sent as empty strings in the payload but auto-populated by NDFC after policy creation:
```
want: POLICY_ID = ""
have: POLICY_ID = "POLICY-1169030" (auto-generated by NDFC)
"" != "POLICY-1169030" → DONT_MATCH (false positive)
```

## Fix

Three normalizations in `dcnm_policy_compare_nvpairs()`:

1. **Case-insensitive comparison** — `.lower()` on both values after `str()` conversion
2. **None/empty equivalence** — treat `None` and `""` as the same value
3. **Skip auto-generated keys** — skip `POLICY_ID` and `SERIAL_NUMBER` when empty in want (NDFC auto-populates these)

## Reproducer

Simple playbook that creates a policy with a boolean field (`EXPORT_GATEWAY_IP: true`) and verifies idempotency:

```yaml
---
- name: Test dcnm_policy idempotency
  hosts: ndfc
  gather_facts: false

  vars:
    test_policies:
      - switch:
          - ip: 10.229.42.151
            policies:
              - create_additional_policy: false
                description: nac_idempotency_test
                name: bgp_vrf_export_gateway
                policy_vars:
                  BGP_AS: "65000.1"
                  VRF_NAME: NaC-Prod_VRF
                  ADDRESS_FAMILY: IPv4Only
                  EXPORT_GATEWAY_IP: true
                  MAX_LOCAL_PATH: 32
                priority: 500

  tasks:
    - name: Apply policies (run 1)
      cisco.dcnm.dcnm_policy:
        fabric: my-fabric
        state: merged
        deploy: false
        use_desc_as_key: true
        config: "{{ test_policies }}"
      register: run1

    - name: Apply policies (run 2 - idempotency check)
      cisco.dcnm.dcnm_policy:
        fabric: my-fabric
        state: merged
        deploy: false
        use_desc_as_key: true
        config: "{{ test_policies }}"
      register: run2

    - name: Assert idempotency
      ansible.builtin.assert:
        that:
          - not run2.changed
        fail_msg: "NOT IDEMPOTENT - run 2 reports changed=true"
        success_msg: "IDEMPOTENT - run 2 reports changed=false"
```

**Before fix:** Run 2 always reports `changed=true` (PUT sent to NDFC).
**After fix:** Run 2 reports `changed=false` (no API call).

## Testing

Verified on ND 4.1 with multiple policy templates:

| Template | Bool Field | Before | After |
|---|---|---|---|
| `bgp_vrf_export_gateway` | `EXPORT_GATEWAY_IP: true` | `changed: true` ❌ | `changed: false` ✅ |
| `bgp_peer_template_dci_underlay_jython` | `BGP_PASSWORD_ENABLE: false` | `changed: true` ❌ | `changed: false` ✅ |
| `ebgp_underlay_dci_template` | `ADMIN_STATE: true`, `POLICY_ID: ""` | `changed: true` ❌ | `changed: false` ✅ |

All policies verified:
- First deploy → `changed: true` ✅
- Re-run (no change) → `changed: false` ✅
- Real change (modify FF_CONF) → `changed: true` ✅
- Re-run after change → `changed: false` ✅

## Impact

Affects all policies using `state: merged` with `use_desc_as_key: true`, including:
- Edge connections (`ebgp_underlay_dci_template`, `bgp_peer_template_dci_underlay_jython`)
- VRF policies (`bgp_vrf_export_gateway`)
- Any policy with boolean or empty-string nvPairs

Without the fix, every pipeline run reports false changes on policies, triggers unnecessary notifications, and prevents true idempotency validation.
