### PR TITLE
Fix inherited empty ENABLE_DSVNI in MSD updates

### DIFF
--- a/plugins/module_utils/fabric/update.py
+++ b/plugins/module_utils/fabric/update.py
@@ -215,6 +215,9 @@ class FabricUpdateCommon(FabricCommon):
 
             # Remove keys that cause errors on ND 4.x during fabric update
             self._remove_nd4x_problematic_keys(full_payload)
+            # Normalize only inherited MSD state; explicit user input must still be validated by NDFC.
+            if payload.get("FABRIC_TYPE") == "VXLAN_EVPN_MSD" and "ENABLE_DSVNI" not in payload and full_payload.get("ENABLE_DSVNI") == "":
+                full_payload["ENABLE_DSVNI"] = "false"
             self._fabric_changes_payload[fabric_name] = full_payload
 
         msg = f"{self.class_name}.{method_name}: "

--- a/tests/unit/modules/dcnm/dcnm_fabric/test_fabric_update_bulk.py
+++ b/tests/unit/modules/dcnm/dcnm_fabric/test_fabric_update_bulk.py
@@ -116,6 +116,89 @@ def test_remove_nd4x_problematic_keys_does_not_add_absent_previous_values(fabric
 
 
 @pytest.mark.parametrize(
+    "is_controller_version_4x, fabric_type, controller_enable_dsvni, requested_enable_dsvni, expected_enable_dsvni",
+    [
+        (True, "VXLAN_EVPN_MSD", "", None, "false"),
+        (True, "VXLAN_EVPN_MSD", "false", None, "false"),
+        (True, "VXLAN_EVPN_MSD", "true", None, "true"),
+        (False, "VXLAN_EVPN_MSD", "", None, None),
+        (True, "VXLAN_EVPN_MSD", "true", "", ""),
+        (True, "VXLAN_EVPN_MSD", "true", "false", "false"),
+        (True, "VXLAN_EVPN_MSD", "true", "true", "true"),
+        (True, "VXLAN_EVPN_MSD", "true", False, "false"),
+        (True, "VXLAN_EVPN_MSD", "false", True, "true"),
+        (True, "VXLAN_EVPN", "", None, ""),
+    ],
+)
+def test_fabric_update_payload_normalizes_only_inherited_empty_enable_dsvni_for_nd4x_msd(
+    fabric_update_bulk,
+    is_controller_version_4x,
+    fabric_type,
+    controller_enable_dsvni,
+    requested_enable_dsvni,
+    expected_enable_dsvni,
+) -> None:
+    controller_version = MockControllerVersion()
+    controller_version.is_controller_version_4x = is_controller_version_4x
+
+    fabric_update_bulk.controller_version = controller_version
+    fabric_update_bulk.fabric_details = FabricDetailsByName()
+    fabric_update_bulk.fabric_details.data = {
+        "msd1": {
+            "nvPairs": {
+                "DELAY_RESTORE": "300",
+                "ENABLE_DSVNI": controller_enable_dsvni,
+                "ENABLE_DSVNI_PREV": "",
+                "FABRIC_NAME": "msd1",
+            }
+        }
+    }
+    payload = {
+        "DELAY_RESTORE": 301,
+        "DEPLOY": False,
+        "FABRIC_NAME": "msd1",
+        "FABRIC_TYPE": fabric_type,
+    }
+    if requested_enable_dsvni is not None:
+        payload["ENABLE_DSVNI"] = requested_enable_dsvni
+
+    fabric_update_bulk._fabric_needs_update_for_merged_state(payload)
+
+    update_payload = fabric_update_bulk._fabric_changes_payload["msd1"]
+    assert update_payload.get("ENABLE_DSVNI") == expected_enable_dsvni
+    assert update_payload.get("ENABLE_DSVNI_PREV") == ("" if is_controller_version_4x else None)
+    assert update_payload["DELAY_RESTORE"] == "301"
+
+
+def test_fabric_update_payload_does_not_add_absent_enable_dsvni(fabric_update_bulk) -> None:
+    controller_version = MockControllerVersion()
+    controller_version.is_controller_version_4x = True
+
+    fabric_update_bulk.controller_version = controller_version
+    fabric_update_bulk.fabric_details = FabricDetailsByName()
+    fabric_update_bulk.fabric_details.data = {
+        "msd1": {
+            "nvPairs": {
+                "DELAY_RESTORE": "300",
+                "FABRIC_NAME": "msd1",
+            }
+        }
+    }
+    payload = {
+        "DELAY_RESTORE": 301,
+        "DEPLOY": False,
+        "FABRIC_NAME": "msd1",
+        "FABRIC_TYPE": "VXLAN_EVPN_MSD",
+    }
+
+    fabric_update_bulk._fabric_needs_update_for_merged_state(payload)
+
+    update_payload = fabric_update_bulk._fabric_changes_payload["msd1"]
+    assert "ENABLE_DSVNI" not in update_payload
+    assert update_payload["DELAY_RESTORE"] == "301"
+
+
+@pytest.mark.parametrize(
     "is_controller_version_4x, expected_payload",
     [
         (


### PR DESCRIPTION
## Summary

Fixes #720.

Existing MSD updates can fail when NDFC returns:

```text
ENABLE_DSVNI=""
```

ND 4.x includes the existing controller `nvPairs` in the update payload. NDFC rejects the inherited empty value and requires:

```text
ENABLE_DSVNI=false
```

## Fix

Normalize the value only when:

- The fabric is `VXLAN_EVPN_MSD`.
- `ENABLE_DSVNI` was omitted by the user.
- The inherited controller value is empty.

Explicit user input, existing `true`/`false` values, absent keys, non-MSD fabrics and ND 3.x behavior remain unchanged. `ENABLE_DSVNI_PREV` is not modified.

## Validation

Validated on Nexus Dashboard 4.3.1 using a disposable MSD:

```text
Normal update:          PASS
Explicit empty input:   Rejected as expected
Idempotent run:         PASS
Cleanup:                PASS
MSD_1:                  Unchanged
```

Focused regression tests and the complete `dcnm_fabric` unit directory passed.

A new MSD stores `ENABLE_DSVNI=false`; therefore, the historical source of the empty value remains unknown.

## Related Work

- #696: General empty `nvPairs` handling.
- #703 / #704: Previous empty boolean normalization.
