### PR TITLE
Fix EE dependency metadata for issue #708

### DIFF
--- a/meta/ee-requirements.txt
+++ b/meta/ee-requirements.txt
@@ -1,0 +1,2 @@
+pydantic
+requests

--- a/meta/execution-environment.yml
+++ b/meta/execution-environment.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  python: meta/ee-requirements.txt


### PR DESCRIPTION
## Summary

- Add collection-level Ansible Builder metadata for Python dependencies.
- Keep development requirements and the ansible<12 constraints workflow unchanged.
- Prevent the pip option -c constraints.txt from being passed into combined EE requirements.

Fixes #708

## Validation

- ansible-builder 3.1.1 introspection of the base commit reproduces -c constraints.txt.
- Feature branch introspection emits only pydantic and requests.
- Built Galaxy artifact contains meta/execution-environment.yml and meta/ee-requirements.txt and introspects cleanly.
- git diff --check passes.
- ansible-test sanity changelog passes.